### PR TITLE
Add interview API and admin memory run-id tooling

### DIFF
--- a/docs/memory_architecture_guide.md
+++ b/docs/memory_architecture_guide.md
@@ -1,0 +1,236 @@
+# YSocial Memory Architecture Guide (Reddit/Forum)
+
+This guide explains YSocial memory in plain language first, then walks through the full architecture diagram and every core memory path.
+
+## 1) Very Brief Plain Explanation (with Reddit-style examples)
+
+YSocial memory is a layered system that helps each agent remember:
+
+- what happened (`events`),
+- what those events mean over time (`reflections`, `summaries`),
+- how it feels about specific users (`social cards`),
+- what is going on in each thread (`thread cards`),
+- and the overall forum climate (`community digest`).
+
+### Quick Reddit-style examples
+
+1. A user comments:  
+   `"@alex your GPU advice fixed my build, thanks!"`  
+   The agent stores this as an event and may update its trust toward `@alex`.
+
+2. After several interactions, the agent forms a reflection like:  
+   `"I usually agree with @alex on hardware topics, but we disagree on pricing."`
+
+3. In a heated thread, the agent stores a thread gist like:  
+   `"Thread split between budget builds and premium-only arguments."`
+
+4. At run level, the community digest may capture:  
+   `"Top topics: GPUs, benchmarks, used-market scams. Norm: sarcastic but helpful."`
+
+## 2) Memory Types and Item Types
+
+### Core memory entities
+
+1. `MemoryInteractionEvent`  
+   Raw interaction log. It records actor/target, thread/post links, event type (`post`, `comment`, `upvote`, `downvote`), topic/tone labels, and importance.
+
+2. `MemoryItem`  
+   The main retrieval unit used during decision-making.  
+   `item_type` is one of:
+   - `event`
+   - `reflection`
+   - `summary`
+
+3. `MemorySocialCard`  
+   Per-agent, per-other-user relationship memory. Tracks continuous signals like `affinity`, `conflict`, `humor`, and `trust`, plus relationship summary/evidence.
+
+4. `MemoryThreadCard`  
+   Per-agent, per-thread memory. Stores thread gist, the agent’s role in thread, top participants, and entry points.
+
+5. `MemoryCommunityDigest`  
+   Per-run forum-level memory. Stores digest text plus `top_topics`, `norms`, `memes`, and `polarizing_issues`.
+
+## 3) Diagram Walkthrough (Every Part)
+
+The diagram is organized into 4 big blocks under a root.
+
+### ROOT
+
+`YSocial Run-Scoped Memory Architecture`  
+Everything is scoped to a run (`run_id`) so memory is isolated per experiment run.
+
+### MODEL block: `Memory Model (What Exists)`
+
+1. `MemoryInteractionEvent (Raw Event Log)`  
+   Fine-grained interaction facts, used as source evidence.
+
+2. `MemoryItem (Retrieval Unit)`  
+   Search corpus for runtime recall. Includes text, metadata, importance, recency/access fields, and embedding state (`pending/ready/failed`).
+
+3. `MemorySocialCard (Per Other User)`  
+   Compact relationship state with decayed/updated social signals.
+
+4. `MemoryThreadCard (Per Thread Root)`  
+   Compact thread-state memory to keep long threads coherent.
+
+5. `MemoryCommunityDigest (Per Run)`  
+   Macro-level memory of forum climate and recurring themes.
+
+### WRITE block: `Memory Write & Update Loops (How It Evolves)`
+
+1. `Event Capture Loop`  
+   New interaction -> event log entry -> `MemoryItem(event)`.
+
+2. `Reflection Synthesis Loop`  
+   Periodic evidence-based synthesis -> `MemoryItem(reflection)`.
+
+3. `Summary Consolidation Loop`  
+   Condenses recurring information -> `MemoryItem(summary)`.
+
+4. `Social Card Update Loop`  
+   Applies signal deltas, decay, and resummarization to social cards.
+
+5. `Thread Card Update Loop`  
+   Maintains thread gist/participants/entry points.
+
+6. `Community Digest Loop`  
+   Cadenced run-level synthesis of topics/norms/memes/polarization.
+
+### RETR block: `Retrieval & Context Assembly (How It Is Used)`
+
+1. `Memory Search + Ranking`  
+   Ranks candidates by a blend of relevance, recency, and importance.
+
+2. `Tier A Context (Focused)`  
+   Immediate, high-salience interaction cues.
+
+3. `Tier B Context (Targeted)`  
+   Query-aligned semantic recall.
+
+4. `Tier C Context (Exploratory)`  
+   Broader recall under uncertainty.
+
+5. `Context Budget Control`  
+   Enforces tier and total character budgets.
+
+6. `Decision Consumption`  
+   Final context is injected into post/comment/vote/rewrite generation.
+
+### CTRL block: `Control & Dynamics (Behavior Shaping)`
+
+1. `Cold-Start Imprint`  
+   First 5 interactions are treated as cold-start memory imprint window.
+
+2. `Progressive Early-Memory Decay`  
+   After cold start, early imprinted memories are progressively softened.
+
+3. `Forgetting Controls`  
+   Social/thread decay lambdas, corruption rates, resummarization cadence.
+
+4. `Cadence Controls`  
+   Reflection cadence/min-event thresholds and digest cadence.
+
+5. `High-Affect Controls`  
+   Controls for high-affect recall behavior (thresholds and uncertainty bands).
+
+## 4) Core Memory Paths (End-to-End)
+
+### Path A: Interaction -> Stored Memory
+
+1. Agent performs an interaction (post/comment/upvote/downvote).
+2. A raw `MemoryInteractionEvent` is created.
+3. A corresponding `MemoryItem(event)` is created for retrieval.
+4. Metadata links the event to user/thread/post context.
+
+Example:  
+`"I disagree with @maria's benchmark interpretation"` becomes an event and a retrievable event-item.
+
+### Path B: Cold-Start and Progressive Decay
+
+1. Cold-start window is now `5` interactions, inclusive.
+2. During interactions `1..5`, items are imprinted strongly.
+3. After interaction `5`, progressive decay starts:
+   - interaction `6` -> decay level `1`
+   - interaction `7` -> decay level `2`
+   - and so on.
+4. Early imprinted items are capped down progressively so early memories do not dominate forever.
+
+Why this matters:  
+Early conversation no longer permanently controls later behavior.
+
+### Path C: Reflection Creation
+
+1. On normal cadence, recent events are evaluated.
+2. If evidence thresholds are met, the agent synthesizes 2-4 higher-level insights.
+3. These are stored as `MemoryItem(reflection)`.
+
+Example reflection:  
+`"I often push back on @nick in politics threads, but align on moderation policy."`
+
+### Path D: Social Relationship Memory
+
+1. Interactions involving another user update social signals.
+2. `MemorySocialCard` tracks relationship dynamics over time.
+3. Decay/resummarization prevents stale or overfit relationship state.
+
+Example:  
+Repeated helpful replies from `@lee` increase trust; repeated bait comments increase conflict.
+
+### Path E: Thread Memory
+
+1. While engaging in a thread, the agent updates `MemoryThreadCard`.
+2. Card stores gist, role, participants, and entry points.
+3. This helps the agent respond coherently in long/nested threads.
+
+Example gist:  
+`"Main dispute: driver stability vs raw FPS, with @sam and @kai as dominant voices."`
+
+### Path F: Community-Level Memory
+
+1. On digest cadence, run-wide event patterns are summarized.
+2. `MemoryCommunityDigest` captures forum climate and recurring patterns.
+3. Used as background context for behavior and tone calibration.
+
+Example digest:  
+`"Norm is blunt technical debate; meme phrase is 'just update BIOS'; polarized on used GPUs."`
+
+### Path G: Retrieval and Tier Assembly
+
+1. For a new decision, memory search retrieves candidate `MemoryItem`s.
+2. Ranking blends relevance + recency + importance.
+3. Retrieved items are distributed into Tier A/B/C packs.
+4. Budgets enforce compact context before prompt injection.
+
+Example:  
+In a heated reply, Tier A may include recent conflict events, Tier B past stance statements, Tier C broad community patterns.
+
+### Path H: Decision-Time Use
+
+1. Assembled memory context is injected into generation prompts.
+2. Agent uses this to choose action style and content:
+   - post
+   - comment
+   - vote
+   - rewrite/edit strategy
+
+Result:  
+Behavior is less reactive-noisy and more temporally consistent.
+
+## 5) What Changed in the Latest Update
+
+1. Cold-start window changed from 10 to 5.
+2. Cold-start is inclusive by interaction count.
+3. Progressive decay is activated after cold-start window.
+4. Cold-start forced reflection/digest overrides were removed; normal cadence rules now apply.
+5. Memory still uses the same core item taxonomy (`event/reflection/summary`), but early-memory dominance is reduced.
+
+## 6) Practical Reading Order for Operators
+
+If you are debugging behavior, inspect in this order:
+
+1. `MemoryItem` quality and type balance (`event/reflection/summary`).
+2. Cold-start/decay behavior for early interactions.
+3. Social card drift (`affinity/conflict/trust`).
+4. Thread card coherence in long threads.
+5. Community digest alignment with observed forum tone.
+6. Retrieval tier composition and budget truncation effects.

--- a/docs/reddit_forum_memory_report.md
+++ b/docs/reddit_forum_memory_report.md
@@ -1,0 +1,685 @@
+# YSocial Reddit/Forum Memory Mechanism Report
+
+## Scope
+
+This document describes the memory mechanism used by the Reddit/forum mode of YSocial.
+It focuses on the `external/YClientReddit` and `external/YServerReddit` stacks, plus the forum prompt templates in `data_schema/prompts_forum.json` and `external/YClientReddit/config_files/prompts.json`.
+
+The short version is:
+
+- the server owns persistent memory storage, search, ranking, and embedding state,
+- the client owns most of the LLM-on-write summarization and prompt-time memory assembly,
+- prompt injection is structured and selective rather than a raw dump of prior events.
+
+## Key Takeaways
+
+1. Reddit/forum memory is a real subsystem, not just conversation history.
+2. Memory is run-scoped. Every experiment run gets its own memory state.
+3. The system stores both raw events and distilled memories.
+4. The client writes memories after actions such as comments, posts, and votes.
+5. The server retrieves memories through a hybrid semantic-plus-lexical search path.
+6. Prompt insertion happens through tiered context blocks, cue fields, and a special high-affect recall path.
+7. The microblogging stack does not use the same architecture.
+
+## High-Level Architecture
+
+The Reddit/forum memory design is split across two sides.
+
+### Server responsibilities
+
+The Reddit server owns the persistent memory model and retrieval APIs:
+
+- memory tables in [`external/YServerReddit/y_server/modals.py`](../external/YServerReddit/y_server/modals.py)
+- memory routes in [`external/YServerReddit/y_server/routes/content_management.py`](../external/YServerReddit/y_server/routes/content_management.py)
+- embedding service in [`external/YServerReddit/y_server/memory_embedding.py`](../external/YServerReddit/y_server/memory_embedding.py)
+
+The server is responsible for:
+
+- storing raw interaction events,
+- storing searchable memory items,
+- storing social, thread, and community summaries,
+- running memory search and ranking,
+- tracking embedding status,
+- tracking recency and access metadata.
+
+### Client responsibilities
+
+The Reddit client owns most of the memory writing and prompt assembly:
+
+- agent logic in [`external/YClientReddit/y_client/classes/base_agent.py`](../external/YClientReddit/y_client/classes/base_agent.py)
+- client prompt templates in [`external/YClientReddit/config_files/prompts.json`](../external/YClientReddit/config_files/prompts.json)
+- forum defaults in [`data_schema/prompts_forum.json`](../data_schema/prompts_forum.json)
+
+The client is responsible for:
+
+- generating structured interaction notes with the LLM,
+- deciding when to refresh social cards, thread cards, and the community digest,
+- generating long-term reflections,
+- fetching relevant memories before a decision or reply,
+- transforming retrieved memory into prompt variables.
+
+## Memory Data Model
+
+The persistent memory schema is defined in [`external/YServerReddit/y_server/modals.py`](../external/YServerReddit/y_server/modals.py#L153).
+
+### 1. `memory_interaction_events`
+
+Model: `MemoryInteractionEvent`
+
+Purpose:
+
+- stores raw interaction records between agents,
+- captures actor and target IDs,
+- links events to threads and posts,
+- stores labels such as relation and tone,
+- stores `event_text`, `importance`, and access metadata.
+
+This is the detailed evidence layer.
+
+### 2. `memory_items`
+
+Model: `MemoryItem`
+
+Purpose:
+
+- stores the searchable retrieval corpus,
+- unifies `event`, `summary`, and `reflection` items,
+- stores the text that retrieval operates on,
+- stores metadata such as topic tags and related user IDs,
+- stores inline embedding state.
+
+Important fields include:
+
+- `item_type`
+- `text`
+- `importance`
+- `access_count`
+- `last_accessed_round`
+- `embedding_json`
+- `embedding_model`
+- `embedding_dim`
+- `embedding_status`
+
+### 3. `memory_social_cards`
+
+Model: `MemorySocialCard`
+
+Purpose:
+
+- stores relationship memory for one agent about one other user,
+- tracks rolling values like `affinity`, `conflict`, `humor`, and `trust`,
+- stores a compact summary string and evidence tail.
+
+This is the main per-user relationship memory.
+
+### 4. `memory_thread_cards`
+
+Model: `MemoryThreadCard`
+
+Purpose:
+
+- stores a compact memory of a thread,
+- records the thread gist,
+- records the agent's role in the thread,
+- tracks top participants and good entry points.
+
+### 5. `memory_community_digests`
+
+Model: `MemoryCommunityDigest`
+
+Purpose:
+
+- stores a run-level digest of the forum,
+- summarizes top topics,
+- captures norms, recurring memes, and polarizing issues.
+
+### Reflection storage detail
+
+Reflections do not have a dedicated table.
+They are stored as `memory_items` with `item_type="reflection"`, via the `/memory/item/upsert` route in [`external/YServerReddit/y_server/routes/content_management.py`](../external/YServerReddit/y_server/routes/content_management.py#L2131).
+
+## Memory API Surface
+
+The main Reddit memory APIs are implemented in [`external/YServerReddit/y_server/routes/content_management.py`](../external/YServerReddit/y_server/routes/content_management.py).
+
+Key routes:
+
+- `/memory/reset`
+- `/memory/event`
+- `/memory/social/upsert`
+- `/memory/thread/upsert`
+- `/memory/community/get`
+- `/memory/community/update`
+- `/memory/item/upsert`
+- `/memory/search`
+- `/memory/get_context`
+- `/memory/events_recent`
+
+These routes are the interface between the client-side memory logic and the server-side memory store.
+
+## Schema Bootstrapping and Indexing
+
+The server does not assume the memory schema already exists.
+The first use of the memory routes triggers `_ensure_memory_schema()` in [`external/YServerReddit/y_server/routes/content_management.py`](../external/YServerReddit/y_server/routes/content_management.py#L580).
+
+That path does three things:
+
+1. creates any missing memory tables,
+2. applies schema evolution helpers and indexes,
+3. starts the background memory embedding indexer thread.
+
+The async indexer loop is `_memory_indexer_loop()` in the same file.
+It polls pending `memory_items`, generates embeddings in batches, and marks each item as `ready` or `failed`.
+
+## Write-Side Memory Lifecycle
+
+The Reddit client updates memory after successful actions.
+The main write hooks are in [`external/YClientReddit/y_client/classes/base_agent.py`](../external/YClientReddit/y_client/classes/base_agent.py).
+
+### Post-write hook
+
+After a successful post, `post()` calls `_memory_after_post(...)` at [`base_agent.py#L5908`](../external/YClientReddit/y_client/classes/base_agent.py#L5908).
+
+### Comment-write hook
+
+After a successful comment, `comment()` calls `_memory_after_comment(...)` at [`base_agent.py#L8099`](../external/YClientReddit/y_client/classes/base_agent.py#L8099).
+
+This is the richest write path and the main source of structured memory.
+
+### Vote/reaction-write hook
+
+After a vote or reaction, the client calls `_memory_after_vote(...)` from the vote paths at [`base_agent.py#L8441`](../external/YClientReddit/y_client/classes/base_agent.py#L8441) and [`base_agent.py#L8495`](../external/YClientReddit/y_client/classes/base_agent.py#L8495).
+
+### Comment path in detail
+
+The comment write flow looks like this:
+
+1. Build write-time memory context with `_memory_build_tiered_context(...)` at [`base_agent.py#L4956`](../external/YClientReddit/y_client/classes/base_agent.py#L4956).
+2. Generate an LLM-based interaction note with `_memory_llm_interaction_note(...)` at [`base_agent.py#L4203`](../external/YClientReddit/y_client/classes/base_agent.py#L4203).
+3. Extract structured fields such as `relation_label`, `tone_label`, `salient_claim`, topic tags, and social deltas.
+4. Record the event through `_memory_record_event(...)`, which POSTs to `/memory/event` at [`base_agent.py#L4346`](../external/YClientReddit/y_client/classes/base_agent.py#L4346).
+5. Refresh the social card.
+6. Maybe refresh the thread card.
+7. Maybe refresh the community digest.
+8. Maybe generate new reflections.
+
+This is best understood as an LLM-on-write pipeline: the client converts a single interaction into both raw memory and distilled memory.
+
+### Interaction-note generation
+
+The structured interaction note is generated with the `handler_memory_interaction_note` prompt in [`external/YClientReddit/config_files/prompts.json`](../external/YClientReddit/config_files/prompts.json#L40).
+
+The note prompt asks the model to return JSON with fields such as:
+
+- `relation_label`
+- `tone_label`
+- `affinity_delta`
+- `conflict_delta`
+- `humor_delta`
+- `trust_delta`
+- `salient_claim`
+- `topics`
+
+This is the most explicit place where the system asks the LLM to produce memory structure rather than direct social content.
+
+### Social-card updates
+
+Relationship memory is updated through `_memory_upsert_social_card(...)` at [`base_agent.py#L4377`](../external/YClientReddit/y_client/classes/base_agent.py#L4377).
+
+The update logic:
+
+- loads the prior social card,
+- applies decay and rolling deltas,
+- appends new evidence,
+- periodically calls the `handler_memory_resummarize_social_card` prompt,
+- writes the result to `/memory/social/upsert`.
+
+The summarization template lives in [`external/YClientReddit/config_files/prompts.json`](../external/YClientReddit/config_files/prompts.json#L41).
+
+### Thread-card updates
+
+Thread memory is updated through `_memory_maybe_update_thread_card(...)` at [`base_agent.py#L4621`](../external/YClientReddit/y_client/classes/base_agent.py#L4621).
+
+The update logic:
+
+- tracks a thread-local event counter,
+- periodically summarizes the thread using `handler_memory_update_thread_card`,
+- writes the result to `/memory/thread/upsert`.
+
+The thread-card prompt lives in [`external/YClientReddit/config_files/prompts.json`](../external/YClientReddit/config_files/prompts.json#L42).
+
+### Community-digest updates
+
+Community memory is updated through `_memory_maybe_update_community_digest(...)` at [`base_agent.py#L4767`](../external/YClientReddit/y_client/classes/base_agent.py#L4767).
+
+The update logic:
+
+- is cadence-gated,
+- reads recent events from `/memory/events_recent`,
+- reads the previous digest from `/memory/community/get`,
+- prompts `handler_memory_update_community_digest`,
+- falls back to a local builder if parsing fails,
+- writes the result to `/memory/community/update`.
+
+The digest prompt lives in [`external/YClientReddit/config_files/prompts.json`](../external/YClientReddit/config_files/prompts.json#L43).
+
+### Reflection generation
+
+Long-term reflections are generated in `_memory_maybe_generate_reflections(...)` at [`base_agent.py#L3648`](../external/YClientReddit/y_client/classes/base_agent.py#L3648).
+
+This path is gated by:
+
+- memory enablement,
+- semantic memory enablement,
+- run ID presence,
+- cadence settings,
+- recent event volume,
+- importance thresholds,
+- a cap on reflection items.
+
+The reflection generator:
+
+1. gathers evidence from `/memory/events_recent` and `_memory_search(...)`,
+2. prompts `handler_memory_generate_reflections`,
+3. falls back to a local heuristic builder if needed,
+4. writes each reflection through `/memory/item/upsert` as `item_type="reflection"`.
+
+The prompt lives in [`external/YClientReddit/config_files/prompts.json`](../external/YClientReddit/config_files/prompts.json#L44).
+
+### Relative richness of write paths
+
+The three write paths are not equally rich.
+
+- Comments: event plus interaction note plus social card plus thread card plus community digest plus reflections.
+- Votes: event plus social/community updates plus reflections, but no rich interaction-note prompt.
+- Posts: event plus community updates plus reflections, but no per-user interaction note.
+
+## Read-Side Retrieval
+
+There are two main retrieval APIs.
+
+### 1. `/memory/get_context`
+
+This route returns structured context assembled from the persistent memory state.
+It is implemented in [`content_management.py#L2679`](../external/YServerReddit/y_server/routes/content_management.py#L2679).
+
+Its response includes:
+
+- `social_card`
+- `thread_card`
+- `community_digest`
+- `recent_pair_events`
+- `user_map`
+- `other_username`
+
+This route is the structured memory fetch.
+It does not perform ranking. It simply packages the latest known context.
+
+### 2. `/memory/search`
+
+This route is the ranked memory retrieval engine.
+It is implemented in [`content_management.py#L2264`](../external/YServerReddit/y_server/routes/content_management.py#L2264).
+
+The flow is:
+
+1. filter candidate `memory_items` by run, agent, and optional scope,
+2. compute semantic similarity when embeddings are available,
+3. otherwise compute lexical relevance,
+4. mix relevance, recency, and importance into a final score,
+5. return the top items and update access metadata.
+
+### Search scoring formula
+
+The final score is:
+
+- `0.55 * relevance`
+- `0.25 * recency`
+- `0.20 * importance`
+
+This is implemented in [`content_management.py#L2394-L2396`](../external/YServerReddit/y_server/routes/content_management.py#L2394).
+
+### Candidate filters
+
+Memory search can be narrowed by:
+
+- `run_id`
+- `agent_user_id`
+- `other_user_id`
+- `thread_root_id`
+- `item_type`
+- time window
+- topic tags
+
+This is important because the prompt-time retrieval often wants pairwise or thread-local memory rather than global recall.
+
+## Importance Estimation
+
+The server uses `_estimate_importance(...)` in [`content_management.py#L409`](../external/YServerReddit/y_server/routes/content_management.py#L409) to estimate event importance when the client does not provide one.
+
+The heuristic considers:
+
+- event type,
+- relation and tone labels,
+- presence of a salient claim,
+- topic overlap with polarizing community issues.
+
+The resulting value is clamped into `[0, 1]`.
+
+There is also special cold-start handling in the `/memory/event` route so that early interactions get a stronger imprint than they otherwise would.
+
+## Embeddings and Indexing
+
+Memory embeddings are produced by `MemoryEmbeddingService` in [`external/YServerReddit/y_server/memory_embedding.py`](../external/YServerReddit/y_server/memory_embedding.py).
+
+Important facts:
+
+- the implementation is Ollama-backed,
+- embeddings are stored inline in `memory_items.embedding_json`,
+- there is no separate vector database,
+- a background indexer upgrades `pending` items to `ready`.
+
+This is a lightweight architecture: retrieval is done in Python over fetched candidates rather than via ANN or a dedicated vector store.
+
+## Prompt Loading and Interpolation
+
+Prompt loading for the Reddit client starts from the CLI in [`external/YClientReddit/y_client.py`](../external/YClientReddit/y_client.py#L24).
+
+The prompt sources are then merged in [`external/YClientReddit/y_client/clients/client_base.py`](../external/YClientReddit/y_client/clients/client_base.py#L97):
+
+- experiment-specific prompts,
+- local Reddit prompt defaults,
+- forum defaults from the shared data schema.
+
+Prompt interpolation eventually goes through `__effify` in [`base_agent.py#L5512`](../external/YClientReddit/y_client/classes/base_agent.py#L5512), which means all `memory_*` placeholders are resolved from the runtime agent state.
+
+## Tiered Prompt Memory Assembly
+
+The core prompt-time assembly function is `_memory_build_tiered_context(...)` at [`base_agent.py#L2202`](../external/YClientReddit/y_client/classes/base_agent.py#L2202).
+
+This function builds a three-tier memory pack.
+
+### Tier A: community-level memory
+
+Tier A is built from `community_digest` returned by `/memory/get_context`.
+It is formatted into blocks such as:
+
+- community vibe,
+- top topics,
+- norms,
+- memes.
+
+This is the broad social climate layer.
+
+### Tier B: targeted memory
+
+Tier B is the main local retrieval layer.
+It combines:
+
+- ranked search hits from `/memory/search`,
+- `social_card`,
+- `thread_card`,
+- `recent_pair_events`.
+
+This is where the system injects the most directly relevant memory about the current counterpart or thread.
+
+### Tier C: expanded fallback recall
+
+Tier C is used when retrieval is uncertain or weak.
+It performs a broader search with wider scope and acts as a global recall supplement.
+
+This is not always present, but it gives the client a fallback when local retrieval is weak.
+
+### Resulting prompt block
+
+The three tiers are merged into explicit memory sections such as:
+
+- `[MEMORY TIER A]`
+- `[MEMORY TIER B]`
+- `[MEMORY TIER C]`
+
+The memory pack is then either prepended to prompt context or converted into specific guidance fields.
+
+## Memory Cue Derivation
+
+The Reddit client does not only pass memory text. It also derives prompt-control hints.
+
+The key cue builder logic lives around [`base_agent.py#L2392`](../external/YClientReddit/y_client/classes/base_agent.py#L2392).
+
+### `memory_scope`
+
+`memory_scope` expresses how safe and strong the retrieved memory is.
+Possible values include:
+
+- `strong`
+- `partial`
+- `degraded`
+- `cold_start`
+- `none`
+
+This is used directly inside prompts to tell the LLM how confidently it may refer to prior memory.
+
+### `memory_callback_hint`
+
+This hint tells the LLM whether it is worth making a callback to prior interaction.
+It depends on retrieval quality and a callback probability setting.
+
+### `memory_argument_hint`
+
+This hint is derived from retrieved relationship signals such as affinity and conflict.
+It nudges the model toward:
+
+- starting from common ground,
+- continuing an argument,
+- or staying balanced.
+
+### `memory_tone_hint`
+
+This hint is derived from trust, conflict, humor, and degraded-mode state.
+It nudges the reply tone toward things like:
+
+- skeptical,
+- bantering,
+- neutral conversational.
+
+### `memory_plan_hint`
+
+This comes from a separate planner prompt, `handler_memory_reply_planner`, defined in [`external/YClientReddit/config_files/prompts.json`](../external/YClientReddit/config_files/prompts.json#L39).
+
+The planner returns a compact strategy with fields such as:
+
+- opening move,
+- callback line,
+- stance,
+- tone,
+- avoid.
+
+## Where Memory Enters Prompt Flows
+
+Memory is inserted at several decision points, not just final text generation.
+
+### 1. Thread browsing
+
+The browsing decision path calls `_memory_build_tiered_context(...)` before the `handler_thread_browse_decision` prompt.
+The memory block is prepended into the `scan_snippets` context.
+
+This means memory can affect which comment the agent chooses to engage with.
+
+### 2. Style selection
+
+The style-selection step receives memory placeholders including:
+
+- `memory_cues_block`
+- `memory_scope`
+- `memory_callback_hint`
+- `memory_argument_hint`
+- `memory_tone_hint`
+- `high_affect_flags`
+- `recalled_memories_block`
+- `memory_usage_requirement`
+
+The style prompt is defined in [`external/YClientReddit/config_files/prompts.json`](../external/YClientReddit/config_files/prompts.json#L3).
+
+This means memory can affect not only what is said, but the style of engagement chosen before generation.
+
+### 3. Main comment generation
+
+The main comment pipeline starts at [`base_agent.py#L7533`](../external/YClientReddit/y_client/classes/base_agent.py#L7533).
+
+The client:
+
+1. fetches memory using the current query text,
+2. builds the tiered memory block,
+3. derives cue hints,
+4. prepends memory into `conv_for_prompt`,
+5. fills the memory placeholders of the final comment template.
+
+The main memory-aware comment prompt is defined in [`external/YClientReddit/config_files/prompts.json`](../external/YClientReddit/config_files/prompts.json#L31).
+
+### 4. Mention/reply action decisions
+
+The mention path starts at [`base_agent.py#L8870`](../external/YClientReddit/y_client/classes/base_agent.py#L8870).
+
+It uses the mention text as a memory query, builds tiered context, and injects memory variables into the `handler_mention_action_decision` prompt in [`external/YClientReddit/config_files/prompts.json`](../external/YClientReddit/config_files/prompts.json#L25).
+
+This means memory can influence whether the agent replies, votes, or ignores.
+
+## High-Affect Memory Recall Path
+
+The high-affect path is the strongest prompt-time memory mechanism.
+
+It is controlled by Reddit client memory settings in [`external/YClientReddit/config_files/config.json`](../external/YClientReddit/config_files/config.json#L142) and the detection logic in [`base_agent.py`](../external/YClientReddit/y_client/classes/base_agent.py#L2917).
+
+### What triggers it
+
+A high-affect state can be triggered by signals such as:
+
+- criticism or challenge,
+- conflict or argument,
+- incoming anecdote,
+- defending a prior opinion.
+
+If the rule-based score lands in an uncertainty band, the client can use an LLM fallback classifier.
+
+### What happens after trigger
+
+If high affect is detected during comment generation:
+
+1. the client performs a bucketed recall over memory types like `interaction`, `opinion`, `personal_experience`, and `relationship`,
+2. it builds a `[RECALLED MEMORIES]` block,
+3. it sets `memory_usage_requirement`,
+4. it expects the generated comment to reference one recalled memory naturally.
+
+The requirement text is defined by `memory_callback_requirements_comment` in [`external/YClientReddit/config_files/prompts.json`](../external/YClientReddit/config_files/prompts.json#L48).
+
+### Enforcement and rewrite
+
+After the initial draft is generated, the client checks whether the reply appears to reference a recalled memory.
+If it does not, the client may invoke `handler_memory_callback_rewrite` in [`external/YClientReddit/config_files/prompts.json`](../external/YClientReddit/config_files/prompts.json#L47).
+
+This rewrite step keeps the same stance and tone but tries to add a memory callback.
+
+This is the clearest place where memory is not merely advisory. It can trigger a second-pass rewrite of the final reply.
+
+## Failure and Degradation Behavior
+
+The Reddit memory subsystem is designed to degrade rather than fail hard.
+
+### Server-side degradation
+
+If embeddings are unavailable:
+
+- the embedding service returns `None`,
+- the background indexer may mark items as `failed`,
+- retrieval falls back to lexical relevance.
+
+The search API also reports degraded retrieval metadata so the client can respond appropriately.
+
+### Client-side degradation
+
+If memory is disabled or unavailable:
+
+- context/search helpers return empty or `None`,
+- prompt assembly proceeds without memory,
+- cue hints fall back to `none`, `cold_start`, or `degraded` behavior,
+- prompts explicitly discourage the model from making specific memory claims when retrieval is weak.
+
+There is also a tiered fallback chain:
+
+- if targeted Tier B retrieval is weak, the client can try a broader reflection search,
+- if that is still weak, it can fall back to older full-context formatting paths.
+
+This is a practical design choice. Weak memory produces weaker guidance, not a broken action pipeline.
+
+## End-to-End Example: Comment Flow
+
+A representative comment flow in Reddit/forum mode is:
+
+1. The agent reads a target comment.
+2. The client builds a query from the target text.
+3. The client calls `/memory/get_context` and `/memory/search`.
+4. The client assembles Tier A, B, and C memory blocks.
+5. The client derives `memory_scope` and cue hints.
+6. The client optionally runs high-affect detection.
+7. The style-selection prompt sees memory cues.
+8. The final comment-generation prompt sees memory blocks and memory hints.
+9. If memory is required and the draft does not reference it, the client rewrites the draft.
+10. The comment is posted.
+11. The client writes the event and updates higher-order memory artifacts.
+
+That loop is what gives the system continuity over time.
+
+## Prompt Templates That Consume Memory
+
+The most important Reddit/forum memory-aware templates are:
+
+- `style_select_comment`
+- `handler_comment`
+- `handler_mention_action_decision`
+- `handler_memory_reply_planner`
+- `handler_memory_interaction_note`
+- `handler_memory_resummarize_social_card`
+- `handler_memory_update_thread_card`
+- `handler_memory_update_community_digest`
+- `handler_memory_generate_reflections`
+- `handler_memory_callback_rewrite`
+- `memory_callback_requirements_comment`
+
+The client runtime versions live in [`external/YClientReddit/config_files/prompts.json`](../external/YClientReddit/config_files/prompts.json), and the shared forum defaults live in [`data_schema/prompts_forum.json`](../data_schema/prompts_forum.json).
+
+## Contrast With Microblogging Mode
+
+The microblogging stack does not implement the same memory architecture.
+
+It has:
+
+- prompt templates,
+- rolling interests and sentiment-like state,
+- short thread context.
+
+It does not have the same Reddit/forum memory structure of:
+
+- memory events,
+- searchable memory items,
+- social cards,
+- thread cards,
+- community digests,
+- reflections,
+- semantic-plus-lexical retrieval,
+- high-affect memory callback enforcement.
+
+So the system described in this document is specifically the Reddit/forum memory mechanism.
+
+## Conclusion
+
+The Reddit/forum memory system in YSocial is a layered memory architecture with three core properties:
+
+1. **Structured write-side memory formation**
+   The client converts interactions into events, summaries, and reflections.
+
+2. **Server-side retrieval and ranking**
+   The server stores and retrieves memory through a hybrid semantic-plus-lexical mechanism.
+
+3. **Prompt-time behavioral shaping**
+   The client injects memory into prompts as both context and control signals, and in high-affect cases can enforce memory-aware callbacks through rewrite.
+
+This makes the Reddit/forum mode much more than a plain stateless prompt pipeline. It is a persistent, run-scoped social memory system designed to support continuity, relationship tracking, thread coherence, and forum-level behavioral context.

--- a/run_tests.py
+++ b/run_tests.py
@@ -2,6 +2,7 @@
 """
 Test runner for y_web pytest suite
 """
+
 import os
 import subprocess
 import sys

--- a/y_web/__init__.py
+++ b/y_web/__init__.py
@@ -114,14 +114,15 @@ def create_postgresql_db(app):
             db_conn.execute(
                 text(
                     """
-                     INSERT INTO admin_users (username, email, password, role)
-                     VALUES (:username, :email, :password, :role)
+                     INSERT INTO admin_users (username, email, password, last_seen, role)
+                     VALUES (:username, :email, :password, :last_seen, :role)
                      """
                 ),
                 {
                     "username": "Admin",
                     "email": "admin@y-not.social",
                     "password": hashed_pw,
+                    "last_seen": "",
                     "role": "admin",
                 },
             )
@@ -277,9 +278,23 @@ def cleanup_db_jupyter_with_new_app():
         traceback.print_exc()
 
 
-# Only register atexit handler for the main application process, not subprocesses
-# Client subprocesses set Y_CLIENT_SUBPROCESS=1 to indicate they should not run cleanup
-if os.environ.get("Y_CLIENT_SUBPROCESS") != "1":
+def _should_register_atexit_cleanup(env=None) -> bool:
+    """
+    Decide whether process-exit cleanup should be registered.
+
+    Cleanup is intentionally opt-in to avoid side effects when utility scripts
+    import y_web just to access helpers/models.
+    """
+    env_map = env if env is not None else os.environ
+    enabled = str(env_map.get("YSOCIAL_ENABLE_ATEXIT_CLEANUP", "")).strip().lower()
+    if enabled not in {"1", "true", "yes", "on"}:
+        return False
+
+    # Client subprocesses explicitly opt out.
+    return str(env_map.get("Y_CLIENT_SUBPROCESS", "")).strip() != "1"
+
+
+if _should_register_atexit_cleanup():
     atexit.register(cleanup_db_jupyter_with_new_app)
 
 
@@ -301,8 +316,6 @@ def create_app(db_type="sqlite", desktop_mode=False):
         ValueError: If unsupported db_type is provided
     """
     import os
-
-    BASE_DIR = os.path.dirname(os.path.abspath(__file__))
 
     app = Flask(__name__, static_url_path="/static")
 
@@ -381,6 +394,59 @@ def create_app(db_type="sqlite", desktop_mode=False):
 
     from .models import Admin_users, User_mgmt
 
+    # SQLite ships with a prebuilt dashboard.db. Ensure the default Admin
+    # credentials are consistent with docs/expectations: Admin / admin.
+    #
+    # Safety: only touches the single default admin record (id=1) when it's the
+    # only admin user and matches the known default email addresses.
+    def _ensure_default_admin_password():
+        if os.getenv("YSOCIAL_ENSURE_DEFAULT_ADMIN_PASSWORD", "1").strip().lower() in {
+            "0",
+            "false",
+            "off",
+            "",
+        }:
+            return
+        if db_type != "sqlite":
+            # Avoid surprising password resets on existing Postgres deployments.
+            # If you really want the same behavior on Postgres, opt in explicitly.
+            if (
+                os.getenv("YSOCIAL_ENSURE_DEFAULT_ADMIN_PASSWORD_POSTGRES", "0")
+                .strip()
+                .lower()
+                not in {"1", "true", "on", "yes"}
+            ):
+                return
+        try:
+            from werkzeug.security import check_password_hash, generate_password_hash
+
+            with app.app_context():
+                admin_count = int(Admin_users.query.filter_by(role="admin").count())
+                admin = (
+                    Admin_users.query.filter_by(id=1, username="Admin", role="admin")
+                    .limit(1)
+                    .first()
+                )
+                if not admin or admin_count != 1:
+                    return
+                if (admin.email or "").strip().lower() not in {
+                    "admin@ysocial.com",
+                    "admin@y-not.social",
+                }:
+                    return
+                if check_password_hash(admin.password, "admin"):
+                    return
+                admin.password = generate_password_hash("admin", method="pbkdf2:sha256")
+                db.session.commit()
+                print(
+                    "[auth] Reset default Admin password to 'admin' "
+                    "(set YSOCIAL_ENSURE_DEFAULT_ADMIN_PASSWORD=0 to disable)."
+                )
+        except Exception as e:
+            print(f"[auth] Failed to ensure default Admin password: {e}")
+
+    _ensure_default_admin_password()
+
     @login_manager.user_loader
     def load_user(user_id):
         """
@@ -440,6 +506,52 @@ def create_app(db_type="sqlite", desktop_mode=False):
     def inject_exp_id():
         """Inject exp_id into all templates."""
         return dict(exp_id=get_current_experiment_id())
+
+    @app.context_processor
+    def inject_feed_home_url():
+        """Inject canonical page-1 feed URL for the active experiment context."""
+        from flask_login import current_user
+
+        from .models import Exps, User_mgmt
+
+        try:
+            if not current_user.is_authenticated:
+                return dict(feed_home_url="/")
+
+            exp = None
+            exp_id = get_current_experiment_id()
+            if exp_id is not None:
+                exp = Exps.query.filter_by(idexp=int(exp_id)).first()
+
+            if exp is None:
+                active_exps = Exps.query.filter(Exps.status != 0).all()
+                if not active_exps:
+                    return dict(feed_home_url="/")
+                if len(active_exps) > 1:
+                    return dict(feed_home_url="/admin/join_simulation")
+                exp = active_exps[0]
+
+            if exp.platform_type == "forum":
+                return dict(
+                    feed_home_url=f"/{exp.idexp}/rfeed/all/feed/rf/1?feed_type=new"
+                )
+
+            feed_user_id = None
+            user_id_str = str(current_user.get_id() or "")
+            if user_id_str.isdigit():
+                feed_user_id = int(user_id_str)
+            else:
+                exp_user = User_mgmt.query.filter_by(
+                    username=getattr(current_user, "username", None)
+                ).first()
+                if exp_user is not None:
+                    feed_user_id = int(exp_user.id)
+
+            if feed_user_id is None:
+                return dict(feed_home_url=f"/{exp.idexp}/feed/all/feed/rf/1")
+            return dict(feed_home_url=f"/{exp.idexp}/feed/{feed_user_id}/feed/rf/1")
+        except Exception:
+            return dict(feed_home_url="/feed")
 
     @app.context_processor
     def inject_active_experiments():
@@ -520,6 +632,65 @@ def create_app(db_type="sqlite", desktop_mode=False):
                 print(f"Error injecting blog post info: {e}")
         return dict(new_blog_post_available=False, blog_post=None)
 
+    @app.context_processor
+    def inject_reply_notifications():
+        """
+        Inject Reddit-style reply notification count for forum UI.
+
+        Only applies to authenticated experiment users (not admin_* sessions) and
+        only when a forum experiment is active in the current request context.
+        """
+        from flask_login import current_user
+
+        try:
+            exp_id = get_current_experiment_id()
+            if not current_user.is_authenticated or exp_id is None:
+                return dict(reply_notif_unread_count=0, reply_notif_url=None)
+
+            # Admin/researcher sessions should not get forum reply notifications.
+            user_id_str = str(current_user.get_id())
+            if user_id_str.startswith("admin_"):
+                return dict(reply_notif_unread_count=0, reply_notif_url=None)
+
+            # Only show in forum (Reddit-style) experiments.
+            from .models import Exps
+
+            exp = Exps.query.filter_by(idexp=int(exp_id)).first()
+            if not exp or exp.platform_type != "forum":
+                return dict(reply_notif_unread_count=0, reply_notif_url=None)
+
+            reply_notif_url = f"/{int(exp_id)}/rnotifications"
+
+            from sqlalchemy import func
+            from sqlalchemy.orm import aliased
+
+            from .models import Post, ReplyInboxState
+
+            state = ReplyInboxState.query.filter_by(user_id=current_user.id).first()
+            cutoff = int(state.last_seen_reply_id) if state else 0
+
+            Reply = aliased(Post)
+            Parent = aliased(Post)
+
+            unread_count = (
+                db.session.query(func.count(Reply.id))
+                .join(Parent, Reply.comment_to == Parent.id)
+                .filter(
+                    Parent.user_id == current_user.id,
+                    Reply.user_id != current_user.id,
+                    Reply.comment_to != -1,
+                    Reply.id > cutoff,
+                )
+                .scalar()
+            )
+
+            return dict(
+                reply_notif_unread_count=int(unread_count or 0),
+                reply_notif_url=reply_notif_url,
+            )
+        except Exception:
+            return dict(reply_notif_unread_count=0, reply_notif_url=None)
+
     # Register your blueprints here as before
     from .auth import auth as auth_blueprint
 
@@ -569,6 +740,11 @@ def create_app(db_type="sqlite", desktop_mode=False):
     from .routes_api.reddit import api_reddit as api_reddit_blueprint
 
     app.register_blueprint(api_reddit_blueprint)
+
+    from .routes_api.interview import api_interview as api_interview_blueprint
+
+    app.register_blueprint(api_interview_blueprint)
+
     from .routes_uploads import uploads as uploads_blueprint
 
     app.register_blueprint(uploads_blueprint)
@@ -609,7 +785,7 @@ def create_app(db_type="sqlite", desktop_mode=False):
                 pg_port = os.getenv("PG_PORT", "5432")
                 pg_database = os.getenv("PG_DBNAME", "dashboard")
                 pg_user = os.getenv("PG_USER", "postgres")
-                pg_password = os.getenv("PG_PASSWORD", "")
+                pg_password = os.getenv("PG_PASSWORD", "password")
                 if pg_password:
                     migrate_postgresql(
                         pg_host, pg_port, pg_database, pg_user, pg_password
@@ -633,7 +809,7 @@ def create_app(db_type="sqlite", desktop_mode=False):
                 pg_port = os.getenv("PG_PORT", "5432")
                 pg_database = os.getenv("PG_DBNAME", "dashboard")
                 pg_user = os.getenv("PG_USER", "postgres")
-                pg_password = os.getenv("PG_PASSWORD", "")
+                pg_password = os.getenv("PG_PASSWORD", "password")
                 if pg_password:
                     migrate_postgresql(
                         pg_host, pg_port, pg_database, pg_user, pg_password
@@ -661,7 +837,7 @@ def create_app(db_type="sqlite", desktop_mode=False):
                 pg_port = os.getenv("PG_PORT", "5432")
                 pg_database = os.getenv("PG_DBNAME", "dashboard")
                 pg_user = os.getenv("PG_USER", "postgres")
-                pg_password = os.getenv("PG_PASSWORD", "")
+                pg_password = os.getenv("PG_PASSWORD", "password")
                 if pg_password:
                     migrate_log_sync_postgresql(
                         pg_host, pg_port, pg_database, pg_user, pg_password
@@ -689,7 +865,7 @@ def create_app(db_type="sqlite", desktop_mode=False):
                 pg_port = os.getenv("PG_PORT", "5432")
                 pg_database = os.getenv("PG_DBNAME", "dashboard")
                 pg_user = os.getenv("PG_USER", "postgres")
-                pg_password = os.getenv("PG_PASSWORD", "")
+                pg_password = os.getenv("PG_PASSWORD", "password")
                 if pg_password:
                     migrate_exp_status_postgresql(
                         pg_host, pg_port, pg_database, pg_user, pg_password
@@ -717,7 +893,7 @@ def create_app(db_type="sqlite", desktop_mode=False):
                 pg_port = os.getenv("PG_PORT", "5432")
                 pg_database = os.getenv("PG_DBNAME", "dashboard")
                 pg_user = os.getenv("PG_USER", "postgres")
-                pg_password = os.getenv("PG_PASSWORD", "")
+                pg_password = os.getenv("PG_PASSWORD", "password")
                 if pg_password:
                     migrate_schedule_postgresql(
                         pg_host, pg_port, pg_database, pg_user, pg_password
@@ -745,7 +921,7 @@ def create_app(db_type="sqlite", desktop_mode=False):
                 pg_port = os.getenv("PG_PORT", "5432")
                 pg_database = os.getenv("PG_DBNAME", "dashboard")
                 pg_user = os.getenv("PG_USER", "postgres")
-                pg_password = os.getenv("PG_PASSWORD", "")
+                pg_password = os.getenv("PG_PASSWORD", "password")
                 if pg_password:
                     migrate_watchdog_postgresql(
                         pg_host, pg_port, pg_database, pg_user, pg_password
@@ -773,7 +949,7 @@ def create_app(db_type="sqlite", desktop_mode=False):
                 pg_port = os.getenv("PG_PORT", "5432")
                 pg_database = os.getenv("PG_DBNAME", "dashboard")
                 pg_user = os.getenv("PG_USER", "postgres")
-                pg_password = os.getenv("PG_PASSWORD", "")
+                pg_password = os.getenv("PG_PASSWORD", "password")
                 if pg_password:
                     migrate_tutorial_postgresql(
                         pg_host, pg_port, pg_database, pg_user, pg_password
@@ -801,7 +977,7 @@ def create_app(db_type="sqlite", desktop_mode=False):
                 pg_port = os.getenv("PG_PORT", "5432")
                 pg_database = os.getenv("PG_DBNAME", "dashboard")
                 pg_user = os.getenv("PG_USER", "postgres")
-                pg_password = os.getenv("PG_PASSWORD", "")
+                pg_password = os.getenv("PG_PASSWORD", "password")
                 if pg_password:
                     migrate_exp_details_tutorial_postgresql(
                         pg_host, pg_port, pg_database, pg_user, pg_password
@@ -809,19 +985,19 @@ def create_app(db_type="sqlite", desktop_mode=False):
         except Exception as e:
             print(f"Failed to run exp_details_tutorial_shown column migration: {e}")
 
-        # Run agent archetypes migration
+        # Run LLM columns migration
         try:
             if db_type == "sqlite":
-                from y_web.migrations.add_agent_archetypes import (
-                    migrate_sqlite as migrate_agent_archetypes_sqlite,
+                from y_web.migrations.add_llm_columns import (
+                    migrate_sqlite as migrate_llm_sqlite,
                 )
 
                 dashboard_db_path = app.config.get("DASHBOARD_DB_PATH")
                 if dashboard_db_path:
-                    migrate_agent_archetypes_sqlite(dashboard_db_path)
+                    migrate_llm_sqlite(dashboard_db_path)
             elif db_type == "postgresql":
-                from y_web.migrations.add_agent_archetypes import (
-                    migrate_postgresql as migrate_agent_archetypes_postgresql,
+                from y_web.migrations.add_llm_columns import (
+                    migrate_postgresql as migrate_llm_postgresql,
                 )
 
                 # Get PostgreSQL connection details from environment variables (same as create_postgresql_db)
@@ -829,72 +1005,158 @@ def create_app(db_type="sqlite", desktop_mode=False):
                 pg_port = os.getenv("PG_PORT", "5432")
                 pg_database = os.getenv("PG_DBNAME", "dashboard")
                 pg_user = os.getenv("PG_USER", "postgres")
-                pg_password = os.getenv("PG_PASSWORD", "")
+                pg_password = os.getenv("PG_PASSWORD", "password")
                 if pg_password:
-                    migrate_agent_archetypes_postgresql(
+                    migrate_llm_postgresql(
                         pg_host, pg_port, pg_database, pg_user, pg_password
                     )
         except Exception as e:
-            print(f"Failed to run agent archetypes migration: {e}")
+            print(f"Failed to run LLM columns migration: {e}")
 
-        # Run agent archetype field migration (for agents and user_mgmt tables)
+        # Run activity_profile columns migration
         try:
             if db_type == "sqlite":
-                from y_web.migrations.add_agent_archetype_field import (
-                    migrate_experiment_databases,
-                    migrate_sqlite_dashboard,
-                    migrate_sqlite_server,
+                from y_web.migrations.add_activity_profile_columns import (
+                    migrate_sqlite as migrate_activity_profile_sqlite,
                 )
 
                 dashboard_db_path = app.config.get("DASHBOARD_DB_PATH")
                 if dashboard_db_path:
-                    migrate_sqlite_dashboard(dashboard_db_path)
-
-                # Migrate the dummy server database
-                dummy_db_path = app.config.get("DUMMY_DB_PATH")
-                if dummy_db_path:
-                    migrate_sqlite_server(dummy_db_path, quiet=True)
-
-                # Migrate all existing experiment databases
-                from y_web.utils.path_utils import get_writable_path
-
-                BASE_DIR = get_writable_path()
-                experiments_dir = os.path.join(BASE_DIR, "y_web", "experiments")
-                if os.path.exists(experiments_dir):
-                    print("Migrating existing experiment databases...")
-                    success, total = migrate_experiment_databases(
-                        experiments_dir, quiet=False
-                    )
-                    if total > 0:
-                        print(f"✓ Migrated {success}/{total} experiment databases")
-
+                    migrate_activity_profile_sqlite(dashboard_db_path)
             elif db_type == "postgresql":
-                from y_web.migrations.add_agent_archetype_field import (
-                    migrate_postgresql_dashboard,
-                    migrate_postgresql_server,
+                from y_web.migrations.add_activity_profile_columns import (
+                    migrate_postgresql as migrate_activity_profile_postgresql,
                 )
 
-                # Get PostgreSQL connection details for dashboard
+                # Get PostgreSQL connection details from environment variables (same as create_postgresql_db)
                 pg_host = os.getenv("PG_HOST", "localhost")
                 pg_port = os.getenv("PG_PORT", "5432")
                 pg_database = os.getenv("PG_DBNAME", "dashboard")
                 pg_user = os.getenv("PG_USER", "postgres")
-                pg_password = os.getenv("PG_PASSWORD", "")
-
+                pg_password = os.getenv("PG_PASSWORD", "password")
                 if pg_password:
-                    dashboard_config = {
-                        "host": pg_host,
-                        "port": pg_port,
-                        "database": pg_database,
-                        "user": pg_user,
-                        "password": pg_password,
-                    }
-                    migrate_postgresql_dashboard(dashboard_config)
-
-                    # Note: Server database migration will happen per experiment
-                    # The schema files are already updated for new installations
+                    migrate_activity_profile_postgresql(
+                        pg_host, pg_port, pg_database, pg_user, pg_password
+                    )
         except Exception as e:
-            print(f"Failed to run agent archetype field migration: {e}")
+            print(f"Failed to run activity_profile columns migration: {e}")
+
+        # Run population username_type column migration
+        try:
+            if db_type == "sqlite":
+                from y_web.migrations.add_population_username_type_column import (
+                    migrate_sqlite as migrate_population_username_type_sqlite,
+                )
+
+                dashboard_db_path = app.config.get("DASHBOARD_DB_PATH")
+                if dashboard_db_path:
+                    migrate_population_username_type_sqlite(dashboard_db_path)
+            elif db_type == "postgresql":
+                from y_web.migrations.add_population_username_type_column import (
+                    migrate_postgresql as migrate_population_username_type_postgresql,
+                )
+
+                pg_host = os.getenv("PG_HOST", "localhost")
+                pg_port = os.getenv("PG_PORT", "5432")
+                pg_database = os.getenv("PG_DBNAME", "dashboard")
+                pg_user = os.getenv("PG_USER", "postgres")
+                pg_password = os.getenv("PG_PASSWORD", "password")
+                if pg_password:
+                    migrate_population_username_type_postgresql(
+                        pg_host, pg_port, pg_database, pg_user, pg_password
+                    )
+        except Exception as e:
+            print(f"Failed to run population username_type migration: {e}")
+
+        # Run blog_posts table migration
+        try:
+            if db_type == "sqlite":
+                from y_web.migrations.add_blog_posts_table import migrate_dashboard_db
+
+                migrate_dashboard_db()
+            elif db_type == "postgresql":
+                from y_web.migrations.add_blog_posts_table import (
+                    migrate_postgresql as migrate_blog_posts_postgresql,
+                )
+
+                pg_host = os.getenv("PG_HOST", "localhost")
+                pg_port = os.getenv("PG_PORT", "5432")
+                pg_database = os.getenv("PG_DBNAME", "dashboard")
+                pg_user = os.getenv("PG_USER", "postgres")
+                pg_password = os.getenv("PG_PASSWORD", "password")
+                if pg_password:
+                    migrate_blog_posts_postgresql(
+                        pg_host, pg_port, pg_database, pg_user, pg_password
+                    )
+        except Exception as e:
+            print(f"Failed to run blog_posts table migration: {e}")
+
+        # Ensure admin interview run_id supports long run-scoped identifiers
+        try:
+            if db_type == "sqlite":
+                from y_web.migrations.add_admin_interview_run_id_text import (
+                    migrate_sqlite as migrate_admin_interview_run_id_sqlite,
+                )
+
+                dashboard_db_path = app.config.get("DASHBOARD_DB_PATH")
+                if dashboard_db_path:
+                    migrate_admin_interview_run_id_sqlite(dashboard_db_path)
+            elif db_type == "postgresql":
+                from y_web.migrations.add_admin_interview_run_id_text import (
+                    migrate_postgresql as migrate_admin_interview_run_id_postgresql,
+                )
+
+                pg_host = os.getenv("PG_HOST", "localhost")
+                pg_port = os.getenv("PG_PORT", "5432")
+                pg_database = os.getenv("PG_DBNAME", "dashboard")
+                pg_user = os.getenv("PG_USER", "postgres")
+                pg_password = os.getenv("PG_PASSWORD", "password")
+                if pg_password:
+                    migrate_admin_interview_run_id_postgresql(
+                        pg_host, pg_port, pg_database, pg_user, pg_password
+                    )
+        except Exception as e:
+            print(f"Failed to run admin interview run_id migration: {e}")
+
+        # Run PostgreSQL schema compatibility migration (adds missing columns/tables)
+        try:
+            if db_type == "postgresql":
+                from y_web.migrations.ensure_postgresql_schema import (
+                    migrate_postgresql as ensure_postgresql_schema,
+                )
+
+                pg_host = os.getenv("PG_HOST", "localhost")
+                pg_port = os.getenv("PG_PORT", "5432")
+                pg_database = os.getenv("PG_DBNAME", "dashboard")
+                pg_user = os.getenv("PG_USER", "postgres")
+                pg_password = os.getenv("PG_PASSWORD", "password")
+                if pg_password:
+                    ensure_postgresql_schema(
+                        pg_host, pg_port, pg_database, pg_user, pg_password
+                    )
+        except Exception as e:
+            print(f"Failed to run PostgreSQL schema compatibility migration: {e}")
+
+        # Ensure dashboard default configuration tables are populated with canonical defaults.
+        # This backfills missing rows for population builder dropdowns and does not delete
+        # or overwrite existing custom/legacy values.
+        try:
+            if db_type == "postgresql":
+                from y_web.migrations.ensure_dashboard_default_config import (
+                    migrate_postgresql as ensure_dashboard_default_config,
+                )
+
+                pg_host = os.getenv("PG_HOST", "localhost")
+                pg_port = os.getenv("PG_PORT", "5432")
+                pg_database = os.getenv("PG_DBNAME", "dashboard")
+                pg_user = os.getenv("PG_USER", "postgres")
+                pg_password = os.getenv("PG_PASSWORD", "password")
+
+                ensure_dashboard_default_config(
+                    pg_host, pg_port, pg_database, pg_user, pg_password
+                )
+        except Exception as e:
+            print(f"Failed to run PostgreSQL dashboard defaults migration: {e}")
 
         # Ensure all tables defined in models exist (including release_info)
         # This creates any missing tables that are defined in models.py

--- a/y_web/__init__.py
+++ b/y_web/__init__.py
@@ -112,12 +112,10 @@ def create_postgresql_db(app):
 
             # Insert initial admin user
             db_conn.execute(
-                text(
-                    """
+                text("""
                      INSERT INTO admin_users (username, email, password, last_seen, role)
                      VALUES (:username, :email, :password, :last_seen, :role)
-                     """
-                ),
+                     """),
                 {
                     "username": "Admin",
                     "email": "admin@y-not.social",
@@ -156,16 +154,14 @@ def create_postgresql_db(app):
             hashed_pw = generate_password_hash("admin", method="pbkdf2:sha256")
 
             # Insert initial admin user
-            stmt = text(
-                """
+            stmt = text("""
                         INSERT INTO user_mgmt (username, email, password, user_type, leaning, age,
                                                language, owner, joined_on, frecsys_type,
                                                round_actions, toxicity, is_page, daily_activity_level)
                         VALUES (:username, :email, :password, :user_type, :leaning, :age,
                                 :language, :owner, :joined_on, :frecsys_type,
                                 :round_actions, :toxicity, :is_page, :daily_activity_level)
-                        """
-            )
+                        """)
 
             dummy_conn.execute(
                 stmt,
@@ -410,12 +406,9 @@ def create_app(db_type="sqlite", desktop_mode=False):
         if db_type != "sqlite":
             # Avoid surprising password resets on existing Postgres deployments.
             # If you really want the same behavior on Postgres, opt in explicitly.
-            if (
-                os.getenv("YSOCIAL_ENSURE_DEFAULT_ADMIN_PASSWORD_POSTGRES", "0")
-                .strip()
-                .lower()
-                not in {"1", "true", "on", "yes"}
-            ):
+            if os.getenv(
+                "YSOCIAL_ENSURE_DEFAULT_ADMIN_PASSWORD_POSTGRES", "0"
+            ).strip().lower() not in {"1", "true", "on", "yes"}:
                 return
         try:
             from werkzeug.security import check_password_hash, generate_password_hash

--- a/y_web/experiment_context.py
+++ b/y_web/experiment_context.py
@@ -123,16 +123,15 @@ def setup_experiment_context():
                             ] = original_db_exp
 
                     # For SQLite experiment DBs, run local schema migrations for post columns.
-                    if (
-                        current_app.config["SQLALCHEMY_DATABASE_URI"].startswith("sqlite")
-                        and exp_uri.startswith("sqlite:///")
-                    ):
+                    if current_app.config["SQLALCHEMY_DATABASE_URI"].startswith(
+                        "sqlite"
+                    ) and exp_uri.startswith("sqlite:///"):
                         try:
-                            from y_web.migrations.add_post_created_at_column import (
-                                migrate_sqlite_experiment_db,
-                            )
                             from y_web.migrations.add_comment_dedupe_columns import (
                                 migrate_sqlite_comment_dedupe_columns,
+                            )
+                            from y_web.migrations.add_post_created_at_column import (
+                                migrate_sqlite_experiment_db,
                             )
 
                             migrate_sqlite_experiment_db(exp_uri)
@@ -266,11 +265,11 @@ def initialize_active_experiment_databases(app):
                 # For SQLite experiment DBs, run local schema migration for post.created_at.
                 if not is_postgresql and exp_uri.startswith("sqlite:///"):
                     try:
-                        from y_web.migrations.add_post_created_at_column import (
-                            migrate_sqlite_experiment_db,
-                        )
                         from y_web.migrations.add_comment_dedupe_columns import (
                             migrate_sqlite_comment_dedupe_columns,
+                        )
+                        from y_web.migrations.add_post_created_at_column import (
+                            migrate_sqlite_experiment_db,
                         )
 
                         migrate_sqlite_experiment_db(exp_uri)

--- a/y_web/main.py
+++ b/y_web/main.py
@@ -548,7 +548,9 @@ def interview(exp_id: int):
     # When admins join experiments, they may still be logged-in as Admin_users.
     # Resolve the corresponding experiment-side user for header links.
     exp_user = User_mgmt.query.filter_by(username=current_user.username).first()
-    logged_id = int(exp_user.id) if exp_user else int(getattr(current_user, "id", 0) or 0)
+    logged_id = (
+        int(exp_user.id) if exp_user else int(getattr(current_user, "id", 0) or 0)
+    )
 
     mentions = []
     try:
@@ -879,11 +881,15 @@ def get_thread(exp_id, post_id):
 
     # Check image_post_id first (standalone images), then fall back to image_id
     from y_web.reddit.service import _resolve_image_post
-    image = _resolve_image_post(getattr(posts[0], 'image_post_id', None))
+
+    image = _resolve_image_post(getattr(posts[0], "image_post_id", None))
     if not image and posts[0].image_id:
         img = Images.query.filter_by(id=posts[0].image_id).first()
         if img and img.url:
-            image = {"url": img.url, "description": getattr(img, "description", "") or ""}
+            image = {
+                "url": img.url,
+                "description": getattr(img, "description", "") or "",
+            }
 
     user = User_mgmt.query.filter_by(id=posts[0].user_id).first()
     profile_pic = ""
@@ -1104,8 +1110,7 @@ def __get_discussions(posts, username, page, exp_id):
         # Just count comments - feed only needs the count, not full details
         # Full comment data is loaded in thread view, not feed view
         comment_count = Post.query.filter(
-            Post.thread_id == post.id,
-            Post.id != post.id
+            Post.thread_id == post.id, Post.id != post.id
         ).count()
         cms = []  # Empty list - comment details not used in feed template
 
@@ -1115,26 +1120,33 @@ def __get_discussions(posts, username, page, exp_id):
         else:
             if is_reddit:
                 from y_web.reddit.service import _article_payload, _resolve_article
+
                 art = _article_payload(_resolve_article(article))
             else:
                 # Non-Reddit feeds: keep existing behavior
                 article_image = None
                 article_img = Images.query.filter_by(article_id=article.id).first()
                 if article_img and article_img.url:
-                    article_image = {"url": article_img.url, "description": getattr(article_img, "description", "") or ""}
+                    article_image = {
+                        "url": article_img.url,
+                        "description": getattr(article_img, "description", "") or "",
+                    }
 
                 art = {
                     "title": article.title,
                     "summary": strip_tags(article.summary),
                     "url": article.link,
-                    "source": (lambda w: w.name if w else "Unknown")(Websites.query.filter_by(id=article.website_id).first()),
+                    "source": (lambda w: w.name if w else "Unknown")(
+                        Websites.query.filter_by(id=article.website_id).first()
+                    ),
                     "image": article_image,
                 }
 
         # Check image_post_id first (standalone images from image_posts table)
-        image_post_id = getattr(post, 'image_post_id', None)
+        image_post_id = getattr(post, "image_post_id", None)
         if image_post_id:
             from y_web.reddit.service import _resolve_image_post
+
             image = _resolve_image_post(image_post_id)
             if image is None:
                 image = ""
@@ -1142,6 +1154,7 @@ def __get_discussions(posts, username, page, exp_id):
             # Fall back to legacy image_id (from Images table)
             if is_reddit:
                 from y_web.reddit.service import _resolve_image
+
                 image = _resolve_image(post.image_id) if post.image_id else ""
             else:
                 image = Images.query.filter_by(id=post.image_id).first()
@@ -1174,7 +1187,9 @@ def __get_discussions(posts, username, page, exp_id):
                 profile_pic = (
                     ag.profile_pic
                     if ag is not None and ag.profile_pic is not None
-                    else (lambda u: u.profile_pic if u else "")(Admin_users.query.filter_by(username=aa.username).first())
+                    else (lambda u: u.profile_pic if u else "")(
+                        Admin_users.query.filter_by(username=aa.username).first()
+                    )
                 )
             except:
                 profile_pic = ""
@@ -1192,9 +1207,9 @@ def __get_discussions(posts, username, page, exp_id):
             if article_title:
                 body_stripped = post_body.strip()
                 if body_stripped.startswith(f"TITLE: {article_title}"):
-                    post_body = body_stripped[len(f"TITLE: {article_title}"):].lstrip()
+                    post_body = body_stripped[len(f"TITLE: {article_title}") :].lstrip()
                 elif body_stripped.startswith(article_title):
-                    post_body = body_stripped[len(article_title):].lstrip()
+                    post_body = body_stripped[len(article_title) :].lstrip()
 
         res.append(
             {
@@ -1334,9 +1349,11 @@ def get_thread_reddit(exp_id, post_id):
 
     # Check image_post_id first (standalone images), then fall back to image_id
     from y_web.reddit.service import _resolve_image_post
-    image = _resolve_image_post(getattr(posts[0], 'image_post_id', None))
+
+    image = _resolve_image_post(getattr(posts[0], "image_post_id", None))
     if not image and posts[0].image_id:
         from y_web.reddit.service import _resolve_image
+
         image = _resolve_image(posts[0].image_id)
 
     user = User_mgmt.query.filter_by(id=posts[0].user_id).first()
@@ -1386,6 +1403,7 @@ def get_thread_reddit(exp_id, post_id):
         art = 0
     else:
         from y_web.reddit.service import _article_payload, _resolve_article
+
         art = _article_payload(_resolve_article(article))
 
     discussion_tree = {
@@ -1475,7 +1493,9 @@ def get_thread_reddit(exp_id, post_id):
 
         # Strip reproduced article content from body (catches LLM copying summary)
         if article and article.summary and comment_content:
-            comment_content, _ = strip_reproduced_article_content(comment_content, article.summary)
+            comment_content, _ = strip_reproduced_article_content(
+                comment_content, article.summary
+            )
 
         is_agent_or_page_comment_author = bool(
             user is not None
@@ -1497,6 +1517,7 @@ def get_thread_reddit(exp_id, post_id):
             art = 0
         else:
             from y_web.reddit.service import _article_payload, _resolve_article
+
             art = _article_payload(_resolve_article(article))
         data = {
             "title": comment_title,
@@ -2070,13 +2091,19 @@ def api_feed_reddit(exp_id, user_id="all", timeline="timeline", mode="rf", page=
             reaction_sub = (
                 db.session.query(
                     Reactions.post_id.label("post_id"),
-                    func.sum(case((Reactions.type == "like", 1), else_=0)).label("like_count"),
-                    func.sum(case((Reactions.type == "dislike", 1), else_=0)).label("dislike_count"),
+                    func.sum(case((Reactions.type == "like", 1), else_=0)).label(
+                        "like_count"
+                    ),
+                    func.sum(case((Reactions.type == "dislike", 1), else_=0)).label(
+                        "dislike_count"
+                    ),
                 )
                 .group_by(Reactions.post_id)
                 .subquery()
             )
-            net_score = func.coalesce(reaction_sub.c.like_count, 0) - func.coalesce(reaction_sub.c.dislike_count, 0)
+            net_score = func.coalesce(reaction_sub.c.like_count, 0) - func.coalesce(
+                reaction_sub.c.dislike_count, 0
+            )
             sign_expr = case((net_score > 0, 1), (net_score < 0, -1), else_=0)
             abs_score = func.abs(net_score)
             max_score = case((abs_score >= 1, abs_score), else_=1)
@@ -2149,13 +2176,19 @@ def api_feed_reddit(exp_id, user_id="all", timeline="timeline", mode="rf", page=
             reaction_sub = (
                 db.session.query(
                     Reactions.post_id.label("post_id"),
-                    func.sum(case((Reactions.type == "like", 1), else_=0)).label("like_count"),
-                    func.sum(case((Reactions.type == "dislike", 1), else_=0)).label("dislike_count"),
+                    func.sum(case((Reactions.type == "like", 1), else_=0)).label(
+                        "like_count"
+                    ),
+                    func.sum(case((Reactions.type == "dislike", 1), else_=0)).label(
+                        "dislike_count"
+                    ),
                 )
                 .group_by(Reactions.post_id)
                 .subquery()
             )
-            net_score = func.coalesce(reaction_sub.c.like_count, 0) - func.coalesce(reaction_sub.c.dislike_count, 0)
+            net_score = func.coalesce(reaction_sub.c.like_count, 0) - func.coalesce(
+                reaction_sub.c.dislike_count, 0
+            )
             sign_expr = case((net_score > 0, 1), (net_score < 0, -1), else_=0)
             abs_score = func.abs(net_score)
             max_score = case((abs_score >= 1, abs_score), else_=1)

--- a/y_web/migrations/add_activity_profile_columns.py
+++ b/y_web/migrations/add_activity_profile_columns.py
@@ -44,9 +44,7 @@ def migrate_sqlite(db_path):
 
         # Add activity_profile column to agents if it doesn't exist
         if "activity_profile" not in agents_columns:
-            cursor.execute(
-                "ALTER TABLE agents ADD COLUMN activity_profile INTEGER"
-            )
+            cursor.execute("ALTER TABLE agents ADD COLUMN activity_profile INTEGER")
             print("✓ Added activity_profile column to agents table in SQLite database")
         else:
             print("○ activity_profile column already exists in agents table")
@@ -57,9 +55,7 @@ def migrate_sqlite(db_path):
 
         # Add activity_profile column to pages if it doesn't exist
         if "activity_profile" not in pages_columns:
-            cursor.execute(
-                "ALTER TABLE pages ADD COLUMN activity_profile INTEGER"
-            )
+            cursor.execute("ALTER TABLE pages ADD COLUMN activity_profile INTEGER")
             print("✓ Added activity_profile column to pages table in SQLite database")
         else:
             print("○ activity_profile column already exists in pages table")
@@ -99,46 +95,42 @@ def migrate_postgresql(host, port, database, user, password):
         cursor = conn.cursor()
 
         # Check agents table columns
-        cursor.execute(
-            """
+        cursor.execute("""
             SELECT column_name
             FROM information_schema.columns
             WHERE table_name = 'agents'
-        """
-        )
+        """)
         agents_columns = [row[0] for row in cursor.fetchall()]
 
         # Add activity_profile column to agents if it doesn't exist
         if "activity_profile" not in agents_columns:
-            cursor.execute(
-                """
+            cursor.execute("""
                 ALTER TABLE agents
                 ADD COLUMN activity_profile INTEGER REFERENCES activity_profiles(id)
-            """
+            """)
+            print(
+                "✓ Added activity_profile column to agents table in PostgreSQL database"
             )
-            print("✓ Added activity_profile column to agents table in PostgreSQL database")
         else:
             print("○ activity_profile column already exists in agents table")
 
         # Check pages table columns
-        cursor.execute(
-            """
+        cursor.execute("""
             SELECT column_name
             FROM information_schema.columns
             WHERE table_name = 'pages'
-        """
-        )
+        """)
         pages_columns = [row[0] for row in cursor.fetchall()]
 
         # Add activity_profile column to pages if it doesn't exist
         if "activity_profile" not in pages_columns:
-            cursor.execute(
-                """
+            cursor.execute("""
                 ALTER TABLE pages
                 ADD COLUMN activity_profile INTEGER REFERENCES activity_profiles(id)
-            """
+            """)
+            print(
+                "✓ Added activity_profile column to pages table in PostgreSQL database"
             )
-            print("✓ Added activity_profile column to pages table in PostgreSQL database")
         else:
             print("○ activity_profile column already exists in pages table")
 

--- a/y_web/migrations/add_agent_archetype_field.py
+++ b/y_web/migrations/add_agent_archetype_field.py
@@ -162,13 +162,11 @@ def migrate_postgresql_dashboard(db_config):
         cursor = conn.cursor()
 
         # Check if column already exists
-        cursor.execute(
-            """
+        cursor.execute("""
             SELECT column_name 
             FROM information_schema.columns 
             WHERE table_name = 'agents' AND column_name = 'archetype'
-        """
-        )
+        """)
 
         if cursor.fetchone() is None:
             print(
@@ -207,13 +205,11 @@ def migrate_postgresql_server(db_config):
         cursor = conn.cursor()
 
         # Check if column already exists
-        cursor.execute(
-            """
+        cursor.execute("""
             SELECT column_name 
             FROM information_schema.columns 
             WHERE table_name = 'user_mgmt' AND column_name = 'archetype'
-        """
-        )
+        """)
 
         if cursor.fetchone() is None:
             print(

--- a/y_web/migrations/add_agent_archetypes.py
+++ b/y_web/migrations/add_agent_archetypes.py
@@ -119,14 +119,12 @@ def migrate_postgresql(host, port, database, user, password):
         cursor = conn.cursor()
 
         # Check if columns already exist
-        cursor.execute(
-            """
+        cursor.execute("""
             SELECT column_name 
             FROM information_schema.columns 
             WHERE table_schema = 'public' 
               AND table_name = 'client'
-        """
-        )
+        """)
         existing_columns = [row[0] for row in cursor.fetchall()]
 
         columns_to_add = []

--- a/y_web/migrations/add_blog_posts_table.py
+++ b/y_web/migrations/add_blog_posts_table.py
@@ -43,8 +43,7 @@ def migrate_dashboard_db():
             return True
 
         # Create the blog_posts table
-        cursor.execute(
-            """
+        cursor.execute("""
             CREATE TABLE blog_posts (
                 id INTEGER PRIMARY KEY AUTOINCREMENT,
                 title TEXT,
@@ -53,8 +52,7 @@ def migrate_dashboard_db():
                 is_read INTEGER DEFAULT 0,
                 latest_check_on TEXT
             )
-        """
-        )
+        """)
 
         conn.commit()
         conn.close()

--- a/y_web/migrations/add_comment_dedupe_columns.py
+++ b/y_web/migrations/add_comment_dedupe_columns.py
@@ -13,7 +13,7 @@ import sqlite3
 
 def _sqlite_path_from_uri(db_uri_or_path: str) -> str:
     if db_uri_or_path.startswith("sqlite:///"):
-        return db_uri_or_path[len("sqlite:///"):]
+        return db_uri_or_path[len("sqlite:///") :]
     return db_uri_or_path
 
 
@@ -33,7 +33,9 @@ def _column_exists(cursor: sqlite3.Cursor, table_name: str, column_name: str) ->
 def migrate_sqlite_comment_dedupe_columns(db_uri_or_path: str) -> bool:
     db_path = _sqlite_path_from_uri(db_uri_or_path)
     if not db_path or not os.path.exists(db_path):
-        print(f"○ SQLite experiment DB not found for comment dedupe migration: {db_path}")
+        print(
+            f"○ SQLite experiment DB not found for comment dedupe migration: {db_path}"
+        )
         return False
 
     try:
@@ -49,31 +51,31 @@ def migrate_sqlite_comment_dedupe_columns(db_uri_or_path: str) -> bool:
             cursor.execute("ALTER TABLE post ADD COLUMN dedupe_key TEXT")
             print("✓ Added dedupe_key column to post table (SQLite experiment DB)")
         else:
-            print("○ dedupe_key column already exists in post table (SQLite experiment DB)")
+            print(
+                "○ dedupe_key column already exists in post table (SQLite experiment DB)"
+            )
 
         if not _column_exists(cursor, "post", "client_action_id"):
             cursor.execute("ALTER TABLE post ADD COLUMN client_action_id TEXT")
-            print("✓ Added client_action_id column to post table (SQLite experiment DB)")
+            print(
+                "✓ Added client_action_id column to post table (SQLite experiment DB)"
+            )
         else:
             print(
                 "○ client_action_id column already exists in post table (SQLite experiment DB)"
             )
 
         # Apply unique partial indexes only where dedupe values are present.
-        cursor.execute(
-            """
+        cursor.execute("""
             CREATE UNIQUE INDEX IF NOT EXISTS idx_post_comment_action_id_uniq
             ON post (user_id, client_action_id)
             WHERE client_action_id IS NOT NULL
-            """
-        )
-        cursor.execute(
-            """
+            """)
+        cursor.execute("""
             CREATE UNIQUE INDEX IF NOT EXISTS idx_post_comment_dedupe_uniq
             ON post (user_id, comment_to, round, dedupe_key)
             WHERE comment_to <> -1 AND dedupe_key IS NOT NULL
-            """
-        )
+            """)
 
         conn.commit()
         conn.close()
@@ -81,4 +83,3 @@ def migrate_sqlite_comment_dedupe_columns(db_uri_or_path: str) -> bool:
     except Exception as exc:
         print(f"✗ Error migrating SQLite experiment DB comment dedupe columns: {exc}")
         return False
-

--- a/y_web/migrations/add_execution_stage_column.py
+++ b/y_web/migrations/add_execution_stage_column.py
@@ -114,36 +114,30 @@ def migrate_postgresql(host, port, database, user, password):
         cursor = conn.cursor()
 
         # Check if table exists
-        cursor.execute(
-            """
+        cursor.execute("""
             SELECT table_name
             FROM information_schema.tables
             WHERE table_name = 'client_execution'
-        """
-        )
+        """)
         if not cursor.fetchone():
             print("○ client_execution table does not exist yet")
             conn.close()
             return True
 
         # Check if column already exists
-        cursor.execute(
-            """
+        cursor.execute("""
             SELECT column_name
             FROM information_schema.columns
             WHERE table_name = 'client_execution'
-        """
-        )
+        """)
         columns = [row[0] for row in cursor.fetchall()]
 
         # Add execution_stage column if it doesn't exist
         if "execution_stage" not in columns:
-            cursor.execute(
-                """
+            cursor.execute("""
                 ALTER TABLE client_execution
                 ADD COLUMN execution_stage VARCHAR(20) DEFAULT 'initializing'
-            """
-            )
+            """)
             print("✓ Added execution_stage column to PostgreSQL database")
 
             # Update existing records based on their elapsed_time

--- a/y_web/migrations/add_exp_details_tutorial_column.py
+++ b/y_web/migrations/add_exp_details_tutorial_column.py
@@ -87,23 +87,19 @@ def migrate_postgresql(host, port, database, user, password):
         cursor = conn.cursor()
 
         # Check if columns already exist
-        cursor.execute(
-            """
+        cursor.execute("""
             SELECT column_name 
             FROM information_schema.columns 
             WHERE table_name = 'admin_users'
-        """
-        )
+        """)
         columns = [row[0] for row in cursor.fetchall()]
 
         # Add exp_details_tutorial_shown column if it doesn't exist
         if "exp_details_tutorial_shown" not in columns:
-            cursor.execute(
-                """
+            cursor.execute("""
                 ALTER TABLE admin_users 
                 ADD COLUMN exp_details_tutorial_shown BOOLEAN DEFAULT FALSE
-            """
-            )
+            """)
             print("✓ Added exp_details_tutorial_shown column to PostgreSQL database")
         else:
             print(

--- a/y_web/migrations/add_exp_status_column.py
+++ b/y_web/migrations/add_exp_status_column.py
@@ -93,23 +93,19 @@ def migrate_postgresql(host, port, database, user, password):
         cursor = conn.cursor()
 
         # Check if column already exists
-        cursor.execute(
-            """
+        cursor.execute("""
             SELECT column_name 
             FROM information_schema.columns 
             WHERE table_name = 'exps'
-        """
-        )
+        """)
         columns = [row[0] for row in cursor.fetchall()]
 
         # Add exp_status column if it doesn't exist
         if "exp_status" not in columns:
-            cursor.execute(
-                """
+            cursor.execute("""
                 ALTER TABLE exps 
                 ADD COLUMN exp_status VARCHAR(20) DEFAULT 'stopped'
-            """
-            )
+            """)
             print("✓ Added exp_status column to PostgreSQL database")
 
             # Update existing experiments based on their running status

--- a/y_web/migrations/add_experiment_schedule_tables.py
+++ b/y_web/migrations/add_experiment_schedule_tables.py
@@ -44,8 +44,7 @@ def migrate_sqlite(db_path):
         )
         if cursor.fetchone() is None:
             # Create experiment_schedule_groups table
-            cursor.execute(
-                """
+            cursor.execute("""
                 CREATE TABLE experiment_schedule_groups (
                     id INTEGER PRIMARY KEY AUTOINCREMENT,
                     name TEXT NOT NULL,
@@ -53,8 +52,7 @@ def migrate_sqlite(db_path):
                     created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
                     is_completed INTEGER NOT NULL DEFAULT 0
                 )
-            """
-            )
+            """)
             print("✓ Created experiment_schedule_groups table")
         else:
             # Check if is_completed column exists, add if not
@@ -71,8 +69,7 @@ def migrate_sqlite(db_path):
         )
         if cursor.fetchone() is None:
             # Create experiment_schedule_items table
-            cursor.execute(
-                """
+            cursor.execute("""
                 CREATE TABLE experiment_schedule_items (
                     id INTEGER PRIMARY KEY AUTOINCREMENT,
                     group_id INTEGER NOT NULL,
@@ -81,8 +78,7 @@ def migrate_sqlite(db_path):
                     FOREIGN KEY (group_id) REFERENCES experiment_schedule_groups(id),
                     FOREIGN KEY (experiment_id) REFERENCES exps(idexp)
                 )
-            """
-            )
+            """)
             print("✓ Created experiment_schedule_items table")
 
         cursor.execute(
@@ -90,16 +86,14 @@ def migrate_sqlite(db_path):
         )
         if cursor.fetchone() is None:
             # Create experiment_schedule_status table
-            cursor.execute(
-                """
+            cursor.execute("""
                 CREATE TABLE experiment_schedule_status (
                     id INTEGER PRIMARY KEY AUTOINCREMENT,
                     is_running INTEGER NOT NULL DEFAULT 0,
                     current_group_id INTEGER,
                     started_at DATETIME
                 )
-            """
-            )
+            """)
             # Insert initial status row
             cursor.execute(
                 "INSERT INTO experiment_schedule_status (is_running) VALUES (0)"
@@ -111,16 +105,14 @@ def migrate_sqlite(db_path):
             "SELECT name FROM sqlite_master WHERE type='table' AND name='experiment_schedule_logs'"
         )
         if cursor.fetchone() is None:
-            cursor.execute(
-                """
+            cursor.execute("""
                 CREATE TABLE experiment_schedule_logs (
                     id INTEGER PRIMARY KEY AUTOINCREMENT,
                     message TEXT NOT NULL,
                     created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
                     log_type TEXT NOT NULL DEFAULT 'info'
                 )
-            """
-            )
+            """)
             print("✓ Created experiment_schedule_logs table")
 
         conn.commit()
@@ -158,69 +150,57 @@ def migrate_postgresql(host, port, database, user, password):
         cursor = conn.cursor()
 
         # Check and create experiment_schedule_groups table
-        cursor.execute(
-            """
+        cursor.execute("""
             SELECT EXISTS (
                 SELECT FROM information_schema.tables 
                 WHERE table_name = 'experiment_schedule_groups'
             )
-        """
-        )
+        """)
         if not cursor.fetchone()[0]:
-            cursor.execute(
-                """
+            cursor.execute("""
                 CREATE TABLE experiment_schedule_groups (
                     id SERIAL PRIMARY KEY,
                     name VARCHAR(100) NOT NULL,
                     order_index INTEGER NOT NULL DEFAULT 0,
                     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
                 )
-            """
-            )
+            """)
             print("✓ Created experiment_schedule_groups table")
 
         # Check and create experiment_schedule_items table
-        cursor.execute(
-            """
+        cursor.execute("""
             SELECT EXISTS (
                 SELECT FROM information_schema.tables 
                 WHERE table_name = 'experiment_schedule_items'
             )
-        """
-        )
+        """)
         if not cursor.fetchone()[0]:
-            cursor.execute(
-                """
+            cursor.execute("""
                 CREATE TABLE experiment_schedule_items (
                     id SERIAL PRIMARY KEY,
                     group_id INTEGER NOT NULL REFERENCES experiment_schedule_groups(id),
                     experiment_id INTEGER NOT NULL REFERENCES exps(idexp),
                     order_index INTEGER NOT NULL DEFAULT 0
                 )
-            """
-            )
+            """)
             print("✓ Created experiment_schedule_items table")
 
         # Check and create experiment_schedule_status table
-        cursor.execute(
-            """
+        cursor.execute("""
             SELECT EXISTS (
                 SELECT FROM information_schema.tables 
                 WHERE table_name = 'experiment_schedule_status'
             )
-        """
-        )
+        """)
         if not cursor.fetchone()[0]:
-            cursor.execute(
-                """
+            cursor.execute("""
                 CREATE TABLE experiment_schedule_status (
                     id SERIAL PRIMARY KEY,
                     is_running INTEGER NOT NULL DEFAULT 0,
                     current_group_id INTEGER,
                     started_at TIMESTAMP
                 )
-            """
-            )
+            """)
             # Insert initial status row
             cursor.execute(
                 "INSERT INTO experiment_schedule_status (is_running) VALUES (0)"

--- a/y_web/migrations/add_initial_agents_column.py
+++ b/y_web/migrations/add_initial_agents_column.py
@@ -85,24 +85,22 @@ def migrate_postgresql(host, port, database, user, password):
         cursor = conn.cursor()
 
         # Check client table columns
-        cursor.execute(
-            """
+        cursor.execute("""
             SELECT column_name
             FROM information_schema.columns
             WHERE table_name = 'client'
-        """
-        )
+        """)
         client_columns = [row[0] for row in cursor.fetchall()]
 
         # Add initial_agents column to client if it doesn't exist
         if "initial_agents" not in client_columns:
-            cursor.execute(
-                """
+            cursor.execute("""
                 ALTER TABLE client
                 ADD COLUMN initial_agents INTEGER DEFAULT NULL
-            """
+            """)
+            print(
+                "✓ Added initial_agents column to client table in PostgreSQL database"
             )
-            print("✓ Added initial_agents column to client table in PostgreSQL database")
         else:
             print("○ initial_agents column already exists in client table")
 

--- a/y_web/migrations/add_llm_columns.py
+++ b/y_web/migrations/add_llm_columns.py
@@ -129,13 +129,11 @@ def migrate_postgresql(host, port, database, user, password):
         cursor = conn.cursor()
 
         # Get existing columns in exps table
-        cursor.execute(
-            """
+        cursor.execute("""
             SELECT column_name 
             FROM information_schema.columns 
             WHERE table_name = 'exps'
-        """
-        )
+        """)
         exps_columns = [row[0] for row in cursor.fetchall()]
 
         # Add LLM default columns to exps table
@@ -163,13 +161,11 @@ def migrate_postgresql(host, port, database, user, password):
             print("○ All LLM columns already exist in exps table")
 
         # Get existing columns in client table
-        cursor.execute(
-            """
+        cursor.execute("""
             SELECT column_name 
             FROM information_schema.columns 
             WHERE table_name = 'client'
-        """
-        )
+        """)
         client_columns = [row[0] for row in cursor.fetchall()]
 
         # Add reply behavior columns to client table
@@ -259,4 +255,3 @@ def main():
 
 if __name__ == "__main__":
     sys.exit(main())
-

--- a/y_web/migrations/add_log_metrics_tables.py
+++ b/y_web/migrations/add_log_metrics_tables.py
@@ -47,8 +47,7 @@ def migrate_sqlite(db_path):
 
         # Create log_file_offsets table if it doesn't exist
         if "log_file_offsets" not in existing_tables:
-            cursor.execute(
-                """
+            cursor.execute("""
                 CREATE TABLE log_file_offsets (
                     id            INTEGER PRIMARY KEY AUTOINCREMENT,
                     exp_id        INTEGER NOT NULL,
@@ -60,8 +59,7 @@ def migrate_sqlite(db_path):
                     FOREIGN KEY (exp_id) REFERENCES exps(idexp) ON DELETE CASCADE,
                     FOREIGN KEY (client_id) REFERENCES client(id) ON DELETE CASCADE
                 )
-            """
-            )
+            """)
             cursor.execute(
                 "CREATE INDEX idx_log_file_offset_lookup ON log_file_offsets(exp_id, log_file_type, client_id)"
             )
@@ -71,8 +69,7 @@ def migrate_sqlite(db_path):
 
         # Create server_log_metrics table if it doesn't exist
         if "server_log_metrics" not in existing_tables:
-            cursor.execute(
-                """
+            cursor.execute("""
                 CREATE TABLE server_log_metrics (
                     id                INTEGER PRIMARY KEY AUTOINCREMENT,
                     exp_id            INTEGER NOT NULL,
@@ -86,8 +83,7 @@ def migrate_sqlite(db_path):
                     max_time          TEXT,
                     FOREIGN KEY (exp_id) REFERENCES exps(idexp) ON DELETE CASCADE
                 )
-            """
-            )
+            """)
             cursor.execute(
                 "CREATE INDEX idx_server_log_metrics_lookup ON server_log_metrics(exp_id, aggregation_level, day, hour, path)"
             )
@@ -97,8 +93,7 @@ def migrate_sqlite(db_path):
 
         # Create client_log_metrics table if it doesn't exist
         if "client_log_metrics" not in existing_tables:
-            cursor.execute(
-                """
+            cursor.execute("""
                 CREATE TABLE client_log_metrics (
                     id                   INTEGER PRIMARY KEY AUTOINCREMENT,
                     exp_id               INTEGER NOT NULL,
@@ -112,8 +107,7 @@ def migrate_sqlite(db_path):
                     FOREIGN KEY (exp_id) REFERENCES exps(idexp) ON DELETE CASCADE,
                     FOREIGN KEY (client_id) REFERENCES client(id) ON DELETE CASCADE
                 )
-            """
-            )
+            """)
             cursor.execute(
                 "CREATE INDEX idx_client_log_metrics_lookup ON client_log_metrics(exp_id, client_id, aggregation_level, day, hour, method_name)"
             )
@@ -156,20 +150,17 @@ def migrate_postgresql(host, port, database, user, password):
         cursor = conn.cursor()
 
         # Check if tables already exist
-        cursor.execute(
-            """
+        cursor.execute("""
             SELECT table_name 
             FROM information_schema.tables 
             WHERE table_schema = 'public' 
               AND table_name IN ('log_file_offsets', 'server_log_metrics', 'client_log_metrics')
-        """
-        )
+        """)
         existing_tables = [row[0] for row in cursor.fetchall()]
 
         # Create log_file_offsets table if it doesn't exist
         if "log_file_offsets" not in existing_tables:
-            cursor.execute(
-                """
+            cursor.execute("""
                 CREATE TABLE log_file_offsets (
                     id            SERIAL PRIMARY KEY,
                     exp_id        INTEGER NOT NULL REFERENCES exps(idexp) ON DELETE CASCADE,
@@ -179,8 +170,7 @@ def migrate_postgresql(host, port, database, user, password):
                     last_offset   BIGINT NOT NULL DEFAULT 0,
                     last_updated  TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
                 )
-            """
-            )
+            """)
             cursor.execute(
                 "CREATE INDEX idx_log_file_offset_lookup ON log_file_offsets(exp_id, log_file_type, client_id)"
             )
@@ -190,8 +180,7 @@ def migrate_postgresql(host, port, database, user, password):
 
         # Create server_log_metrics table if it doesn't exist
         if "server_log_metrics" not in existing_tables:
-            cursor.execute(
-                """
+            cursor.execute("""
                 CREATE TABLE server_log_metrics (
                     id                SERIAL PRIMARY KEY,
                     exp_id            INTEGER NOT NULL REFERENCES exps(idexp) ON DELETE CASCADE,
@@ -204,8 +193,7 @@ def migrate_postgresql(host, port, database, user, password):
                     min_time          TIMESTAMP,
                     max_time          TIMESTAMP
                 )
-            """
-            )
+            """)
             cursor.execute(
                 "CREATE INDEX idx_server_log_metrics_lookup ON server_log_metrics(exp_id, aggregation_level, day, hour, path)"
             )
@@ -215,8 +203,7 @@ def migrate_postgresql(host, port, database, user, password):
 
         # Create client_log_metrics table if it doesn't exist
         if "client_log_metrics" not in existing_tables:
-            cursor.execute(
-                """
+            cursor.execute("""
                 CREATE TABLE client_log_metrics (
                     id                   SERIAL PRIMARY KEY,
                     exp_id               INTEGER NOT NULL REFERENCES exps(idexp) ON DELETE CASCADE,
@@ -228,8 +215,7 @@ def migrate_postgresql(host, port, database, user, password):
                     call_count           INTEGER NOT NULL DEFAULT 0,
                     total_execution_time DOUBLE PRECISION NOT NULL DEFAULT 0.0
                 )
-            """
-            )
+            """)
             cursor.execute(
                 "CREATE INDEX idx_client_log_metrics_lookup ON client_log_metrics(exp_id, client_id, aggregation_level, day, hour, method_name)"
             )

--- a/y_web/migrations/add_log_sync_settings.py
+++ b/y_web/migrations/add_log_sync_settings.py
@@ -46,23 +46,19 @@ def migrate_sqlite(db_path):
         table_exists = cursor.fetchone() is not None
 
         if not table_exists:
-            cursor.execute(
-                """
+            cursor.execute("""
                 CREATE TABLE log_sync_settings (
                     id                    INTEGER PRIMARY KEY AUTOINCREMENT,
                     enabled               INTEGER NOT NULL DEFAULT 1,
                     sync_interval_minutes INTEGER NOT NULL DEFAULT 10,
                     last_sync             TEXT
                 )
-            """
-            )
+            """)
             # Insert default settings row
-            cursor.execute(
-                """
+            cursor.execute("""
                 INSERT INTO log_sync_settings (enabled, sync_interval_minutes)
                 VALUES (1, 10)
-            """
-            )
+            """)
             print("✓ Created log_sync_settings table in SQLite database")
         else:
             print("○ log_sync_settings table already exists in SQLite database")
@@ -102,34 +98,28 @@ def migrate_postgresql(host, port, database, user, password):
         cursor = conn.cursor()
 
         # Check if table already exists
-        cursor.execute(
-            """
+        cursor.execute("""
             SELECT table_name 
             FROM information_schema.tables 
             WHERE table_schema = 'public' 
               AND table_name = 'log_sync_settings'
-        """
-        )
+        """)
         table_exists = cursor.fetchone() is not None
 
         if not table_exists:
-            cursor.execute(
-                """
+            cursor.execute("""
                 CREATE TABLE log_sync_settings (
                     id                    SERIAL PRIMARY KEY,
                     enabled               BOOLEAN NOT NULL DEFAULT TRUE,
                     sync_interval_minutes INTEGER NOT NULL DEFAULT 10,
                     last_sync             TIMESTAMP
                 )
-            """
-            )
+            """)
             # Insert default settings row
-            cursor.execute(
-                """
+            cursor.execute("""
                 INSERT INTO log_sync_settings (enabled, sync_interval_minutes)
                 VALUES (TRUE, 10)
-            """
-            )
+            """)
             print("✓ Created log_sync_settings table in PostgreSQL database")
         else:
             print("○ log_sync_settings table already exists in PostgreSQL database")

--- a/y_web/migrations/add_opinion_dynamics_tables.py
+++ b/y_web/migrations/add_opinion_dynamics_tables.py
@@ -46,16 +46,14 @@ def migrate_sqlite(db_path):
         groups_exists = cursor.fetchone() is not None
 
         if not groups_exists:
-            cursor.execute(
-                """
+            cursor.execute("""
                 CREATE TABLE opinion_groups (
                     id          INTEGER PRIMARY KEY AUTOINCREMENT,
                     name        VARCHAR(100) NOT NULL,
                     lower_bound REAL NOT NULL,
                     upper_bound REAL NOT NULL
                 )
-            """
-            )
+            """)
             print("✓ Created opinion_groups table in SQLite database")
         else:
             print("○ opinion_groups table already exists in SQLite database")
@@ -68,16 +66,14 @@ def migrate_sqlite(db_path):
 
         distributions_created = False
         if not distributions_exists:
-            cursor.execute(
-                """
+            cursor.execute("""
                 CREATE TABLE opinion_distributions (
                     id                INTEGER PRIMARY KEY AUTOINCREMENT,
                     name              VARCHAR(100) NOT NULL,
                     distribution_type VARCHAR(50) NOT NULL,
                     parameters        TEXT NOT NULL
                 )
-            """
-            )
+            """)
             print("✓ Created opinion_distributions table in SQLite database")
             distributions_created = True
         else:
@@ -160,54 +156,46 @@ def migrate_postgresql(host, port, database, user, password):
         cursor = conn.cursor()
 
         # Check if opinion_groups table already exists
-        cursor.execute(
-            """
+        cursor.execute("""
             SELECT table_name 
             FROM information_schema.tables 
             WHERE table_schema = 'public' 
               AND table_name = 'opinion_groups'
-        """
-        )
+        """)
         groups_exists = cursor.fetchone() is not None
 
         if not groups_exists:
-            cursor.execute(
-                """
+            cursor.execute("""
                 CREATE TABLE opinion_groups (
                     id          SERIAL PRIMARY KEY,
                     name        VARCHAR(100) NOT NULL,
                     lower_bound DOUBLE PRECISION NOT NULL,
                     upper_bound DOUBLE PRECISION NOT NULL
                 )
-            """
-            )
+            """)
             print("✓ Created opinion_groups table in PostgreSQL database")
         else:
             print("○ opinion_groups table already exists in PostgreSQL database")
 
         # Check if opinion_distributions table already exists
-        cursor.execute(
-            """
+        cursor.execute("""
             SELECT table_name 
             FROM information_schema.tables 
             WHERE table_schema = 'public' 
               AND table_name = 'opinion_distributions'
-        """
-        )
+        """)
         distributions_exists = cursor.fetchone() is not None
 
         distributions_created = False
         if not distributions_exists:
-            cursor.execute(
-                """
+            cursor.execute("""
                 CREATE TABLE opinion_distributions (
                     id                SERIAL PRIMARY KEY,
                     name              VARCHAR(100) NOT NULL,
                     distribution_type VARCHAR(50) NOT NULL,
                     parameters        TEXT NOT NULL
                 )
-            """
-            )
+            """)
             print("✓ Created opinion_distributions table in PostgreSQL database")
             distributions_created = True
         else:

--- a/y_web/migrations/add_population_username_type_column.py
+++ b/y_web/migrations/add_population_username_type_column.py
@@ -54,7 +54,9 @@ def migrate_sqlite(db_path: str) -> bool:
         return False
 
 
-def migrate_postgresql(host: str, port: str, database: str, user: str, password: str) -> bool:
+def migrate_postgresql(
+    host: str, port: str, database: str, user: str, password: str
+) -> bool:
     """
     Add username_type column to population table in PostgreSQL database.
 
@@ -78,22 +80,18 @@ def migrate_postgresql(host: str, port: str, database: str, user: str, password:
         )
         cursor = conn.cursor()
 
-        cursor.execute(
-            """
+        cursor.execute("""
             SELECT column_name
             FROM information_schema.columns
             WHERE table_schema = 'public' AND table_name = 'population'
-        """
-        )
+        """)
         columns = {row[0] for row in cursor.fetchall()}
 
         if "username_type" not in columns:
-            cursor.execute(
-                """
+            cursor.execute("""
                 ALTER TABLE population
                 ADD COLUMN username_type VARCHAR(20) DEFAULT 'microblogging'
-            """
-            )
+            """)
             print(
                 "✓ Added username_type column to population table in PostgreSQL database"
             )
@@ -106,4 +104,3 @@ def migrate_postgresql(host: str, port: str, database: str, user: str, password:
     except Exception as e:
         print(f"✗ Error migrating PostgreSQL database: {e}")
         return False
-

--- a/y_web/migrations/add_post_created_at_column.py
+++ b/y_web/migrations/add_post_created_at_column.py
@@ -14,7 +14,7 @@ import sqlite3
 
 def _sqlite_path_from_uri(db_uri_or_path: str) -> str:
     if db_uri_or_path.startswith("sqlite:///"):
-        return db_uri_or_path[len("sqlite:///"):]
+        return db_uri_or_path[len("sqlite:///") :]
     return db_uri_or_path
 
 
@@ -53,12 +53,13 @@ def migrate_sqlite_experiment_db(db_uri_or_path: str) -> bool:
             cursor.execute("ALTER TABLE post ADD COLUMN created_at DATETIME")
             print("✓ Added created_at column to post table (SQLite experiment DB)")
         else:
-            print("○ created_at column already exists in post table (SQLite experiment DB)")
+            print(
+                "○ created_at column already exists in post table (SQLite experiment DB)"
+            )
 
         # Backfill from simulation rounds when possible.
         if _table_exists(cursor, "rounds"):
-            cursor.execute(
-                """
+            cursor.execute("""
                 UPDATE post
                 SET created_at = (
                     SELECT datetime(
@@ -77,8 +78,7 @@ def migrate_sqlite_experiment_db(db_uri_or_path: str) -> bool:
                     WHERE rounds.id = post.round
                 )
                 WHERE created_at IS NULL
-                """
-            )
+                """)
 
         # Final fallback for any unresolved legacy rows.
         cursor.execute(
@@ -91,4 +91,3 @@ def migrate_sqlite_experiment_db(db_uri_or_path: str) -> bool:
     except Exception as exc:
         print(f"✗ Error migrating SQLite experiment DB post.created_at: {exc}")
         return False
-

--- a/y_web/migrations/add_telemetry_columns.py
+++ b/y_web/migrations/add_telemetry_columns.py
@@ -95,35 +95,29 @@ def migrate_postgresql(host, port, database, user, password):
         cursor = conn.cursor()
 
         # Check if columns already exist
-        cursor.execute(
-            """
+        cursor.execute("""
             SELECT column_name 
             FROM information_schema.columns 
             WHERE table_name = 'admin_users'
-        """
-        )
+        """)
         columns = [row[0] for row in cursor.fetchall()]
 
         # Add telemetry_enabled column if it doesn't exist
         if "telemetry_enabled" not in columns:
-            cursor.execute(
-                """
+            cursor.execute("""
                 ALTER TABLE admin_users 
                 ADD COLUMN telemetry_enabled BOOLEAN DEFAULT TRUE
-            """
-            )
+            """)
             print("✓ Added telemetry_enabled column to PostgreSQL database")
         else:
             print("○ telemetry_enabled column already exists in PostgreSQL database")
 
         # Add telemetry_notice_shown column if it doesn't exist
         if "telemetry_notice_shown" not in columns:
-            cursor.execute(
-                """
+            cursor.execute("""
                 ALTER TABLE admin_users 
                 ADD COLUMN telemetry_notice_shown BOOLEAN DEFAULT FALSE
-            """
-            )
+            """)
             print("✓ Added telemetry_notice_shown column to PostgreSQL database")
         else:
             print(

--- a/y_web/migrations/add_tutorial_shown_column.py
+++ b/y_web/migrations/add_tutorial_shown_column.py
@@ -85,23 +85,19 @@ def migrate_postgresql(host, port, database, user, password):
         cursor = conn.cursor()
 
         # Check if columns already exist
-        cursor.execute(
-            """
+        cursor.execute("""
             SELECT column_name 
             FROM information_schema.columns 
             WHERE table_name = 'admin_users'
-        """
-        )
+        """)
         columns = [row[0] for row in cursor.fetchall()]
 
         # Add tutorial_shown column if it doesn't exist
         if "tutorial_shown" not in columns:
-            cursor.execute(
-                """
+            cursor.execute("""
                 ALTER TABLE admin_users 
                 ADD COLUMN tutorial_shown BOOLEAN DEFAULT FALSE
-            """
-            )
+            """)
             print("✓ Added tutorial_shown column to PostgreSQL database")
         else:
             print("○ tutorial_shown column already exists in PostgreSQL database")

--- a/y_web/migrations/add_watchdog_settings.py
+++ b/y_web/migrations/add_watchdog_settings.py
@@ -51,8 +51,7 @@ def migrate_sqlite(db_path):
         table_exists = cursor.fetchone() is not None
 
         if not table_exists:
-            cursor.execute(
-                """
+            cursor.execute("""
                 CREATE TABLE watchdog_settings (
                     id                   INTEGER PRIMARY KEY AUTOINCREMENT,
                     enabled              INTEGER NOT NULL DEFAULT 1,
@@ -64,19 +63,16 @@ def migrate_sqlite(db_path):
                     restart_cooldown_sec INTEGER NOT NULL DEFAULT 60,
                     last_run             TEXT
                 )
-            """
-            )
+            """)
             # Insert default settings row
-            cursor.execute(
-                """
+            cursor.execute("""
                 INSERT INTO watchdog_settings (
                     enabled, run_interval_minutes, server_heartbeat_timeout_sec,
                     client_heartbeat_timeout_sec, heartbeat_interval_sec,
                     max_restart_attempts, restart_cooldown_sec
                 )
                 VALUES (1, 1, 300, 300, 60, 3, 60)
-            """
-            )
+            """)
             print("✓ Created watchdog_settings table in SQLite database")
         else:
             print("○ watchdog_settings table already exists in SQLite database")
@@ -157,19 +153,16 @@ def migrate_postgresql(host, port, database, user, password):
         cursor = conn.cursor()
 
         # Check if table already exists
-        cursor.execute(
-            """
+        cursor.execute("""
             SELECT table_name 
             FROM information_schema.tables 
             WHERE table_schema = 'public' 
               AND table_name = 'watchdog_settings'
-        """
-        )
+        """)
         table_exists = cursor.fetchone() is not None
 
         if not table_exists:
-            cursor.execute(
-                """
+            cursor.execute("""
                 CREATE TABLE watchdog_settings (
                     id                   SERIAL PRIMARY KEY,
                     enabled              BOOLEAN NOT NULL DEFAULT TRUE,
@@ -181,35 +174,29 @@ def migrate_postgresql(host, port, database, user, password):
                     restart_cooldown_sec INTEGER NOT NULL DEFAULT 60,
                     last_run             TIMESTAMP
                 )
-            """
-            )
+            """)
             # Insert default settings row
-            cursor.execute(
-                """
+            cursor.execute("""
                 INSERT INTO watchdog_settings (
                     enabled, run_interval_minutes, server_heartbeat_timeout_sec,
                     client_heartbeat_timeout_sec, heartbeat_interval_sec,
                     max_restart_attempts, restart_cooldown_sec
                 )
                 VALUES (TRUE, 1, 300, 300, 60, 3, 60)
-            """
-            )
+            """)
             print("✓ Created watchdog_settings table in PostgreSQL database")
         else:
             print("○ watchdog_settings table already exists in PostgreSQL database")
 
-            cursor.execute(
-                """
+            cursor.execute("""
                 ALTER TABLE watchdog_settings
                 ADD COLUMN IF NOT EXISTS server_heartbeat_timeout_sec INTEGER NOT NULL DEFAULT 300,
                 ADD COLUMN IF NOT EXISTS client_heartbeat_timeout_sec INTEGER NOT NULL DEFAULT 300,
                 ADD COLUMN IF NOT EXISTS heartbeat_interval_sec INTEGER NOT NULL DEFAULT 60,
                 ADD COLUMN IF NOT EXISTS max_restart_attempts INTEGER NOT NULL DEFAULT 3,
                 ADD COLUMN IF NOT EXISTS restart_cooldown_sec INTEGER NOT NULL DEFAULT 60
-            """
-            )
-            cursor.execute(
-                """
+            """)
+            cursor.execute("""
                 UPDATE watchdog_settings
                 SET
                     server_heartbeat_timeout_sec = COALESCE(server_heartbeat_timeout_sec, 300),
@@ -217,8 +204,7 @@ def migrate_postgresql(host, port, database, user, password):
                     heartbeat_interval_sec = COALESCE(heartbeat_interval_sec, 60),
                     max_restart_attempts = COALESCE(max_restart_attempts, 3),
                     restart_cooldown_sec = COALESCE(restart_cooldown_sec, 60)
-            """
-            )
+            """)
 
         conn.commit()
         conn.close()

--- a/y_web/migrations/ensure_dashboard_default_config.py
+++ b/y_web/migrations/ensure_dashboard_default_config.py
@@ -61,7 +61,9 @@ def _tuple_by_columns(row: dict[str, Any], columns: tuple[str, ...]) -> tuple[An
     return tuple(row[c] for c in columns)
 
 
-def _build_key_from_row(row: dict[str, Any], key_columns: tuple[str, ...]) -> tuple[str, ...]:
+def _build_key_from_row(
+    row: dict[str, Any], key_columns: tuple[str, ...]
+) -> tuple[str, ...]:
     return _normalize_key(tuple(row[c] for c in key_columns))
 
 
@@ -73,7 +75,9 @@ def _sqlite_template_path() -> str:
     return os.path.join(ysocial_root, "data_schema", "database_dashboard.db")
 
 
-def load_canonical_defaults(sqlite_path: str | None = None) -> dict[str, list[dict[str, Any]]]:
+def load_canonical_defaults(
+    sqlite_path: str | None = None,
+) -> dict[str, list[dict[str, Any]]]:
     """
     Load canonical defaults from bundled SQLite dashboard database.
 
@@ -248,7 +252,9 @@ def migrate_postgresql(
                 if key in existing_keys:
                     continue
 
-                insert_query = sql.SQL("INSERT INTO {table} ({cols}) VALUES ({vals})").format(
+                insert_query = sql.SQL(
+                    "INSERT INTO {table} ({cols}) VALUES ({vals})"
+                ).format(
                     table=sql.Identifier(spec.name),
                     cols=sql.SQL(", ").join(sql.Identifier(c) for c in spec.columns),
                     vals=sql.SQL(", ").join(sql.Placeholder() for _ in spec.columns),
@@ -266,7 +272,9 @@ def migrate_postgresql(
 
         conn.commit()
         conn.close()
-        print(f"✓ Dashboard default configuration backfill complete ({total_inserted} rows inserted)")
+        print(
+            f"✓ Dashboard default configuration backfill complete ({total_inserted} rows inserted)"
+        )
         return True
 
     except Exception as e:

--- a/y_web/migrations/ensure_postgresql_schema.py
+++ b/y_web/migrations/ensure_postgresql_schema.py
@@ -98,23 +98,19 @@ def migrate_dashboard_db(host, port, database, user, password):
         # Check and add pages columns
         if _table_exists(cursor, "pages"):
             if not _column_exists(cursor, "pages", "fetch_images_from_url"):
-                cursor.execute(
-                    """
+                cursor.execute("""
                     ALTER TABLE pages
                     ADD COLUMN fetch_images_from_url BOOLEAN DEFAULT FALSE
-                """
-                )
+                """)
                 print("✓ Added fetch_images_from_url column to pages table")
             else:
                 print("○ fetch_images_from_url column already exists in pages table")
 
             if not _column_exists(cursor, "pages", "fetch_images_timeout"):
-                cursor.execute(
-                    """
+                cursor.execute("""
                     ALTER TABLE pages
                     ADD COLUMN fetch_images_timeout INTEGER DEFAULT 10
-                """
-                )
+                """)
                 print("✓ Added fetch_images_timeout column to pages table")
             else:
                 print("○ fetch_images_timeout column already exists in pages table")
@@ -122,12 +118,10 @@ def migrate_dashboard_db(host, port, database, user, password):
         # Check and add client columns
         if _table_exists(cursor, "client"):
             if not _column_exists(cursor, "client", "initial_agents"):
-                cursor.execute(
-                    """
+                cursor.execute("""
                     ALTER TABLE client
                     ADD COLUMN initial_agents INTEGER DEFAULT 0
-                """
-                )
+                """)
                 print("✓ Added initial_agents column to client table")
             else:
                 print("○ initial_agents column already exists in client table")
@@ -142,12 +136,10 @@ def migrate_dashboard_db(host, port, database, user, password):
                     and char_max_len is not None
                     and char_max_len < 120
                 ):
-                    cursor.execute(
-                        """
+                    cursor.execute("""
                         ALTER TABLE admin_users
                         ALTER COLUMN password TYPE TEXT
-                    """
-                    )
+                    """)
                     print("✓ Widened admin_users.password to TEXT")
                 else:
                     print("○ admin_users.password column already supports long hashes")
@@ -213,8 +205,7 @@ def migrate_server_db(host, port, database, user, password):
 
         # Create image_posts table if it doesn't exist
         if not _table_exists(cursor, "image_posts"):
-            cursor.execute(
-                """
+            cursor.execute("""
                 CREATE TABLE image_posts (
                     id           SERIAL PRIMARY KEY,
                     url          VARCHAR(500) NOT NULL,
@@ -227,8 +218,7 @@ def migrate_server_db(host, port, database, user, password):
                     local_path   VARCHAR(500),
                     high_res_url VARCHAR(500)
                 )
-            """
-            )
+            """)
             print("✓ Created image_posts table")
         else:
             print("○ image_posts table already exists")
@@ -236,23 +226,19 @@ def migrate_server_db(host, port, database, user, password):
         # Check and add websites columns
         if _table_exists(cursor, "websites"):
             if not _column_exists(cursor, "websites", "fetch_images_from_url"):
-                cursor.execute(
-                    """
+                cursor.execute("""
                     ALTER TABLE websites
                     ADD COLUMN fetch_images_from_url BOOLEAN DEFAULT FALSE
-                """
-                )
+                """)
                 print("✓ Added fetch_images_from_url column to websites table")
             else:
                 print("○ fetch_images_from_url column already exists in websites table")
 
             if not _column_exists(cursor, "websites", "fetch_images_timeout"):
-                cursor.execute(
-                    """
+                cursor.execute("""
                     ALTER TABLE websites
                     ADD COLUMN fetch_images_timeout INTEGER DEFAULT 10
-                """
-                )
+                """)
                 print("✓ Added fetch_images_timeout column to websites table")
             else:
                 print("○ fetch_images_timeout column already exists in websites table")
@@ -260,12 +246,10 @@ def migrate_server_db(host, port, database, user, password):
         # Check and add images columns
         if _table_exists(cursor, "images"):
             if not _column_exists(cursor, "images", "remote_article_id"):
-                cursor.execute(
-                    """
+                cursor.execute("""
                     ALTER TABLE images
                     ADD COLUMN remote_article_id INTEGER
-                """
-                )
+                """)
                 print("✓ Added remote_article_id column to images table")
             else:
                 print("○ remote_article_id column already exists in images table")
@@ -273,32 +257,27 @@ def migrate_server_db(host, port, database, user, password):
         # Check and add post.image_post_id column (links to image_posts table)
         if _table_exists(cursor, "post"):
             if not _column_exists(cursor, "post", "image_post_id"):
-                cursor.execute(
-                    """
+                cursor.execute("""
                     ALTER TABLE post
                     ADD COLUMN image_post_id INTEGER REFERENCES image_posts(id) ON DELETE CASCADE
-                """
-                )
+                """)
                 print("✓ Added image_post_id column to post table")
             else:
                 print("○ image_post_id column already exists in post table")
 
             # Ensure post.created_at exists for minute-level wall-clock timestamps.
             if not _column_exists(cursor, "post", "created_at"):
-                cursor.execute(
-                    """
+                cursor.execute("""
                     ALTER TABLE post
                     ADD COLUMN created_at TIMESTAMP
-                """
-                )
+                """)
                 print("✓ Added created_at column to post table")
             else:
                 print("○ created_at column already exists in post table")
 
             # Backfill legacy rows from simulation day/hour when possible.
             if _table_exists(cursor, "rounds"):
-                cursor.execute(
-                    """
+                cursor.execute("""
                     UPDATE post p
                     SET created_at = (
                         date_trunc('day', NOW())
@@ -314,70 +293,55 @@ def migrate_server_db(host, port, database, user, password):
                     FROM rounds r
                     WHERE p.round = r.id
                       AND p.created_at IS NULL
-                """
-                )
+                """)
 
             # Final fallback for unresolved rows.
-            cursor.execute(
-                """
+            cursor.execute("""
                 UPDATE post
                 SET created_at = NOW()
                 WHERE created_at IS NULL
-            """
-            )
+            """)
 
             # Set stable defaults/constraints for future writes.
-            cursor.execute(
-                """
+            cursor.execute("""
                 ALTER TABLE post
                 ALTER COLUMN created_at SET DEFAULT NOW()
-            """
-            )
-            cursor.execute(
-                """
+            """)
+            cursor.execute("""
                 ALTER TABLE post
                 ALTER COLUMN created_at SET NOT NULL
-            """
-            )
+            """)
 
             # Ensure idempotent comment dedupe columns exist.
             if not _column_exists(cursor, "post", "dedupe_key"):
-                cursor.execute(
-                    """
+                cursor.execute("""
                     ALTER TABLE post
                     ADD COLUMN dedupe_key VARCHAR(64)
-                """
-                )
+                """)
                 print("✓ Added dedupe_key column to post table")
             else:
                 print("○ dedupe_key column already exists in post table")
 
             if not _column_exists(cursor, "post", "client_action_id"):
-                cursor.execute(
-                    """
+                cursor.execute("""
                     ALTER TABLE post
                     ADD COLUMN client_action_id VARCHAR(96)
-                """
-                )
+                """)
                 print("✓ Added client_action_id column to post table")
             else:
                 print("○ client_action_id column already exists in post table")
 
             # Indexes for idempotency/deduplication on new comments.
-            cursor.execute(
-                """
+            cursor.execute("""
                 CREATE UNIQUE INDEX IF NOT EXISTS idx_post_comment_action_id_uniq
                 ON post (user_id, client_action_id)
                 WHERE client_action_id IS NOT NULL
-            """
-            )
-            cursor.execute(
-                """
+            """)
+            cursor.execute("""
                 CREATE UNIQUE INDEX IF NOT EXISTS idx_post_comment_dedupe_uniq
                 ON post (user_id, comment_to, round, dedupe_key)
                 WHERE comment_to <> -1 AND dedupe_key IS NOT NULL
-            """
-            )
+            """)
 
         conn.commit()
         conn.close()

--- a/y_web/models.py
+++ b/y_web/models.py
@@ -49,7 +49,6 @@ class User_mgmt(UserMixin, db.Model):
     daily_activity_level = db.Column(db.Integer(), default=1)
     profession = db.Column(db.String(50), default="")
     activity_profile = db.Column(db.String(50), default="Always On")
-    archetype = db.Column(db.String(50), nullable=True, default=None)
 
     posts = db.relationship("Post", backref="author", lazy=True)
     liked = db.relationship("Reactions", backref="liked_by", lazy=True)
@@ -74,6 +73,7 @@ class Post(db.Model):
     news_id = db.Column(db.String(50), db.ForeignKey("articles.id"), default=None)
     image_id = db.Column(db.Integer(), db.ForeignKey("images.id"), default=None)
     image_post_id = db.Column(db.Integer(), db.ForeignKey("image_posts.id"), default=None)
+    # Dedupe controls for idempotent comment creation.
     dedupe_key = db.Column(db.String(64), nullable=True, default=None)
     client_action_id = db.Column(db.String(96), nullable=True, default=None)
     created_at = db.Column(db.DateTime, nullable=False, default=db.func.now())
@@ -133,7 +133,12 @@ class Mentions(db.Model):
 
 
 class ReplyInboxState(db.Model):
-    """Tracks the last seen reply notification for a user."""
+    """
+    Tracks the last seen reply notification for a user.
+
+    This provides Reddit-style "unread" notifications without storing a row per
+    notification: a reply is unread if its Post.id > last_seen_reply_id.
+    """
 
     __bind_key__ = "db_exp"
     __tablename__ = "reply_inbox_state"
@@ -302,7 +307,12 @@ class Images(db.Model):
 
 
 class ImagePosts(db.Model):
-    """Standalone image posts available to experiment users."""
+    """
+    Standalone image posts for agent sharing.
+
+    Stores pre-fetched images from external sources (e.g., Reddit) that agents
+    can select and share. Includes metadata like source, description, and usage tracking.
+    """
 
     __tablename__ = "image_posts"
     __bind_key__ = "db_exp"
@@ -375,35 +385,6 @@ class Post_Toxicity(db.Model):
     flirtation = db.Column(db.REAL, default=0)
 
 
-class Agent_Opinion(db.Model):
-    """
-    Agent opinion tracking for interactions.
-
-    Stores opinions that agents form about topics, posts, and other agents
-    during their interactions in the simulation. The opinion is stored as
-    a float value representing the agent's sentiment or stance.
-
-    Fields:
-        id: Primary key
-        agent_id: ID of the agent forming the opinion
-        tid: Transaction/interaction ID for this opinion event
-        topic_id: ID of the topic being discussed (FK to interests)
-        id_interacted_with: ID of the user/agent being interacted with
-        id_post: ID of the post that triggered this opinion (FK to post)
-        opinion: Numerical opinion value (float) indicating sentiment/stance
-    """
-
-    __bind_key__ = "db_exp"
-    __tablename__ = "agent_opinion"
-    id = db.Column(db.Integer, primary_key=True)
-    agent_id = db.Column(db.Integer, nullable=False)
-    tid = db.Column(db.Integer, nullable=False)
-    topic_id = db.Column(db.Integer, db.ForeignKey("interests.iid"), nullable=False)
-    id_interacted_with = db.Column(db.Integer, nullable=False)
-    id_post = db.Column(db.Integer, db.ForeignKey("post.id"), nullable=False)
-    opinion = db.Column(db.REAL, nullable=False)
-
-
 ############################################################################################################
 
 
@@ -437,6 +418,69 @@ class Admin_users(UserMixin, db.Model):
         return f"admin_{self.id}"
 
 
+class AdminInterviewSession(db.Model):
+    """
+    Stores an admin interview session for a specific experiment + agent.
+
+    Sessions are stored in the dashboard DB so they survive navigation and can be
+    inspected later. Memory is run-scoped and may be missing early in a live run.
+    """
+
+    __bind_key__ = "db_admin"
+    __tablename__ = "admin_interview_sessions"
+
+    id = db.Column(db.Integer, primary_key=True)
+    exp_id = db.Column(db.Integer, nullable=False, index=True)
+    admin_username = db.Column(db.String(50), nullable=False, index=True)
+
+    agent_user_id = db.Column(db.Integer, nullable=False)
+    agent_username = db.Column(db.String(50), nullable=False)
+
+    run_id = db.Column(db.Text, nullable=True, index=True)
+
+    backend_mode = db.Column(db.String(20), nullable=False, default="agent_runtime")
+    llm_model = db.Column(db.String(200), nullable=True)
+    llm_base_url = db.Column(db.String(300), nullable=True)
+
+    persona_snapshot = db.Column(db.Text, nullable=True)
+    interests_snapshot_json = db.Column(db.Text, nullable=True)
+    memory_snapshot_json = db.Column(db.Text, nullable=True)
+
+    created_at = db.Column(db.DateTime, nullable=False, default=db.func.now())
+    updated_at = db.Column(
+        db.DateTime,
+        nullable=False,
+        default=db.func.now(),
+        onupdate=db.func.now(),
+    )
+
+    messages = db.relationship(
+        "AdminInterviewMessage",
+        backref="session",
+        lazy=True,
+        cascade="all, delete-orphan",
+    )
+
+
+class AdminInterviewMessage(db.Model):
+    """Stores one message in an AdminInterviewSession."""
+
+    __bind_key__ = "db_admin"
+    __tablename__ = "admin_interview_messages"
+
+    id = db.Column(db.Integer, primary_key=True)
+    session_id = db.Column(
+        db.Integer,
+        db.ForeignKey("admin_interview_sessions.id"),
+        nullable=False,
+        index=True,
+    )
+    role = db.Column(db.String(12), nullable=False)  # admin | agent | system
+    content = db.Column(db.Text, nullable=False)
+    meta_json = db.Column(db.Text, nullable=True)
+    created_at = db.Column(db.DateTime, nullable=False, default=db.func.now())
+
+
 class Exps(db.Model):
     """
     Experiment configuration and metadata.
@@ -467,6 +511,7 @@ class Exps(db.Model):
     server_pid = db.Column(db.Integer, nullable=True, default=None)
     llm_agents_enabled = db.Column(db.Integer, nullable=False, default=1)
     exp_status = db.Column(db.String(20), nullable=False, default="stopped")
+    # Experiment-wide LLM defaults
     llm_default = db.Column(db.String(100), default="http://127.0.0.1:11434/v1")
     llm_api_key_default = db.Column(db.String(300), default="NULL")
     llm_max_tokens_default = db.Column(db.Integer, default=-1)
@@ -576,6 +621,8 @@ class Population(db.Model):
     id = db.Column(db.Integer, primary_key=True)
     name = db.Column(db.String(50), nullable=False)
     descr = db.Column(db.String(200), nullable=False)
+    # Distinguishes populations intended for microblogging vs forum (Reddit-like) experiments.
+    # Enforced at client creation time.
     username_type = db.Column(db.String(20), nullable=False, default="microblogging")
     size = db.Column(db.Integer)
     llm = db.Column(db.String(50))
@@ -627,7 +674,6 @@ class Agent(db.Model):
     activity_profile = db.Column(
         db.Integer, db.ForeignKey("activity_profiles.id"), nullable=True
     )
-    archetype = db.Column(db.String(50), nullable=True, default=None)
 
 
 class Agent_Population(db.Model):
@@ -760,28 +806,15 @@ class Client(db.Model):
     population_id = db.Column(
         db.Integer, db.ForeignKey("population.id"), nullable=False
     )
+    initial_agents = db.Column(db.Integer, nullable=True, default=None)
     network_type = db.Column(db.String(50), default="")
     crecsys = db.Column(db.String(50))
     frecsys = db.Column(db.String(50))
     pid = db.Column(db.Integer, nullable=True, default=None)
+    # Reply behavior controls
     reply_probability = db.Column(db.REAL, default=0.4)
     max_replies_per_round = db.Column(db.Integer, default=2)
     reply_cooldown_rounds = db.Column(db.Integer, default=2)
-    initial_agents = db.Column(db.Integer, nullable=True, default=None)
-    # Agent archetype percentages
-    archetype_validator = db.Column(db.REAL, default=0.52)
-    archetype_broadcaster = db.Column(db.REAL, default=0.20)
-    archetype_explorer = db.Column(db.REAL, default=0.28)
-    # Transition probabilities (3x3 matrix)
-    trans_val_val = db.Column(db.REAL, default=0.853)
-    trans_val_broad = db.Column(db.REAL, default=0.081)
-    trans_val_expl = db.Column(db.REAL, default=0.066)
-    trans_broad_broad = db.Column(db.REAL, default=0.729)
-    trans_broad_val = db.Column(db.REAL, default=0.195)
-    trans_broad_expl = db.Column(db.REAL, default=0.075)
-    trans_expl_expl = db.Column(db.REAL, default=0.490)
-    trans_expl_val = db.Column(db.REAL, default=0.364)
-    trans_expl_broad = db.Column(db.REAL, default=0.146)
 
 
 class Client_Execution(db.Model):
@@ -800,6 +833,8 @@ class Client_Execution(db.Model):
     expected_duration_rounds = db.Column(db.Integer, default=0)
     last_active_hour = db.Column(db.Integer, default=-1)
     last_active_day = db.Column(db.Integer, default=-1)
+    # Execution stage tracking: "initializing" -> "agents_loaded" -> "running"
+    # Used to detect failed runs during agent loading and restart fresh
     execution_stage = db.Column(db.String(20), default="initializing")
 
 
@@ -1181,41 +1216,19 @@ class WatchdogSettings(db.Model):
     run_interval_minutes = db.Column(
         db.Integer, nullable=False, default=1
     )  # Default 1 minute
-    server_heartbeat_timeout_sec = db.Column(db.Integer, nullable=False, default=300)
-    client_heartbeat_timeout_sec = db.Column(db.Integer, nullable=False, default=300)
-    heartbeat_interval_sec = db.Column(db.Integer, nullable=False, default=60)
-    max_restart_attempts = db.Column(db.Integer, nullable=False, default=3)
-    restart_cooldown_sec = db.Column(db.Integer, nullable=False, default=60)
+    server_heartbeat_timeout_sec = db.Column(
+        db.Integer, nullable=False, default=300
+    )  # Server stale heartbeat timeout
+    client_heartbeat_timeout_sec = db.Column(
+        db.Integer, nullable=False, default=300
+    )  # Client stale heartbeat timeout
+    heartbeat_interval_sec = db.Column(
+        db.Integer, nullable=False, default=60
+    )  # Expected heartbeat write interval
+    max_restart_attempts = db.Column(
+        db.Integer, nullable=False, default=3
+    )  # Max retries per unhealthy incident
+    restart_cooldown_sec = db.Column(
+        db.Integer, nullable=False, default=60
+    )  # Cooldown between restart attempts
     last_run = db.Column(db.DateTime, nullable=True)  # Last time watchdog ran
-
-
-class OpinionGroup(db.Model):
-    """
-    Opinion group definitions for opinion dynamics simulations.
-
-    Defines groups of opinions with a name and value range [lower_bound, upper_bound]
-    where bounds are in the interval [0, 1].
-    """
-
-    __bind_key__ = "db_admin"
-    __tablename__ = "opinion_groups"
-    id = db.Column(db.Integer, primary_key=True)
-    name = db.Column(db.String(100), nullable=False)
-    lower_bound = db.Column(db.Float, nullable=False)
-    upper_bound = db.Column(db.Float, nullable=False)
-
-
-class OpinionDistribution(db.Model):
-    """
-    Opinion distribution configurations for opinion dynamics simulations.
-
-    Stores distribution types (uniform, beta, etc.) and their parameters
-    as a JSON string for flexible configuration of opinion initialization.
-    """
-
-    __bind_key__ = "db_admin"
-    __tablename__ = "opinion_distributions"
-    id = db.Column(db.Integer, primary_key=True)
-    name = db.Column(db.String(100), nullable=False)
-    distribution_type = db.Column(db.String(50), nullable=False)
-    parameters = db.Column(db.Text, nullable=False)  # JSON string

--- a/y_web/models.py
+++ b/y_web/models.py
@@ -72,7 +72,9 @@ class Post(db.Model):
     thread_id = db.Column(db.Integer)
     news_id = db.Column(db.String(50), db.ForeignKey("articles.id"), default=None)
     image_id = db.Column(db.Integer(), db.ForeignKey("images.id"), default=None)
-    image_post_id = db.Column(db.Integer(), db.ForeignKey("image_posts.id"), default=None)
+    image_post_id = db.Column(
+        db.Integer(), db.ForeignKey("image_posts.id"), default=None
+    )
     # Dedupe controls for idempotent comment creation.
     dedupe_key = db.Column(db.String(64), nullable=True, default=None)
     client_action_id = db.Column(db.String(96), nullable=True, default=None)

--- a/y_web/recsys_support/content_recsys.py
+++ b/y_web/recsys_support/content_recsys.py
@@ -6,7 +6,8 @@ the social media feed including reverse chronological, popularity-based,
 follower-based, and random sampling approaches.
 """
 
-from sqlalchemy import case, desc, func as sql_func
+from sqlalchemy import case, desc
+from sqlalchemy import func as sql_func
 from sqlalchemy.sql.expression import func
 
 from y_web import db
@@ -121,8 +122,7 @@ def get_suggested_posts(uid, mode, page=1, per_page=10, follower_ratio=0.6):
         # Reddit-style: sort by net score (likes - dislikes)
         like_count = (
             db.session.query(
-                Reactions.post_id,
-                sql_func.count(Reactions.id).label("likes")
+                Reactions.post_id, sql_func.count(Reactions.id).label("likes")
             )
             .filter(Reactions.type == 1)
             .group_by(Reactions.post_id)
@@ -130,14 +130,15 @@ def get_suggested_posts(uid, mode, page=1, per_page=10, follower_ratio=0.6):
         )
         dislike_count = (
             db.session.query(
-                Reactions.post_id,
-                sql_func.count(Reactions.id).label("dislikes")
+                Reactions.post_id, sql_func.count(Reactions.id).label("dislikes")
             )
             .filter(Reactions.type == -1)
             .group_by(Reactions.post_id)
             .subquery()
         )
-        score_expr = sql_func.coalesce(like_count.c.likes, 0) - sql_func.coalesce(dislike_count.c.dislikes, 0)
+        score_expr = sql_func.coalesce(like_count.c.likes, 0) - sql_func.coalesce(
+            dislike_count.c.dislikes, 0
+        )
         posts = (
             db.session.query(Post)
             .filter(Post.user_id != uid, Post.comment_to == -1)
@@ -156,8 +157,7 @@ def get_suggested_posts(uid, mode, page=1, per_page=10, follower_ratio=0.6):
 
         like_count = (
             db.session.query(
-                Reactions.post_id,
-                sql_func.count(Reactions.id).label("likes")
+                Reactions.post_id, sql_func.count(Reactions.id).label("likes")
             )
             .filter(Reactions.type == 1)
             .group_by(Reactions.post_id)
@@ -165,8 +165,7 @@ def get_suggested_posts(uid, mode, page=1, per_page=10, follower_ratio=0.6):
         )
         dislike_count = (
             db.session.query(
-                Reactions.post_id,
-                sql_func.count(Reactions.id).label("dislikes")
+                Reactions.post_id, sql_func.count(Reactions.id).label("dislikes")
             )
             .filter(Reactions.type == -1)
             .group_by(Reactions.post_id)
@@ -174,14 +173,12 @@ def get_suggested_posts(uid, mode, page=1, per_page=10, follower_ratio=0.6):
         )
 
         # Net score
-        net_score = sql_func.coalesce(like_count.c.likes, 0) - sql_func.coalesce(dislike_count.c.dislikes, 0)
+        net_score = sql_func.coalesce(like_count.c.likes, 0) - sql_func.coalesce(
+            dislike_count.c.dislikes, 0
+        )
 
         # Sign of score: 1 if positive, -1 if negative, 0 if zero
-        sign_expr = case(
-            (net_score > 0, 1),
-            (net_score < 0, -1),
-            else_=0
-        )
+        sign_expr = case((net_score > 0, 1), (net_score < 0, -1), else_=0)
 
         # Logarithmic order: log10(max(abs(score), 1))
         # Using ln(x)/ln(10) for SQLite compatibility
@@ -206,8 +203,7 @@ def get_suggested_posts(uid, mode, page=1, per_page=10, follower_ratio=0.6):
         # Reddit-style: sort by comment count
         comment_count = (
             db.session.query(
-                Post.thread_id,
-                sql_func.count(Post.id).label("comment_count")
+                Post.thread_id, sql_func.count(Post.id).label("comment_count")
             )
             .filter(Post.comment_to != -1)
             .group_by(Post.thread_id)
@@ -217,7 +213,10 @@ def get_suggested_posts(uid, mode, page=1, per_page=10, follower_ratio=0.6):
             db.session.query(Post)
             .filter(Post.user_id != uid, Post.comment_to == -1)
             .outerjoin(comment_count, comment_count.c.thread_id == Post.id)
-            .order_by(sql_func.coalesce(comment_count.c.comment_count, 0).desc(), desc(Post.id))
+            .order_by(
+                sql_func.coalesce(comment_count.c.comment_count, 0).desc(),
+                desc(Post.id),
+            )
             .paginate(page=page, per_page=per_page, error_out=False)
         )
         additional_posts = None

--- a/y_web/reddit/actions.py
+++ b/y_web/reddit/actions.py
@@ -5,42 +5,43 @@ import os
 import re
 import time
 import uuid
-from typing import Tuple, Optional
+from typing import Optional, Tuple
 from urllib.parse import parse_qs, unquote, urlparse
 
 import requests
-
 from flask import current_app, g
 from sqlalchemy import func
 from sqlalchemy.exc import IntegrityError
 
 from y_web import db
+from y_web.experiment_context import (
+    get_db_bind_key_for_exp,
+    register_experiment_database,
+)
+from y_web.llm_annotations import Annotator, ContentAnnotator
 from y_web.models import (
+    Admin_users,
+    Articles,
+    Emotions,
+    Exps,
+    Hashtags,
+    Images,
+    Interests,
+    Mentions,
     Post,
+    Post_emotions,
+    Post_hashtags,
+    Post_Sentiment,
+    Post_topics,
     Reactions,
     Rounds,
-    User_mgmt,
-    Images,
-    Articles,
-    Websites,
-    Emotions,
-    Post_emotions,
-    Hashtags,
-    Post_hashtags,
-    Mentions,
-    Interests,
-    User_interest,
-    Post_topics,
-    Post_Sentiment,
-    Admin_users,
     User_Experiment,
-    Exps,
+    User_interest,
+    User_mgmt,
+    Websites,
 )
-from y_web.utils.text_utils import vader_sentiment, toxicity
 from y_web.utils.article_extractor import extract_article_info
-from y_web.llm_annotations import ContentAnnotator, Annotator
-from y_web.experiment_context import register_experiment_database, get_db_bind_key_for_exp
-
+from y_web.utils.text_utils import toxicity, vader_sentiment
 
 _IMAGE_EXTENSIONS = (".jpg", ".jpeg", ".png", ".gif", ".bmp", ".webp", ".svg")
 _VIDEO_EXTENSIONS = (".mp4",)
@@ -161,7 +162,9 @@ def _remote_looks_like_image(url: str) -> bool:
         resp = requests.head(
             url, headers=headers, timeout=_DOWNLOAD_TIMEOUT, allow_redirects=True
         )
-        content_type = resp.headers.get("Content-Type", "").split(";")[0].strip().lower()
+        content_type = (
+            resp.headers.get("Content-Type", "").split(";")[0].strip().lower()
+        )
         if content_type.startswith("image/"):
             return True
     except Exception:
@@ -175,7 +178,9 @@ def _remote_looks_like_image(url: str) -> bool:
             stream=True,
             allow_redirects=True,
         )
-        content_type = resp.headers.get("Content-Type", "").split(";")[0].strip().lower()
+        content_type = (
+            resp.headers.get("Content-Type", "").split(";")[0].strip().lower()
+        )
         return content_type.startswith("image/")
     except Exception:
         return False
@@ -233,7 +238,9 @@ def _download_image_to_uploads(remote_url: str, exp_id: int) -> Optional[str]:
             return None
 
         # Determine file extension: prefer Content-Type, fall back to URL path.
-        content_type = resp.headers.get("Content-Type", "").split(";")[0].strip().lower()
+        content_type = (
+            resp.headers.get("Content-Type", "").split(";")[0].strip().lower()
+        )
         ext = _CONTENT_TYPE_TO_EXT.get(content_type)
         if not ext:
             path = urlparse(remote_url).path.lower()
@@ -245,7 +252,10 @@ def _download_image_to_uploads(remote_url: str, exp_id: int) -> Optional[str]:
             return None
 
         from y_web.utils.path_utils import get_writable_path
-        out_dir = os.path.join(get_writable_path(), "y_web", "uploads", "reddit", str(exp_id))
+
+        out_dir = os.path.join(
+            get_writable_path(), "y_web", "uploads", "reddit", str(exp_id)
+        )
         os.makedirs(out_dir, exist_ok=True)
 
         filename = f"{uuid.uuid4().hex}{ext}"
@@ -267,13 +277,12 @@ def _ensure_experiment_context(user) -> None:
     It looks up the user's active experiment and sets up the database binding.
     """
     # Check if context is already set up
-    if hasattr(g, 'current_exp_id') and g.current_exp_id is not None:
+    if hasattr(g, "current_exp_id") and g.current_exp_id is not None:
         return
 
     # Find the user's experiment - prefer active experiments (status=1)
     user_exp = (
-        User_Experiment.query
-        .join(Exps, User_Experiment.exp_id == Exps.idexp)
+        User_Experiment.query.join(Exps, User_Experiment.exp_id == Exps.idexp)
         .filter(User_Experiment.user_id == user.id, Exps.status == 1)
         .first()
     )
@@ -307,8 +316,12 @@ def _ensure_experiment_context(user) -> None:
     # Override db_exp bind to point to this experiment's database
     if bind_key in current_app.config["SQLALCHEMY_BINDS"]:
         if not hasattr(g, "original_db_exp_bind"):
-            g.original_db_exp_bind = current_app.config["SQLALCHEMY_BINDS"].get("db_exp")
-        current_app.config["SQLALCHEMY_BINDS"]["db_exp"] = current_app.config["SQLALCHEMY_BINDS"][bind_key]
+            g.original_db_exp_bind = current_app.config["SQLALCHEMY_BINDS"].get(
+                "db_exp"
+            )
+        current_app.config["SQLALCHEMY_BINDS"]["db_exp"] = current_app.config[
+            "SQLALCHEMY_BINDS"
+        ][bind_key]
 
 
 def _get_current_round() -> int:
@@ -707,10 +720,14 @@ def create_post_reddit(user, content: str, url: Optional[str] = None) -> Post:
             if looks_like_media:
                 stored_url = candidate_media_url
                 # Download only remote images to avoid CDN gated rendering issues.
-                if _looks_like_image_url(candidate_media_url) and candidate_media_url.startswith(("http://", "https://")):
+                if _looks_like_image_url(
+                    candidate_media_url
+                ) and candidate_media_url.startswith(("http://", "https://")):
                     exp_id = getattr(g, "current_exp_id", None)
                     if exp_id is not None:
-                        local_path = _download_image_to_uploads(candidate_media_url, exp_id)
+                        local_path = _download_image_to_uploads(
+                            candidate_media_url, exp_id
+                        )
                         if local_path:
                             stored_url = local_path
 
@@ -736,7 +753,9 @@ def create_post_reddit(user, content: str, url: Optional[str] = None) -> Post:
 
                 img = Images.query.filter_by(url=stored_url).first()
                 if img is None:
-                    img = Images(url=stored_url, description=annotation, article_id=None)
+                    img = Images(
+                        url=stored_url, description=annotation, article_id=None
+                    )
                     db.session.add(img)
                     db.session.commit()
                 img_id = img.id
@@ -748,7 +767,9 @@ def create_post_reddit(user, content: str, url: Optional[str] = None) -> Post:
                 else:
                     article_info = extract_article_info(normalized_url)
 
-                    source = (article_info.get("source") or "").strip() or urlparse(normalized_url).netloc
+                    source = (article_info.get("source") or "").strip() or urlparse(
+                        normalized_url
+                    ).netloc
                     website = Websites.query.filter_by(name=source).first()
                     if not website:
                         website = Websites(
@@ -763,8 +784,12 @@ def create_post_reddit(user, content: str, url: Optional[str] = None) -> Post:
                         db.session.add(website)
                         db.session.commit()
 
-                    title = (article_info.get("title") or f"Shared Link: {source}").strip()
-                    summary = (article_info.get("summary") or "User shared article").strip()
+                    title = (
+                        article_info.get("title") or f"Shared Link: {source}"
+                    ).strip()
+                    summary = (
+                        article_info.get("summary") or "User shared article"
+                    ).strip()
 
                     article = Articles(
                         title=title[:200],
@@ -779,9 +804,13 @@ def create_post_reddit(user, content: str, url: Optional[str] = None) -> Post:
 
                     image_url = (article_info.get("image") or "").strip()
                     if image_url and len(image_url) <= 200:
-                        existing_image = Images.query.filter_by(article_id=article.id).first()
+                        existing_image = Images.query.filter_by(
+                            article_id=article.id
+                        ).first()
                         if existing_image is None:
-                            existing_image = Images.query.filter_by(url=image_url).first()
+                            existing_image = Images.query.filter_by(
+                                url=image_url
+                            ).first()
                         if existing_image is None:
                             db.session.add(Images(url=image_url, article_id=article.id))
                             db.session.commit()

--- a/y_web/reddit/hot_rank.py
+++ b/y_web/reddit/hot_rank.py
@@ -21,7 +21,9 @@ def stable_uniform_0_1(*parts: object, salt: str = "forum-hot-longtail-v1") -> f
     return x / float(2**64)
 
 
-def base_hot_score(net_score: int, post_round: int, *, round_decay: float = 12.0) -> float:
+def base_hot_score(
+    net_score: int, post_round: int, *, round_decay: float = 12.0
+) -> float:
     """
     Match the current forum Hot base used in `reddit/service.py`:
       log10(abs(net)+1) + sign(net) * (post_round / round_decay)
@@ -32,7 +34,9 @@ def base_hot_score(net_score: int, post_round: int, *, round_decay: float = 12.0
         sign = -1.0
     else:
         sign = 0.0
-    return math.log10(abs(net_score) + 1.0) + sign * (float(post_round) / float(round_decay))
+    return math.log10(abs(net_score) + 1.0) + sign * (
+        float(post_round) / float(round_decay)
+    )
 
 
 def longtail_boost(

--- a/y_web/reddit/service.py
+++ b/y_web/reddit/service.py
@@ -5,16 +5,17 @@ import json
 import os
 import re
 import sys
-from datetime import datetime, time, timedelta
 from dataclasses import dataclass
+from datetime import datetime, time, timedelta
 from typing import Any, Dict, Iterable, List, Optional, Tuple
-from urllib.parse import parse_qs, urlparse, urlunparse, urlencode
+from urllib.parse import parse_qs, urlencode, urlparse, urlunparse
 from zoneinfo import ZoneInfo
 
 from bs4 import BeautifulSoup
 from sqlalchemy import case, func, or_, text
 from sqlalchemy.exc import OperationalError
 from sqlalchemy.orm import aliased
+
 from y_web import db
 from y_web.data_access import get_elicited_emotions, get_topics
 from y_web.experiment_context import get_current_experiment_id
@@ -22,15 +23,16 @@ from y_web.models import (
     Admin_users,
     Agent,
     Articles,
+    Exps,
     Images,
     Page,
     Post,
     Reactions,
     Rounds,
-    Exps,
     User_mgmt,
     Websites,
 )
+from y_web.reddit.hot_rank import rank_posts_longtail
 from y_web.utils.experiment_clock import (
     DEFAULT_CLOCK_MODE,
     DEFAULT_CLOCK_TIMEZONE,
@@ -46,22 +48,21 @@ from y_web.utils.text_utils import (
     strip_reproduced_article_content,
     strip_tags,
 )
-from y_web.reddit.hot_rank import rank_posts_longtail
 
 
 def clean_reddit_formatting(text: str) -> str:
     """Remove Reddit-specific formatting artifacts from text."""
     if not text:
-        return ''
+        return ""
     normalized = html.unescape(text)
     # Remove "submitted by /u/username" patterns (tolerate extra spaces)
     normalized = re.sub(
-        r'\bsubmitted\s+by\s+/?u/[A-Za-z0-9_-]+\b', '', normalized, flags=re.IGNORECASE
+        r"\bsubmitted\s+by\s+/?u/[A-Za-z0-9_-]+\b", "", normalized, flags=re.IGNORECASE
     )
     # Remove [link] [comments] patterns
-    normalized = re.sub(r'\[link\]|\[comments\]', '', normalized, flags=re.IGNORECASE)
+    normalized = re.sub(r"\[link\]|\[comments\]", "", normalized, flags=re.IGNORECASE)
     # Clean up extra whitespace
-    normalized = re.sub(r'\s+', ' ', normalized)
+    normalized = re.sub(r"\s+", " ", normalized)
     return normalized.strip()
 
 
@@ -134,6 +135,7 @@ def _fetch_and_cache_og_image(article) -> Optional[Dict[str, str]]:
     image = None
     try:
         import requests
+
         from y_web.utils.article_extractor import extract_image
 
         headers = {
@@ -199,10 +201,10 @@ def _strip_article_title_from_body(body: str, article: Optional[ArticlePreview])
 
     # Try matching with "TITLE: " prefix first
     if body_stripped.startswith(f"TITLE: {article_title}"):
-        body_stripped = body_stripped[len(f"TITLE: {article_title}"):].lstrip()
+        body_stripped = body_stripped[len(f"TITLE: {article_title}") :].lstrip()
     # Also try matching without the prefix (in case it was already partially stripped)
     elif body_stripped.startswith(article_title):
-        body_stripped = body_stripped[len(article_title):].lstrip()
+        body_stripped = body_stripped[len(article_title) :].lstrip()
 
     return body_stripped
 
@@ -483,7 +485,9 @@ def _format_display_time(day: str, hour: str) -> str:
     Simulation day/hour is mapped onto the experiment anchor date in the configured timezone.
     """
     clock = _resolve_experiment_clock()
-    timezone_name = str(clock.get("timezone", DEFAULT_CLOCK_TIMEZONE) or DEFAULT_CLOCK_TIMEZONE)
+    timezone_name = str(
+        clock.get("timezone", DEFAULT_CLOCK_TIMEZONE) or DEFAULT_CLOCK_TIMEZONE
+    )
 
     try:
         tz = ZoneInfo(timezone_name)
@@ -521,7 +525,9 @@ def _format_display_time(day: str, hour: str) -> str:
     return dt.strftime("%d-%m-%y %H:%M")
 
 
-def _format_display_time_from_created_at(created_at: Optional[datetime]) -> Optional[str]:
+def _format_display_time_from_created_at(
+    created_at: Optional[datetime],
+) -> Optional[str]:
     """
     Format a persisted post/comment timestamp as calendar datetime.
     """
@@ -529,7 +535,9 @@ def _format_display_time_from_created_at(created_at: Optional[datetime]) -> Opti
         return None
 
     clock = _resolve_experiment_clock()
-    timezone_name = str(clock.get("timezone", DEFAULT_CLOCK_TIMEZONE) or DEFAULT_CLOCK_TIMEZONE)
+    timezone_name = str(
+        clock.get("timezone", DEFAULT_CLOCK_TIMEZONE) or DEFAULT_CLOCK_TIMEZONE
+    )
 
     try:
         tz = ZoneInfo(timezone_name)
@@ -560,12 +568,17 @@ def _resolve_article(article: Optional[Articles]) -> Optional[ArticlePreview]:
     try:
         img = Images.query.filter_by(article_id=article.id).first()
         if img and img.url:
-            image = {"url": img.url, "description": getattr(img, "description", "") or ""}
+            image = {
+                "url": img.url,
+                "description": getattr(img, "description", "") or "",
+            }
     except OperationalError:
         # Handle schema mismatch for older databases
         try:
             row = db.session.execute(
-                text("SELECT url, description FROM images WHERE article_id = :article_id LIMIT 1"),
+                text(
+                    "SELECT url, description FROM images WHERE article_id = :article_id LIMIT 1"
+                ),
                 {"article_id": article.id},
             ).fetchone()
             if row and row[0]:
@@ -629,7 +642,11 @@ def _resolve_image(image_id: Optional[int]) -> Optional[str]:
                 {"image_id": image_id},
             ).fetchone()
             if row and row[0]:
-                return {"url": row[0], "description": "", "media_type": _media_type_from_url(row[0])}
+                return {
+                    "url": row[0],
+                    "description": "",
+                    "media_type": _media_type_from_url(row[0]),
+                }
             return ""
         raise
     if not image:
@@ -638,7 +655,11 @@ def _resolve_image(image_id: Optional[int]) -> Optional[str]:
     description = getattr(image, "description", "") or ""
     if not url:
         return ""
-    return {"url": url, "description": description, "media_type": _media_type_from_url(url)}
+    return {
+        "url": url,
+        "description": description,
+        "media_type": _media_type_from_url(url),
+    }
 
 
 def _media_type_from_url(url: str) -> str:
@@ -684,11 +705,14 @@ def _resolve_image_post(image_post_id: Optional[int]) -> Optional[Dict[str, str]
     try:
         # Use the current experiment's database bind
         from y_web.experiment_context import get_current_experiment_bind
+
         bind_key = get_current_experiment_bind()
         engine = db.get_engine(bind=bind_key)
         with engine.connect() as conn:
             row = conn.execute(
-                text("SELECT url, description, local_path FROM image_posts WHERE id = :id LIMIT 1"),
+                text(
+                    "SELECT url, description, local_path FROM image_posts WHERE id = :id LIMIT 1"
+                ),
                 {"id": image_post_id},
             ).fetchone()
             if row and row[0]:
@@ -697,7 +721,11 @@ def _resolve_image_post(image_post_id: Optional[int]) -> Optional[Dict[str, str]
                     url = f"/static/{row[2]}"
                 else:
                     url = _upgrade_reddit_image_url(row[0])
-                return {"url": url, "description": row[1] or "", "media_type": _media_type_from_url(url)}
+                return {
+                    "url": url,
+                    "description": row[1] or "",
+                    "media_type": _media_type_from_url(url),
+                }
     except Exception:
         pass
     return None
@@ -755,7 +783,9 @@ def _build_comment_payload(
 
         day, hour = _format_round(comment.round)
         comment_created_at = getattr(comment, "created_at", None)
-        display_time = _format_display_time_from_created_at(comment_created_at) or _format_display_time(day, hour)
+        display_time = _format_display_time_from_created_at(
+            comment_created_at
+        ) or _format_display_time(day, hour)
 
         likes, dislikes = reaction_map.get(comment.id, (0, 0))
         viewer_vote = viewer_vote_map.get(comment.id)
@@ -773,7 +803,9 @@ def _build_comment_payload(
                 "day": day,
                 "hour": hour,
                 "display_time": display_time,
-                "created_at": comment_created_at.isoformat() if comment_created_at else None,
+                "created_at": (
+                    comment_created_at.isoformat() if comment_created_at else None
+                ),
                 "likes": likes,
                 "dislikes": dislikes,
                 "is_liked": viewer_vote == "like",
@@ -830,7 +862,9 @@ def _create_feed_post(
 
     day, hour = _format_round(post.round)
     post_created_at = getattr(post, "created_at", None)
-    display_time = _format_display_time_from_created_at(post_created_at) or _format_display_time(day, hour)
+    display_time = _format_display_time_from_created_at(
+        post_created_at
+    ) or _format_display_time(day, hour)
 
     likes, dislikes = reaction_map.get(post.id, (0, 0))
     viewer_vote = viewer_vote_map.get(post.id)
@@ -839,8 +873,13 @@ def _create_feed_post(
 
     title, body = process_reddit_post(post.tweet)
 
-    article_row = Articles.query.filter_by(id=post.news_id).first() if post.news_id else None
-    article_needs_enrichment = bool(article_row and _article_summary_needs_enrichment(getattr(article_row, "summary", None)))
+    article_row = (
+        Articles.query.filter_by(id=post.news_id).first() if post.news_id else None
+    )
+    article_needs_enrichment = bool(
+        article_row
+        and _article_summary_needs_enrichment(getattr(article_row, "summary", None))
+    )
     article = _resolve_article(article_row)
 
     # Strip article title from body if it appears at the beginning (avoids duplication)
@@ -859,11 +898,19 @@ def _create_feed_post(
     exp_id = get_current_experiment_id()
     processed_body = augment_text(body, exp_id) if body else ""
 
-    image_row = Images.query.filter_by(id=post.image_id).first() if getattr(post, "image_id", None) else None
-    image_needs_enrichment = bool(image_row and not (getattr(image_row, "description", "") or "").strip())
+    image_row = (
+        Images.query.filter_by(id=post.image_id).first()
+        if getattr(post, "image_id", None)
+        else None
+    )
+    image_needs_enrichment = bool(
+        image_row and not (getattr(image_row, "description", "") or "").strip()
+    )
 
     # Check image_post_id first (new standalone images), then fall back to image_id (old format)
-    image = _resolve_image_post(getattr(post, 'image_post_id', None)) or _resolve_image(post.image_id)
+    image = _resolve_image_post(getattr(post, "image_post_id", None)) or _resolve_image(
+        post.image_id
+    )
     if not image and article and article.image:
         image = article.image
     shared_from = _shared_from(post)
@@ -951,7 +998,9 @@ def build_user_feed_posts(
 ) -> Tuple[List[FeedPost], bool]:
     from y_web.recsys_support import get_suggested_posts
 
-    sys.stderr.write(f"[DEBUG] build_user_feed_posts called with feed_type={feed_type}, target_user_id={target_user_id}\n")
+    sys.stderr.write(
+        f"[DEBUG] build_user_feed_posts called with feed_type={feed_type}, target_user_id={target_user_id}\n"
+    )
     sys.stderr.flush()
 
     recsys_posts, additional = get_suggested_posts(
@@ -984,12 +1033,20 @@ def build_user_feed_posts(
     if feed_type == "top":
         # Sort by score (likes - dislikes) descending
         reaction_map = _fetch_reaction_map([p.id for p in normalized])
-        normalized.sort(key=lambda p: (reaction_map.get(p.id, (0, 0))[0] - reaction_map.get(p.id, (0, 0))[1], p.id), reverse=True)
+        normalized.sort(
+            key=lambda p: (
+                reaction_map.get(p.id, (0, 0))[0] - reaction_map.get(p.id, (0, 0))[1],
+                p.id,
+            ),
+            reverse=True,
+        )
     elif feed_type == "most_commented":
         # Sort by comment count descending
         thread_ids = [p.thread_id or p.id for p in normalized]
         comment_map = _fetch_comment_map(thread_ids)
-        normalized.sort(key=lambda p: (comment_map.get(p.thread_id or p.id, 0), p.id), reverse=True)
+        normalized.sort(
+            key=lambda p: (comment_map.get(p.thread_id or p.id, 0), p.id), reverse=True
+        )
     else:
         # Default: Sort by post ID descending (newest first)
         normalized.sort(key=lambda p: p.id, reverse=True)
@@ -1018,7 +1075,9 @@ def fetch_feed_page(
     search_query: str = "",
     exclude_user_ids: Optional[List[int]] = None,
 ) -> FeedPage:
-    sys.stderr.write(f"[DEBUG] fetch_feed_page called with feed_type={feed_type}, page={page}, per_page={per_page}\n")
+    sys.stderr.write(
+        f"[DEBUG] fetch_feed_page called with feed_type={feed_type}, page={page}, per_page={per_page}\n"
+    )
     sys.stderr.flush()
     base_query = db.session.query(Post).filter(Post.comment_to == -1).options()
 
@@ -1074,7 +1133,9 @@ def fetch_feed_page(
         # Hot score: logarithmic order + sign * time_boost
         hot_score = log_order + sign_expr * (Post.round / round_decay)
 
-        longtail_enabled = os.getenv("YSOCIAL_FORUM_HOT_LONGTAIL", "1").strip().lower() not in {
+        longtail_enabled = os.getenv(
+            "YSOCIAL_FORUM_HOT_LONGTAIL", "1"
+        ).strip().lower() not in {
             "0",
             "false",
             "off",
@@ -1108,9 +1169,7 @@ def fetch_feed_page(
 
             post_ids = [p.id for p in candidates]
             reaction_map = _fetch_reaction_map(post_ids)
-            current_round_id = (
-                db.session.query(func.max(Rounds.id)).scalar() or 0
-            )
+            current_round_id = db.session.query(func.max(Rounds.id)).scalar() or 0
 
             ranked = rank_posts_longtail(
                 candidates,
@@ -1142,9 +1201,18 @@ def fetch_feed_page(
 
     pagination = base_query.paginate(page=page, per_page=per_page, error_out=False)
 
-    sys.stderr.write(f"[DEBUG] Found {len(pagination.items)} posts out of {pagination.total} total, feed_type={feed_type}\n")
+    sys.stderr.write(
+        f"[DEBUG] Found {len(pagination.items)} posts out of {pagination.total} total, feed_type={feed_type}\n"
+    )
     if pagination.items:
-        post_ids = [item.id if isinstance(item, Post) else item[0].id if isinstance(item, tuple) else str(item) for item in pagination.items[:10]]
+        post_ids = [
+            (
+                item.id
+                if isinstance(item, Post)
+                else item[0].id if isinstance(item, tuple) else str(item)
+            )
+            for item in pagination.items[:10]
+        ]
         sys.stderr.write(f"[DEBUG] First 10 post IDs returned: {post_ids}\n")
     sys.stderr.flush()
 
@@ -1168,12 +1236,17 @@ def _post_with_aggregates(
     profile_pic = _get_profile_pic(author) if author else ""
     day, hour = _format_round(post.round)
     post_created_at = getattr(post, "created_at", None)
-    display_time = _format_display_time_from_created_at(post_created_at) or _format_display_time(day, hour)
+    display_time = _format_display_time_from_created_at(
+        post_created_at
+    ) or _format_display_time(day, hour)
 
     title, body = process_reddit_post(post.tweet)
-    article_row = Articles.query.filter_by(id=post.news_id).first() if post.news_id else None
+    article_row = (
+        Articles.query.filter_by(id=post.news_id).first() if post.news_id else None
+    )
     article_needs_enrichment = bool(
-        article_row and _article_summary_needs_enrichment(getattr(article_row, "summary", None))
+        article_row
+        and _article_summary_needs_enrichment(getattr(article_row, "summary", None))
     )
     article = _resolve_article(article_row)
 
@@ -1193,11 +1266,19 @@ def _post_with_aggregates(
     exp_id = get_current_experiment_id()
     processed_body = augment_text(body, exp_id) if body else ""
 
-    image_row = Images.query.filter_by(id=post.image_id).first() if getattr(post, "image_id", None) else None
-    image_needs_enrichment = bool(image_row and not (getattr(image_row, "description", "") or "").strip())
+    image_row = (
+        Images.query.filter_by(id=post.image_id).first()
+        if getattr(post, "image_id", None)
+        else None
+    )
+    image_needs_enrichment = bool(
+        image_row and not (getattr(image_row, "description", "") or "").strip()
+    )
 
     # Check image_post_id first (new standalone images), then fall back to image_id (old format)
-    image_obj = _resolve_image_post(getattr(post, 'image_post_id', None)) or _resolve_image(post.image_id)
+    image_obj = _resolve_image_post(
+        getattr(post, "image_post_id", None)
+    ) or _resolve_image(post.image_id)
     if not image_obj and article and article.image:
         image_obj = article.image
 

--- a/y_web/routes_admin/clients_routes.py
+++ b/y_web/routes_admin/clients_routes.py
@@ -59,11 +59,11 @@ from y_web.utils.experiment_clock import (
     validate_timezone,
 )
 from y_web.utils.experiment_helpers import get_experiment_uid_from_db_name
-from y_web.utils.miscellanea import check_privileges, llm_backend_status, ollama_status
 from y_web.utils.memory_run_id import (
     build_memory_run_seed,
     normalize_memory_run_id,
 )
+from y_web.utils.miscellanea import check_privileges, llm_backend_status, ollama_status
 from y_web.utils.path_utils import get_resource_path, get_writable_path
 
 clientsr = Blueprint("clientsr", __name__)
@@ -424,19 +424,28 @@ def create_client():
     if memory_enabled_raw is None:
         memory_enabled = True
     else:
-        memory_enabled = str(memory_enabled_raw).strip().lower() in {"1", "true", "on", "yes"}
+        memory_enabled = str(memory_enabled_raw).strip().lower() in {
+            "1",
+            "true",
+            "on",
+            "yes",
+        }
 
     memory_pair_limit = request.form.get("memory_pair_limit", 5)
     memory_prompt_max_chars = request.form.get(
         "memory_prompt_max_chars", DEFAULT_MEMORY_PROMPT_MAX_CHARS
     )
     memory_social_decay_lambda = request.form.get("memory_social_decay_lambda", 0.05)
-    memory_social_corruption_rate = request.form.get("memory_social_corruption_rate", 0.02)
+    memory_social_corruption_rate = request.form.get(
+        "memory_social_corruption_rate", 0.02
+    )
     memory_social_resummarize_every_events = request.form.get(
         "memory_social_resummarize_every_events", 4
     )
     memory_thread_decay_lambda = request.form.get("memory_thread_decay_lambda", 0.03)
-    memory_thread_corruption_rate = request.form.get("memory_thread_corruption_rate", 0.01)
+    memory_thread_corruption_rate = request.form.get(
+        "memory_thread_corruption_rate", 0.01
+    )
     memory_thread_resummarize_every_events = request.form.get(
         "memory_thread_resummarize_every_events", 4
     )
@@ -450,9 +459,12 @@ def create_client():
     if memory_semantic_enabled_raw is None:
         memory_semantic_enabled = True
     else:
-        memory_semantic_enabled = (
-            str(memory_semantic_enabled_raw).strip().lower() in {"1", "true", "on", "yes"}
-        )
+        memory_semantic_enabled = str(memory_semantic_enabled_raw).strip().lower() in {
+            "1",
+            "true",
+            "on",
+            "yes",
+        }
     memory_search_k = request.form.get("memory_search_k", 8)
     memory_search_max_chars = request.form.get(
         "memory_search_max_chars", DEFAULT_MEMORY_SEARCH_MAX_CHARS
@@ -490,9 +502,12 @@ def create_client():
     if memory_embedding_async_raw is None:
         memory_embedding_async = True
     else:
-        memory_embedding_async = (
-            str(memory_embedding_async_raw).strip().lower() in {"1", "true", "on", "yes"}
-        )
+        memory_embedding_async = str(memory_embedding_async_raw).strip().lower() in {
+            "1",
+            "true",
+            "on",
+            "yes",
+        }
     memory_importance_mode = request.form.get(
         "memory_importance_mode", "heuristic_then_batch_llm"
     )
@@ -639,18 +654,26 @@ def create_client():
         errors.append("Memory Thread Corruption Rate must be a valid number")
 
     try:
-        memory_social_resummarize_every_events = int(memory_social_resummarize_every_events)
+        memory_social_resummarize_every_events = int(
+            memory_social_resummarize_every_events
+        )
         if memory_social_resummarize_every_events < 1:
             errors.append("Memory Social Resummarize Every (events) must be at least 1")
     except (ValueError, TypeError):
-        errors.append("Memory Social Resummarize Every (events) must be a valid integer")
+        errors.append(
+            "Memory Social Resummarize Every (events) must be a valid integer"
+        )
 
     try:
-        memory_thread_resummarize_every_events = int(memory_thread_resummarize_every_events)
+        memory_thread_resummarize_every_events = int(
+            memory_thread_resummarize_every_events
+        )
         if memory_thread_resummarize_every_events < 1:
             errors.append("Memory Thread Resummarize Every (events) must be at least 1")
     except (ValueError, TypeError):
-        errors.append("Memory Thread Resummarize Every (events) must be a valid integer")
+        errors.append(
+            "Memory Thread Resummarize Every (events) must be a valid integer"
+        )
 
     try:
         memory_evidence_tail_max = int(memory_evidence_tail_max)
@@ -761,9 +784,7 @@ def create_client():
         )
     ):
         tiers_total = (
-            memory_tier_a_max_chars
-            + memory_tier_b_max_chars
-            + memory_tier_c_max_chars
+            memory_tier_a_max_chars + memory_tier_b_max_chars + memory_tier_c_max_chars
         )
         if tiers_total > memory_total_max_chars:
             errors.append(
@@ -795,7 +816,9 @@ def create_client():
         errors.append("Memory Reflection Min Events must be a valid integer")
 
     try:
-        memory_reflection_trigger_importance_sum = float(memory_reflection_trigger_importance_sum)
+        memory_reflection_trigger_importance_sum = float(
+            memory_reflection_trigger_importance_sum
+        )
         if memory_reflection_trigger_importance_sum < 0:
             errors.append("Memory Reflection Trigger Sum must be >= 0")
     except (ValueError, TypeError):
@@ -1059,9 +1082,7 @@ def create_client():
         f"{BASE_DIR}{os.sep}y_web{os.sep}experiments{os.sep}{uid}{os.sep}"
         f"client_{name}-{population.name}.json"
     )
-    experiment_config_path = (
-        f"{BASE_DIR}{os.sep}y_web{os.sep}experiments{os.sep}{uid}{os.sep}config_server.json"
-    )
+    experiment_config_path = f"{BASE_DIR}{os.sep}y_web{os.sep}experiments{os.sep}{uid}{os.sep}config_server.json"
 
     resolved_clock = {
         "mode": clock_mode,
@@ -1119,7 +1140,9 @@ def create_client():
                             existing_client_config["simulation"], resolved_clock
                         )
                         with open(client_path, "w") as existing_client_file:
-                            json.dump(existing_client_config, existing_client_file, indent=4)
+                            json.dump(
+                                existing_client_config, existing_client_file, indent=4
+                            )
                         clock_sync_applied = True
                 except Exception:
                     continue
@@ -1162,7 +1185,7 @@ def create_client():
         },
         "simulation": {
             "name": name,
-            "population": population.name.replace(' ', ''),
+            "population": population.name.replace(" ", ""),
             "client": "YClientWeb",
             "days": int(days),
             "slots": 24,
@@ -1177,14 +1200,30 @@ def create_client():
                 "post": float(post),
                 "image": float(image) if image is not None else 0,
                 # Enforce action restrictions per platform type
-                "news": 0.0 if exp.platform_type == "forum" else (float(news) if news is not None else 0),
+                "news": (
+                    0.0
+                    if exp.platform_type == "forum"
+                    else (float(news) if news is not None else 0)
+                ),
                 "comment": float(comment) if comment is not None else 0,
                 "read": float(read) if read is not None else 0,
-                "share": 0.0 if exp.platform_type == "forum" else (float(share) if share is not None else 0),
+                "share": (
+                    0.0
+                    if exp.platform_type == "forum"
+                    else (float(share) if share is not None else 0)
+                ),
                 "search": float(search) if search is not None else 0,
                 "cast": float(vote) if vote is not None else 0,
-                "share_link": 0.0 if exp.platform_type == "microblogging" else (float(share_link) if share_link is not None else 0),
-                "share_image": 0.0 if exp.platform_type == "microblogging" else (float(share_image) if share_image is not None else 0),
+                "share_link": (
+                    0.0
+                    if exp.platform_type == "microblogging"
+                    else (float(share_link) if share_link is not None else 0)
+                ),
+                "share_image": (
+                    0.0
+                    if exp.platform_type == "microblogging"
+                    else (float(share_image) if share_image is not None else 0)
+                ),
             },
             "emotion_annotation": emotion_annotation,
         },
@@ -1263,12 +1302,18 @@ def create_client():
             "memory_prompt_max_chars": int(memory_prompt_max_chars),
             "memory_social_decay_lambda": float(memory_social_decay_lambda),
             "memory_social_corruption_rate": float(memory_social_corruption_rate),
-            "memory_social_resummarize_every_events": int(memory_social_resummarize_every_events),
+            "memory_social_resummarize_every_events": int(
+                memory_social_resummarize_every_events
+            ),
             "memory_thread_decay_lambda": float(memory_thread_decay_lambda),
             "memory_thread_corruption_rate": float(memory_thread_corruption_rate),
-            "memory_thread_resummarize_every_events": int(memory_thread_resummarize_every_events),
+            "memory_thread_resummarize_every_events": int(
+                memory_thread_resummarize_every_events
+            ),
             "memory_evidence_tail_max": int(memory_evidence_tail_max),
-            "memory_digest_update_cadence_rounds": int(memory_digest_update_cadence_rounds),
+            "memory_digest_update_cadence_rounds": int(
+                memory_digest_update_cadence_rounds
+            ),
             "memory_digest_events_limit": int(memory_digest_events_limit),
             "memory_cold_start_window": int(memory_cold_start_window),
             "memory_semantic_enabled": bool(memory_semantic_enabled),
@@ -1279,11 +1324,17 @@ def create_client():
             "memory_tier_b_max_chars": int(memory_tier_b_max_chars),
             "memory_tier_c_max_chars": int(memory_tier_c_max_chars),
             "memory_total_max_chars": int(memory_total_max_chars),
-            "memory_tier_c_uncertainty_threshold": float(memory_tier_c_uncertainty_threshold),
+            "memory_tier_c_uncertainty_threshold": float(
+                memory_tier_c_uncertainty_threshold
+            ),
             "memory_reflection_cadence_rounds": int(memory_reflection_cadence_rounds),
             "memory_reflection_min_events": int(memory_reflection_min_events),
-            "memory_reflection_trigger_importance_sum": float(memory_reflection_trigger_importance_sum),
-            "memory_reflection_max_items_per_run": int(memory_reflection_max_items_per_run),
+            "memory_reflection_trigger_importance_sum": float(
+                memory_reflection_trigger_importance_sum
+            ),
+            "memory_reflection_max_items_per_run": int(
+                memory_reflection_max_items_per_run
+            ),
             "memory_embedding_model": str(memory_embedding_model).strip(),
             "memory_embedding_async": bool(memory_embedding_async),
             "memory_importance_mode": str(memory_importance_mode).strip(),
@@ -1701,9 +1752,9 @@ def delete_client(uid):
 
     # Delete association of population and experiment if no other client uses it.
     # Important: only delete for this experiment, not globally for the population.
-    remaining_clients = (
-        Client.query.filter_by(id_exp=exp_id, population_id=pop_id).count()
-    )
+    remaining_clients = Client.query.filter_by(
+        id_exp=exp_id, population_id=pop_id
+    ).count()
     if remaining_clients == 0:
         Population_Experiment.query.filter_by(
             id_population=pop_id, id_exp=exp_id
@@ -1831,6 +1882,7 @@ def get_progress(client_id):
     Also includes process health status and error detection.
     """
     import psutil
+
     from y_web.utils.path_utils import get_writable_path
 
     # get client and experiment info for log path
@@ -1845,7 +1897,9 @@ def get_progress(client_id):
     if client and client.pid:
         try:
             process = psutil.Process(client.pid)
-            process_alive = process.is_running() and process.status() != psutil.STATUS_ZOMBIE
+            process_alive = (
+                process.is_running() and process.status() != psutil.STATUS_ZOMBIE
+            )
         except (psutil.NoSuchProcess, psutil.AccessDenied):
             process_alive = False
 
@@ -1858,7 +1912,9 @@ def get_progress(client_id):
             # Extract experiment folder using helper function
             exp_folder = get_experiment_uid_from_db_name(exp.db_name)
             if exp_folder:
-                log_dir = os.path.join(writable_base, "y_web", "experiments", exp_folder)
+                log_dir = os.path.join(
+                    writable_base, "y_web", "experiments", exp_folder
+                )
             else:
                 log_dir = None
             if not log_dir:
@@ -1874,7 +1930,9 @@ def get_progress(client_id):
                             # Get the error message (next line after ERROR)
                             idx = lines.index(line)
                             if idx + 1 < len(lines):
-                                last_error = lines[idx].strip() + " " + lines[idx + 1].strip()
+                                last_error = (
+                                    lines[idx].strip() + " " + lines[idx + 1].strip()
+                                )
                             else:
                                 last_error = line.strip()
                             break
@@ -1882,13 +1940,15 @@ def get_progress(client_id):
             pass  # Ignore log reading errors
 
     if client_execution is None:
-        return json.dumps({
-            "progress": 0,
-            "infinite": False,
-            "process_alive": process_alive,
-            "has_error": has_error,
-            "last_error": last_error,
-        })
+        return json.dumps(
+            {
+                "progress": 0,
+                "infinite": False,
+                "process_alive": process_alive,
+                "has_error": has_error,
+                "last_error": last_error,
+            }
+        )
 
     # Check if this is an infinite client (expected_duration_rounds = -1)
     if client_execution.expected_duration_rounds == -1:
@@ -1923,13 +1983,15 @@ def get_progress(client_id):
     else:
         progress = 0
 
-    return json.dumps({
-        "progress": progress,
-        "infinite": False,
-        "process_alive": process_alive,
-        "has_error": has_error,
-        "last_error": last_error,
-    })
+    return json.dumps(
+        {
+            "progress": progress,
+            "infinite": False,
+            "process_alive": process_alive,
+            "has_error": has_error,
+            "last_error": last_error,
+        }
+    )
 
 
 @clientsr.route("/admin/set_network/<int:uid>", methods=["POST"])

--- a/y_web/routes_admin/clients_routes.py
+++ b/y_web/routes_admin/clients_routes.py
@@ -8,28 +8,23 @@ client execution control (start/pause/resume/terminate).
 
 import json
 import os
-import random
 import shutil
-import sys
 import traceback
 
 import faker
 import networkx as nx
-import numpy as np
 from flask import (
     Blueprint,
     flash,
     redirect,
     render_template,
     request,
-    url_for,
 )
 from flask_login import current_user, login_required
 
 from y_web import db
 from y_web.models import (
     ActivityProfile,
-    AgeClass,
     Agent,
     Agent_Population,
     Agent_Profile,
@@ -39,8 +34,6 @@ from y_web.models import (
     Exp_Topic,
     Exps,
     Follow_Recsys,
-    OpinionDistribution,
-    OpinionGroup,
     Page,
     Page_Population,
     Population,
@@ -57,13 +50,49 @@ from y_web.utils import (
     terminate_client,
 )
 from y_web.utils.desktop_file_handler import send_file_desktop
+from y_web.utils.experiment_clock import (
+    apply_clock_to_client_simulation,
+    current_local_time,
+    ensure_experiment_clock,
+    validate_clock_mode,
+    validate_feed_refresh,
+    validate_timezone,
+)
+from y_web.utils.experiment_helpers import get_experiment_uid_from_db_name
 from y_web.utils.miscellanea import check_privileges, llm_backend_status, ollama_status
-from y_web.utils.path_utils import get_resource_path
+from y_web.utils.memory_run_id import (
+    build_memory_run_seed,
+    normalize_memory_run_id,
+)
+from y_web.utils.path_utils import get_resource_path, get_writable_path
 
 clientsr = Blueprint("clientsr", __name__)
 
-# Constants for opinion distribution sampling
-DISTRIBUTION_SCALE_FACTOR = 10.0  # Scale factor for gamma/lognormal distributions
+# Defaults for context-heavy prompts.
+DEFAULT_OLLAMA_MAX_TOKENS = 768
+DEFAULT_MAX_THREAD_CONTEXT_CHARS = 3200
+MAX_MAX_THREAD_CONTEXT_CHARS = 4800
+DEFAULT_MEMORY_PROMPT_MAX_CHARS = 1600
+MAX_MEMORY_PROMPT_MAX_CHARS = 3200
+DEFAULT_MEMORY_SEARCH_MAX_CHARS = 900
+MAX_MEMORY_SEARCH_MAX_CHARS = 1800
+DEFAULT_MEMORY_TIER_A_MAX_CHARS = 350
+MAX_MEMORY_TIER_A_MAX_CHARS = 2000
+DEFAULT_MEMORY_TIER_B_MAX_CHARS = 900
+DEFAULT_MEMORY_TIER_C_MAX_CHARS = 900
+MAX_MEMORY_TIER_BC_MAX_CHARS = 3200
+DEFAULT_MEMORY_TOTAL_MAX_CHARS = 2200
+MAX_MEMORY_TOTAL_MAX_CHARS = 5000
+
+
+def _normalize_llm_max_tokens(raw_value):
+    try:
+        parsed = int(raw_value)
+    except (TypeError, ValueError):
+        return DEFAULT_OLLAMA_MAX_TOKENS
+    if parsed <= 0:
+        return DEFAULT_OLLAMA_MAX_TOKENS
+    return parsed
 
 
 @clientsr.route("/admin/reset_client/<int:uid>")
@@ -78,13 +107,27 @@ def reset_client(uid):
 
     # delete experiment json files
     client = Client.query.filter_by(id=uid).first()
+    if not client:
+        flash("Client not found", "error")
+        return redirect(request.referrer or "/admin/experiments")
+
     exp = Exps.query.filter_by(idexp=client.id_exp).first()
+    if not exp:
+        flash("Experiment not found", "error")
+        return redirect(request.referrer or "/admin/experiments")
+
+    # Extract experiment folder using helper function
+    exp_folder = get_experiment_uid_from_db_name(exp.db_name)
+    if not exp_folder:
+        flash("Invalid experiment database configuration", "error")
+        return redirect(request.referrer or "/admin/experiments")
+
     population = Population.query.filter_by(id=client.population_id).first()
-    path = f"{BASE_DIR}{os.sep}y_web{os.sep}experiments{os.sep}{exp.db_name.split(os.sep)[1]}{os.sep}{population.name}.json"
+    path = f"{BASE_DIR}{os.sep}y_web{os.sep}experiments{os.sep}{exp_folder}{os.sep}{population.name.replace(' ', '')}.json"
     if os.path.exists(path):
         os.remove(path)
 
-    path = f"{BASE_DIR}{os.sep}y_web{os.sep}experiments{os.sep}{exp.db_name.split(os.sep)[1]}{os.sep}prompts.json"
+    path = f"{BASE_DIR}{os.sep}y_web{os.sep}experiments{os.sep}{exp_folder}{os.sep}prompts.json"
     if os.path.exists(path):
         os.remove(path)
 
@@ -93,7 +136,7 @@ def reset_client(uid):
         prompts_src = get_resource_path(os.path.join("data_schema", "prompts.json"))
         shutil.copy(
             prompts_src,
-            f"{BASE_DIR}{os.sep}y_web{os.sep}experiments{os.sep}{exp.db_name.split(os.sep)[1]}{os.sep}prompts.json",
+            f"{BASE_DIR}{os.sep}y_web{os.sep}experiments{os.sep}{exp_folder}{os.sep}prompts.json",
         )
     elif exp.platform_type == "forum":
         prompts_src = get_resource_path(
@@ -101,7 +144,7 @@ def reset_client(uid):
         )
         shutil.copy(
             prompts_src,
-            f"{BASE_DIR}{os.sep}y_web{os.sep}experiments{os.sep}{exp.db_name.split(os.sep)[1]}{os.sep}prompts.json",
+            f"{BASE_DIR}{os.sep}y_web{os.sep}experiments{os.sep}{exp_folder}{os.sep}prompts.json",
         )
     else:
         raise Exception(f"unsupported platform: {exp.platform_type}")
@@ -266,6 +309,15 @@ def clients(idexp):
         else Population.query.all()
     )
 
+    # Only allow populations compatible with this experiment's platform type.
+    # Default to microblogging for legacy populations without username_type.
+    pops = [
+        p
+        for p in pops
+        if (getattr(p, "username_type", "microblogging") or "microblogging")
+        == exp.platform_type
+    ]
+
     crecsys = Content_Recsys.query.all()
     frecsys = Follow_Recsys.query.all()
 
@@ -274,6 +326,39 @@ def clients(idexp):
         exp.llm_agents_enabled if hasattr(exp, "llm_agents_enabled") else True
     )
 
+    # Get experiment-wide LLM defaults
+    exp_llm_defaults = {
+        "llm": getattr(exp, "llm_default", None) or "http://127.0.0.1:11434/v1",
+        "llm_api_key": getattr(exp, "llm_api_key_default", None) or "NULL",
+        "llm_max_tokens": _normalize_llm_max_tokens(
+            getattr(exp, "llm_max_tokens_default", None)
+        ),
+        "llm_temperature": getattr(exp, "llm_temperature_default", None) or 1.5,
+        "llm_v": getattr(exp, "llm_v_default", None) or "http://127.0.0.1:11434/v1",
+        "llm_v_api_key": getattr(exp, "llm_v_api_key_default", None) or "NULL",
+        "llm_v_max_tokens": getattr(exp, "llm_v_max_tokens_default", None) or 300,
+        "llm_v_temperature": getattr(exp, "llm_v_temperature_default", None) or 0.5,
+    }
+
+    experiment_clock = {}
+    try:
+        exp_uid = get_experiment_uid_from_db_name(exp.db_name)
+        if exp_uid:
+            base_dir = get_writable_path()
+            config_path = os.path.join(
+                base_dir,
+                "y_web",
+                "experiments",
+                exp_uid,
+                "config_server.json",
+            )
+            if os.path.exists(config_path):
+                with open(config_path, "r") as config_file:
+                    config_payload = json.load(config_file)
+                experiment_clock = ensure_experiment_clock(config_payload)
+    except Exception:
+        experiment_clock = {}
+
     return render_template(
         "admin/clients.html",
         experiment=exp,
@@ -281,6 +366,8 @@ def clients(idexp):
         crecsys=crecsys,
         frecsys=frecsys,
         llm_agents_enabled=llm_agents_enabled,
+        exp_llm_defaults=exp_llm_defaults,
+        experiment_clock=experiment_clock,
     )
 
 
@@ -294,6 +381,7 @@ def create_client():
     descr = request.form.get("descr")
     exp_id = request.form.get("id_exp")
     population_id = request.form.get("population_id")
+    initial_agents = request.form.get("initial_agents")
     days = request.form.get("days")
     percentage_new_agents_iteration = request.form.get(
         "percentage_new_agents_iteration"
@@ -302,6 +390,9 @@ def create_client():
         "percentage_removed_agents_iteration"
     )
     max_length_thread_reading = request.form.get("max_length_thread_reading")
+    max_thread_context_chars = request.form.get(
+        "max_thread_context_chars", DEFAULT_MAX_THREAD_CONTEXT_CHARS
+    )
     reading_from_follower_ratio = request.form.get("reading_from_follower_ratio")
     probability_of_daily_follow = request.form.get("probability_of_daily_follow")
     probability_of_secondary_follow = request.form.get(
@@ -318,18 +409,112 @@ def create_client():
     search = request.form.get("search")
     vote = request.form.get("vote")
     share_link = request.form.get("share_link")
+    share_image = request.form.get("share_image")
+    clock_mode = request.form.get("clock_mode")
+    clock_timezone = request.form.get("clock_timezone")
+    clock_feed_refresh = request.form.get("clock_feed_refresh", "hourly")
+
+    # Reply behavior controls (guardrails)
+    max_replies_per_round = request.form.get("max_replies_per_round", 2)
+    reply_cooldown_rounds = request.form.get("reply_cooldown_rounds", 2)
+
+    # Run-scoped agent memory controls (hybrid storage + LLM-on-write + decay)
+    # Checkbox fields are absent when unchecked, so treat missing as the feature default (enabled).
+    memory_enabled_raw = request.form.get("memory_enabled")
+    if memory_enabled_raw is None:
+        memory_enabled = True
+    else:
+        memory_enabled = str(memory_enabled_raw).strip().lower() in {"1", "true", "on", "yes"}
+
+    memory_pair_limit = request.form.get("memory_pair_limit", 5)
+    memory_prompt_max_chars = request.form.get(
+        "memory_prompt_max_chars", DEFAULT_MEMORY_PROMPT_MAX_CHARS
+    )
+    memory_social_decay_lambda = request.form.get("memory_social_decay_lambda", 0.05)
+    memory_social_corruption_rate = request.form.get("memory_social_corruption_rate", 0.02)
+    memory_social_resummarize_every_events = request.form.get(
+        "memory_social_resummarize_every_events", 4
+    )
+    memory_thread_decay_lambda = request.form.get("memory_thread_decay_lambda", 0.03)
+    memory_thread_corruption_rate = request.form.get("memory_thread_corruption_rate", 0.01)
+    memory_thread_resummarize_every_events = request.form.get(
+        "memory_thread_resummarize_every_events", 4
+    )
+    memory_evidence_tail_max = request.form.get("memory_evidence_tail_max", 8)
+    memory_digest_update_cadence_rounds = request.form.get(
+        "memory_digest_update_cadence_rounds", 3
+    )
+    memory_digest_events_limit = request.form.get("memory_digest_events_limit", 80)
+    memory_cold_start_window = request.form.get("memory_cold_start_window", 5)
+    memory_semantic_enabled_raw = request.form.get("memory_semantic_enabled")
+    if memory_semantic_enabled_raw is None:
+        memory_semantic_enabled = True
+    else:
+        memory_semantic_enabled = (
+            str(memory_semantic_enabled_raw).strip().lower() in {"1", "true", "on", "yes"}
+        )
+    memory_search_k = request.form.get("memory_search_k", 8)
+    memory_search_max_chars = request.form.get(
+        "memory_search_max_chars", DEFAULT_MEMORY_SEARCH_MAX_CHARS
+    )
+    memory_search_time_window_rounds = request.form.get(
+        "memory_search_time_window_rounds", 40
+    )
+    memory_tier_a_max_chars = request.form.get(
+        "memory_tier_a_max_chars", DEFAULT_MEMORY_TIER_A_MAX_CHARS
+    )
+    memory_tier_b_max_chars = request.form.get(
+        "memory_tier_b_max_chars", DEFAULT_MEMORY_TIER_B_MAX_CHARS
+    )
+    memory_tier_c_max_chars = request.form.get(
+        "memory_tier_c_max_chars", DEFAULT_MEMORY_TIER_C_MAX_CHARS
+    )
+    memory_total_max_chars = request.form.get(
+        "memory_total_max_chars", DEFAULT_MEMORY_TOTAL_MAX_CHARS
+    )
+    memory_tier_c_uncertainty_threshold = request.form.get(
+        "memory_tier_c_uncertainty_threshold", 0.45
+    )
+    memory_reflection_cadence_rounds = request.form.get(
+        "memory_reflection_cadence_rounds", 3
+    )
+    memory_reflection_min_events = request.form.get("memory_reflection_min_events", 12)
+    memory_reflection_trigger_importance_sum = request.form.get(
+        "memory_reflection_trigger_importance_sum", 3.5
+    )
+    memory_reflection_max_items_per_run = request.form.get(
+        "memory_reflection_max_items_per_run", 60
+    )
+    memory_embedding_model = request.form.get("memory_embedding_model", "BAAI/bge-m3")
+    memory_embedding_async_raw = request.form.get("memory_embedding_async")
+    if memory_embedding_async_raw is None:
+        memory_embedding_async = True
+    else:
+        memory_embedding_async = (
+            str(memory_embedding_async_raw).strip().lower() in {"1", "true", "on", "yes"}
+        )
+    memory_importance_mode = request.form.get(
+        "memory_importance_mode", "heuristic_then_batch_llm"
+    )
+
+    # Normalize required foreign keys early to avoid DB type errors (e.g., PostgreSQL int vs "")
+    try:
+        exp_id = int(exp_id)
+    except (TypeError, ValueError):
+        flash("Invalid experiment ID.", "error")
+        return redirect(request.referrer or "/admin/experiments")
+
+    try:
+        population_id = int(population_id)
+    except (TypeError, ValueError):
+        flash("Please select a valid population.", "error")
+        return redirect(request.referrer or f"/admin/clients/{exp_id}")
 
     # Check if LLM agents are enabled for this experiment
     exp = Exps.query.filter_by(idexp=exp_id).first()
     llm_agents_enabled = (
         exp.llm_agents_enabled if (exp and hasattr(exp, "llm_agents_enabled")) else True
     )
-
-    annotations = {an: None for an in exp.annotations.split(",")}
-    if "opinions" in annotations:
-        opinions_enabled = True
-    else:
-        opinions_enabled = False
 
     # Get LLM parameters from form, or use defaults if LLM agents are disabled
     if llm_agents_enabled:
@@ -347,7 +532,7 @@ def create_client():
         # Use default values when LLM agents are disabled
         llm = "http://127.0.0.1:11434/v1"
         llm_api_key = "NULL"
-        llm_max_tokens = "-1"
+        llm_max_tokens = str(DEFAULT_OLLAMA_MAX_TOKENS)
         llm_temperature = "1.5"
         llm_v_agent = "minicpm-v"
         llm_v = "http://127.0.0.1:11434/v1"
@@ -358,31 +543,6 @@ def create_client():
 
     crecsys = request.form.get("recsys_type")
     frecsys = request.form.get("frecsys_type")
-
-    # Get agent archetype enabled status
-    enable_archetypes = request.form.get("enable_archetypes") == "on"
-
-    # Get agent archetype values (optional, with defaults)
-    try:
-        archetype_validator = (
-            float(request.form.get("archetype_validator", "52")) / 100.0
-        )
-        archetype_broadcaster = (
-            float(request.form.get("archetype_broadcaster", "20")) / 100.0
-        )
-        archetype_explorer = float(request.form.get("archetype_explorer", "28")) / 100.0
-        trans_val_val = float(request.form.get("trans_val_val", "85.3")) / 100.0
-        trans_val_broad = float(request.form.get("trans_val_broad", "8.1")) / 100.0
-        trans_val_expl = float(request.form.get("trans_val_expl", "6.6")) / 100.0
-        trans_broad_broad = float(request.form.get("trans_broad_broad", "72.9")) / 100.0
-        trans_broad_val = float(request.form.get("trans_broad_val", "19.5")) / 100.0
-        trans_broad_expl = float(request.form.get("trans_broad_expl", "7.5")) / 100.0
-        trans_expl_expl = float(request.form.get("trans_expl_expl", "49.0")) / 100.0
-        trans_expl_val = float(request.form.get("trans_expl_val", "36.4")) / 100.0
-        trans_expl_broad = float(request.form.get("trans_expl_broad", "14.6")) / 100.0
-    except (ValueError, TypeError) as e:
-        flash(f"Invalid archetype values: {str(e)}", "error")
-        return redirect(request.referrer)
 
     # Validate simulation parameters
     errors = []
@@ -401,6 +561,16 @@ def create_client():
     except (ValueError, TypeError):
         errors.append("Max Length Thread Reading must be a valid integer")
     try:
+        max_thread_context_chars = int(max_thread_context_chars)
+        if max_thread_context_chars < 200:
+            errors.append("Max Thread Context Chars must be at least 200")
+        if max_thread_context_chars > MAX_MAX_THREAD_CONTEXT_CHARS:
+            errors.append(
+                f"Max Thread Context Chars must be <= {MAX_MAX_THREAD_CONTEXT_CHARS}"
+            )
+    except (ValueError, TypeError):
+        errors.append("Max Thread Context Chars must be a valid integer")
+    try:
         attention_window = int(attention_window)
     except (ValueError, TypeError):
         errors.append("Attention Window must be a valid integer")
@@ -408,6 +578,249 @@ def create_client():
         visibility_rounds = int(visibility_rounds)
     except (ValueError, TypeError):
         errors.append("Visibility Rounds must be a valid integer")
+    try:
+        clock_mode = validate_clock_mode(clock_mode)
+    except ValueError as exc:
+        errors.append(str(exc))
+    try:
+        clock_timezone = validate_timezone(clock_timezone)
+    except ValueError as exc:
+        errors.append(str(exc))
+    try:
+        clock_feed_refresh = validate_feed_refresh(clock_feed_refresh)
+    except ValueError as exc:
+        errors.append(str(exc))
+
+    # Validate agent memory fields
+    try:
+        memory_pair_limit = int(memory_pair_limit)
+        if memory_pair_limit < 1:
+            errors.append("Memory Pair Limit must be at least 1")
+    except (ValueError, TypeError):
+        errors.append("Memory Pair Limit must be a valid integer")
+
+    try:
+        memory_prompt_max_chars = int(memory_prompt_max_chars)
+        if memory_prompt_max_chars < 200:
+            errors.append("Memory Prompt Max Chars must be at least 200")
+        if memory_prompt_max_chars > MAX_MEMORY_PROMPT_MAX_CHARS:
+            errors.append(
+                f"Memory Prompt Max Chars must be <= {MAX_MEMORY_PROMPT_MAX_CHARS}"
+            )
+    except (ValueError, TypeError):
+        errors.append("Memory Prompt Max Chars must be a valid integer")
+
+    try:
+        memory_social_decay_lambda = float(memory_social_decay_lambda)
+        if memory_social_decay_lambda < 0:
+            errors.append("Memory Social Decay (lambda) must be >= 0")
+    except (ValueError, TypeError):
+        errors.append("Memory Social Decay (lambda) must be a valid number")
+
+    try:
+        memory_thread_decay_lambda = float(memory_thread_decay_lambda)
+        if memory_thread_decay_lambda < 0:
+            errors.append("Memory Thread Decay (lambda) must be >= 0")
+    except (ValueError, TypeError):
+        errors.append("Memory Thread Decay (lambda) must be a valid number")
+
+    try:
+        memory_social_corruption_rate = float(memory_social_corruption_rate)
+        if not (0 <= memory_social_corruption_rate <= 1):
+            errors.append("Memory Social Corruption Rate must be between 0 and 1")
+    except (ValueError, TypeError):
+        errors.append("Memory Social Corruption Rate must be a valid number")
+
+    try:
+        memory_thread_corruption_rate = float(memory_thread_corruption_rate)
+        if not (0 <= memory_thread_corruption_rate <= 1):
+            errors.append("Memory Thread Corruption Rate must be between 0 and 1")
+    except (ValueError, TypeError):
+        errors.append("Memory Thread Corruption Rate must be a valid number")
+
+    try:
+        memory_social_resummarize_every_events = int(memory_social_resummarize_every_events)
+        if memory_social_resummarize_every_events < 1:
+            errors.append("Memory Social Resummarize Every (events) must be at least 1")
+    except (ValueError, TypeError):
+        errors.append("Memory Social Resummarize Every (events) must be a valid integer")
+
+    try:
+        memory_thread_resummarize_every_events = int(memory_thread_resummarize_every_events)
+        if memory_thread_resummarize_every_events < 1:
+            errors.append("Memory Thread Resummarize Every (events) must be at least 1")
+    except (ValueError, TypeError):
+        errors.append("Memory Thread Resummarize Every (events) must be a valid integer")
+
+    try:
+        memory_evidence_tail_max = int(memory_evidence_tail_max)
+        if memory_evidence_tail_max < 0:
+            errors.append("Memory Evidence Tail Max must be >= 0")
+    except (ValueError, TypeError):
+        errors.append("Memory Evidence Tail Max must be a valid integer")
+
+    try:
+        memory_digest_update_cadence_rounds = int(memory_digest_update_cadence_rounds)
+        if memory_digest_update_cadence_rounds < 1:
+            errors.append("Memory Digest Update Cadence (rounds) must be at least 1")
+    except (ValueError, TypeError):
+        errors.append("Memory Digest Update Cadence (rounds) must be a valid integer")
+
+    try:
+        memory_digest_events_limit = int(memory_digest_events_limit)
+        if memory_digest_events_limit < 10:
+            errors.append("Memory Digest Events Limit must be at least 10")
+    except (ValueError, TypeError):
+        errors.append("Memory Digest Events Limit must be a valid integer")
+
+    try:
+        memory_cold_start_window = int(memory_cold_start_window)
+        if memory_cold_start_window < 1:
+            errors.append("Memory Cold-Start Window must be at least 1")
+        if memory_cold_start_window > 1000:
+            errors.append("Memory Cold-Start Window must be <= 1000")
+    except (ValueError, TypeError):
+        errors.append("Memory Cold-Start Window must be a valid integer")
+
+    try:
+        memory_search_k = int(memory_search_k)
+        if memory_search_k < 1:
+            errors.append("Memory Search K must be at least 1")
+    except (ValueError, TypeError):
+        errors.append("Memory Search K must be a valid integer")
+
+    try:
+        memory_search_max_chars = int(memory_search_max_chars)
+        if memory_search_max_chars < 300:
+            errors.append("Memory Search Max Chars must be at least 300")
+        if memory_search_max_chars > MAX_MEMORY_SEARCH_MAX_CHARS:
+            errors.append(
+                f"Memory Search Max Chars must be <= {MAX_MEMORY_SEARCH_MAX_CHARS}"
+            )
+    except (ValueError, TypeError):
+        errors.append("Memory Search Max Chars must be a valid integer")
+
+    try:
+        memory_search_time_window_rounds = int(memory_search_time_window_rounds)
+        if memory_search_time_window_rounds < 0:
+            errors.append("Memory Search Window (rounds) must be >= 0")
+    except (ValueError, TypeError):
+        errors.append("Memory Search Window (rounds) must be a valid integer")
+
+    try:
+        memory_tier_a_max_chars = int(memory_tier_a_max_chars)
+        if memory_tier_a_max_chars < 100:
+            errors.append("Memory Tier A Max Chars must be at least 100")
+        if memory_tier_a_max_chars > MAX_MEMORY_TIER_A_MAX_CHARS:
+            errors.append(
+                f"Memory Tier A Max Chars must be <= {MAX_MEMORY_TIER_A_MAX_CHARS}"
+            )
+    except (ValueError, TypeError):
+        errors.append("Memory Tier A Max Chars must be a valid integer")
+
+    try:
+        memory_tier_b_max_chars = int(memory_tier_b_max_chars)
+        if memory_tier_b_max_chars < 400:
+            errors.append("Memory Tier B Max Chars must be at least 400")
+        if memory_tier_b_max_chars > MAX_MEMORY_TIER_BC_MAX_CHARS:
+            errors.append(
+                f"Memory Tier B Max Chars must be <= {MAX_MEMORY_TIER_BC_MAX_CHARS}"
+            )
+    except (ValueError, TypeError):
+        errors.append("Memory Tier B Max Chars must be a valid integer")
+
+    try:
+        memory_tier_c_max_chars = int(memory_tier_c_max_chars)
+        if memory_tier_c_max_chars < 400:
+            errors.append("Memory Tier C Max Chars must be at least 400")
+        if memory_tier_c_max_chars > MAX_MEMORY_TIER_BC_MAX_CHARS:
+            errors.append(
+                f"Memory Tier C Max Chars must be <= {MAX_MEMORY_TIER_BC_MAX_CHARS}"
+            )
+    except (ValueError, TypeError):
+        errors.append("Memory Tier C Max Chars must be a valid integer")
+
+    try:
+        memory_total_max_chars = int(memory_total_max_chars)
+        if memory_total_max_chars < 800:
+            errors.append("Memory Total Max Chars must be at least 800")
+        if memory_total_max_chars > MAX_MEMORY_TOTAL_MAX_CHARS:
+            errors.append(
+                f"Memory Total Max Chars must be <= {MAX_MEMORY_TOTAL_MAX_CHARS}"
+            )
+    except (ValueError, TypeError):
+        errors.append("Memory Total Max Chars must be a valid integer")
+
+    if all(
+        isinstance(v, int)
+        for v in (
+            memory_tier_a_max_chars,
+            memory_tier_b_max_chars,
+            memory_tier_c_max_chars,
+            memory_total_max_chars,
+        )
+    ):
+        tiers_total = (
+            memory_tier_a_max_chars
+            + memory_tier_b_max_chars
+            + memory_tier_c_max_chars
+        )
+        if tiers_total > memory_total_max_chars:
+            errors.append(
+                "Memory tier budgets must fit within Memory Total Max Chars "
+                f"(tier sum {tiers_total} > total {memory_total_max_chars})."
+            )
+
+    llm_max_tokens = _normalize_llm_max_tokens(llm_max_tokens)
+
+    try:
+        memory_tier_c_uncertainty_threshold = float(memory_tier_c_uncertainty_threshold)
+        if not (0 <= memory_tier_c_uncertainty_threshold <= 1):
+            errors.append("Memory Tier C Uncertainty must be between 0 and 1")
+    except (ValueError, TypeError):
+        errors.append("Memory Tier C Uncertainty must be a valid number")
+
+    try:
+        memory_reflection_cadence_rounds = int(memory_reflection_cadence_rounds)
+        if memory_reflection_cadence_rounds < 1:
+            errors.append("Memory Reflection Cadence must be at least 1")
+    except (ValueError, TypeError):
+        errors.append("Memory Reflection Cadence must be a valid integer")
+
+    try:
+        memory_reflection_min_events = int(memory_reflection_min_events)
+        if memory_reflection_min_events < 1:
+            errors.append("Memory Reflection Min Events must be at least 1")
+    except (ValueError, TypeError):
+        errors.append("Memory Reflection Min Events must be a valid integer")
+
+    try:
+        memory_reflection_trigger_importance_sum = float(memory_reflection_trigger_importance_sum)
+        if memory_reflection_trigger_importance_sum < 0:
+            errors.append("Memory Reflection Trigger Sum must be >= 0")
+    except (ValueError, TypeError):
+        errors.append("Memory Reflection Trigger Sum must be a valid number")
+
+    try:
+        memory_reflection_max_items_per_run = int(memory_reflection_max_items_per_run)
+        if memory_reflection_max_items_per_run < 1:
+            errors.append("Memory Reflection Max Items must be at least 1")
+    except (ValueError, TypeError):
+        errors.append("Memory Reflection Max Items must be a valid integer")
+
+    try:
+        memory_embedding_model = str(memory_embedding_model).strip()
+        if len(memory_embedding_model) == 0:
+            errors.append("Memory Embedding Model cannot be empty")
+    except Exception:
+        errors.append("Memory Embedding Model must be a valid string")
+
+    try:
+        memory_importance_mode = str(memory_importance_mode).strip()
+        if len(memory_importance_mode) == 0:
+            errors.append("Memory Importance Mode cannot be empty")
+    except Exception:
+        errors.append("Memory Importance Mode must be a valid string")
 
     # Validate probability fields (must be float in [0, 1])
     try:
@@ -490,6 +903,14 @@ def create_client():
         flash("Population not found.", "error")
         return redirect(request.referrer)
 
+    pop_type = getattr(population, "username_type", "microblogging") or "microblogging"
+    if pop_type != exp.platform_type:
+        flash(
+            f"Population Username Type '{pop_type}' is incompatible with experiment platform '{exp.platform_type}'.",
+            "error",
+        )
+        return redirect(request.referrer)
+
     # check if the population is already assigned to the experiment
     # if not, add it
     pop_exp = Population_Experiment.query.filter_by(
@@ -500,12 +921,31 @@ def create_client():
         db.session.add(pop_exp)
         db.session.commit()
 
+    # Enforce action restrictions per platform type
+    if exp.platform_type == "forum":
+        news = 0  # Forum mode doesn't use news
+        share = 0  # Forum mode doesn't use share
+        # share_link is KEPT for forum mode - it's the key action for Reddit-style link sharing
+    elif exp.platform_type == "microblogging":
+        share_link = 0  # Microblogging doesn't use share_link
+
+    # Parse initial_agents (can be empty/None)
+    initial_agents_int = None
+    if initial_agents and initial_agents.strip():
+        try:
+            initial_agents_int = int(initial_agents)
+            if initial_agents_int < 1:
+                initial_agents_int = None
+        except (ValueError, TypeError):
+            initial_agents_int = None
+
     # create the Client object
     client = Client(
         name=name,
         descr=descr,
         id_exp=exp_id,
         population_id=population_id,
+        initial_agents=initial_agents_int,
         days=days,
         percentage_new_agents_iteration=percentage_new_agents_iteration,
         percentage_removed_agents_iteration=percentage_removed_agents_iteration,
@@ -535,19 +975,9 @@ def create_client():
         probability_of_secondary_follow=probability_of_secondary_follow,
         crecsys=crecsys,
         frecsys=frecsys,
+        max_replies_per_round=int(max_replies_per_round),
+        reply_cooldown_rounds=int(reply_cooldown_rounds),
         status=0,
-        archetype_validator=archetype_validator,
-        archetype_broadcaster=archetype_broadcaster,
-        archetype_explorer=archetype_explorer,
-        trans_val_val=trans_val_val,
-        trans_val_broad=trans_val_broad,
-        trans_val_expl=trans_val_expl,
-        trans_broad_broad=trans_broad_broad,
-        trans_broad_val=trans_broad_val,
-        trans_broad_expl=trans_broad_expl,
-        trans_expl_expl=trans_expl_expl,
-        trans_expl_val=trans_expl_val,
-        trans_expl_broad=trans_expl_broad,
     )
 
     db.session.add(client)
@@ -618,6 +1048,106 @@ def create_client():
         for h in range(24)
     }
 
+    # Extract experiment folder using helper function.
+    uid = get_experiment_uid_from_db_name(exp.db_name)
+    if not uid:
+        flash("Invalid experiment database configuration", "error")
+        return redirect(request.referrer or "/admin/experiments")
+
+    BASE_DIR = get_writable_path()
+    client_config_path = (
+        f"{BASE_DIR}{os.sep}y_web{os.sep}experiments{os.sep}{uid}{os.sep}"
+        f"client_{name}-{population.name}.json"
+    )
+    experiment_config_path = (
+        f"{BASE_DIR}{os.sep}y_web{os.sep}experiments{os.sep}{uid}{os.sep}config_server.json"
+    )
+
+    resolved_clock = {
+        "mode": clock_mode,
+        "timezone": clock_timezone,
+        "feed_refresh": clock_feed_refresh,
+    }
+    experiment_clock_updated = False
+    clock_sync_applied = False
+
+    try:
+        if os.path.exists(experiment_config_path):
+            with open(experiment_config_path, "r") as config_file:
+                experiment_config = json.load(config_file)
+        else:
+            experiment_config = {}
+
+        existing_clock = ensure_experiment_clock(experiment_config)
+        if (
+            existing_clock["mode"] != resolved_clock["mode"]
+            or existing_clock["timezone"] != resolved_clock["timezone"]
+            or existing_clock["feed_refresh"] != resolved_clock["feed_refresh"]
+        ):
+            experiment_clock_updated = True
+
+        experiment_config["clock"] = {
+            "mode": resolved_clock["mode"],
+            "timezone": resolved_clock["timezone"],
+            "feed_refresh": resolved_clock["feed_refresh"],
+        }
+
+        if (
+            resolved_clock["mode"] == "real_time"
+            and "anchor_date" not in experiment_config["clock"]
+        ):
+            experiment_config["clock"]["anchor_date"] = (
+                current_local_time(resolved_clock["timezone"]).date().isoformat()
+            )
+
+        resolved_clock = ensure_experiment_clock(experiment_config)
+
+        with open(experiment_config_path, "w") as config_file:
+            json.dump(experiment_config, config_file, indent=4)
+
+        if experiment_clock_updated:
+            exp_dir = os.path.dirname(experiment_config_path)
+            for item in os.listdir(exp_dir):
+                if not (item.startswith("client_") and item.endswith(".json")):
+                    continue
+                client_path = os.path.join(exp_dir, item)
+                try:
+                    with open(client_path, "r") as existing_client_file:
+                        existing_client_config = json.load(existing_client_file)
+                    if isinstance(existing_client_config.get("simulation"), dict):
+                        apply_clock_to_client_simulation(
+                            existing_client_config["simulation"], resolved_clock
+                        )
+                        with open(client_path, "w") as existing_client_file:
+                            json.dump(existing_client_config, existing_client_file, indent=4)
+                        clock_sync_applied = True
+                except Exception:
+                    continue
+    except Exception:
+        # Keep client creation resilient if experiment config is unavailable.
+        pass
+
+    existing_memory_run_key = None
+    if os.path.exists(client_config_path):
+        try:
+            with open(client_config_path, "r") as existing_file:
+                existing_cfg = json.load(existing_file)
+            existing_memory_run_key = str(
+                (existing_cfg.get("agents", {}) or {}).get("memory_run_id") or ""
+            ).strip()
+        except Exception:
+            existing_memory_run_key = None
+
+    # Keep run_id stable across client config edits and enforce DB-safe length.
+    memory_run_key = normalize_memory_run_id(existing_memory_run_key)
+    if not memory_run_key:
+        seeded_run_key = build_memory_run_seed(
+            uid,
+            str(name),
+            str(population.name),
+        )
+        memory_run_key = normalize_memory_run_id(seeded_run_key)
+
     config = {
         "servers": {
             "llm": llm,
@@ -632,10 +1162,11 @@ def create_client():
         },
         "simulation": {
             "name": name,
-            "population": population.name,
+            "population": population.name.replace(' ', ''),
             "client": "YClientWeb",
             "days": int(days),
             "slots": 24,
+            "initial_agents": initial_agents_int,
             "percentage_new_agents_iteration": float(percentage_new_agents_iteration),
             "percentage_removed_agents_iteration": float(
                 percentage_removed_agents_iteration
@@ -645,40 +1176,17 @@ def create_client():
             "actions_likelihood": {
                 "post": float(post),
                 "image": float(image) if image is not None else 0,
-                "news": float(news) if news is not None else 0,
+                # Enforce action restrictions per platform type
+                "news": 0.0 if exp.platform_type == "forum" else (float(news) if news is not None else 0),
                 "comment": float(comment) if comment is not None else 0,
                 "read": float(read) if read is not None else 0,
-                "share": float(share) if share is not None else 0,
+                "share": 0.0 if exp.platform_type == "forum" else (float(share) if share is not None else 0),
                 "search": float(search) if search is not None else 0,
                 "cast": float(vote) if vote is not None else 0,
-                "share_link": float(share_link) if share_link is not None else 0,
+                "share_link": 0.0 if exp.platform_type == "microblogging" else (float(share_link) if share_link is not None else 0),
+                "share_image": 0.0 if exp.platform_type == "microblogging" else (float(share_image) if share_image is not None else 0),
             },
             "emotion_annotation": emotion_annotation,
-            "agent_archetypes": {
-                "enabled": enable_archetypes,
-                "distribution": {
-                    "validator": archetype_validator,
-                    "broadcaster": archetype_broadcaster,
-                    "explorer": archetype_explorer,
-                },
-                "transitions": {
-                    "validator": {
-                        "validator": trans_val_val,
-                        "broadcaster": trans_val_broad,
-                        "explorer": trans_val_expl,
-                    },
-                    "broadcaster": {
-                        "validator": trans_broad_val,
-                        "broadcaster": trans_broad_broad,
-                        "explorer": trans_broad_expl,
-                    },
-                    "explorer": {
-                        "validator": trans_expl_val,
-                        "broadcaster": trans_expl_broad,
-                        "explorer": trans_expl_expl,
-                    },
-                },
-            },
         },
         "posts": {
             "visibility_rounds": int(visibility_rounds),
@@ -715,8 +1223,10 @@ def create_client():
         },
         "agents": {
             "llm_v_agent": "minicpm-v",
+            "username_type": pop_type,
             "reading_from_follower_ratio": float(reading_from_follower_ratio),
             "max_length_thread_reading": int(max_length_thread_reading),
+            "max_thread_context_chars": int(max_thread_context_chars),
             "attention_window": int(attention_window),
             "probability_of_daily_follow": float(probability_of_daily_follow),
             "probability_of_secondary_follow": float(probability_of_secondary_follow),
@@ -736,8 +1246,70 @@ def create_client():
                 "ag": ["critical/judgmental", "friendly/compassionate"],
                 "ne": ["resilient/confident", "sensitive/nervous"],
             },
+            "max_replies_per_round": int(max_replies_per_round),
+            "reply_cooldown_rounds": int(reply_cooldown_rounds),
+            # Forum agents: sequential thread browsing before commenting
+            "thread_browse_mode": "llm",
+            "thread_browse_order": "tree_dfs",
+            "thread_browse_max_nodes": 400,
+            "thread_browse_chunk_size": 20,
+            "thread_browse_top_k": 6,
+            "thread_browse_max_llm_steps": 3,
+            "thread_browse_snippet_chars": 220,
+            "thread_browse_context_window": 30,
+            # Run-scoped agent memory (hybrid storage, LLM-on-write + decay)
+            "memory_enabled": bool(memory_enabled),
+            "memory_pair_limit": int(memory_pair_limit),
+            "memory_prompt_max_chars": int(memory_prompt_max_chars),
+            "memory_social_decay_lambda": float(memory_social_decay_lambda),
+            "memory_social_corruption_rate": float(memory_social_corruption_rate),
+            "memory_social_resummarize_every_events": int(memory_social_resummarize_every_events),
+            "memory_thread_decay_lambda": float(memory_thread_decay_lambda),
+            "memory_thread_corruption_rate": float(memory_thread_corruption_rate),
+            "memory_thread_resummarize_every_events": int(memory_thread_resummarize_every_events),
+            "memory_evidence_tail_max": int(memory_evidence_tail_max),
+            "memory_digest_update_cadence_rounds": int(memory_digest_update_cadence_rounds),
+            "memory_digest_events_limit": int(memory_digest_events_limit),
+            "memory_cold_start_window": int(memory_cold_start_window),
+            "memory_semantic_enabled": bool(memory_semantic_enabled),
+            "memory_search_k": int(memory_search_k),
+            "memory_search_max_chars": int(memory_search_max_chars),
+            "memory_search_time_window_rounds": int(memory_search_time_window_rounds),
+            "memory_tier_a_max_chars": int(memory_tier_a_max_chars),
+            "memory_tier_b_max_chars": int(memory_tier_b_max_chars),
+            "memory_tier_c_max_chars": int(memory_tier_c_max_chars),
+            "memory_total_max_chars": int(memory_total_max_chars),
+            "memory_tier_c_uncertainty_threshold": float(memory_tier_c_uncertainty_threshold),
+            "memory_reflection_cadence_rounds": int(memory_reflection_cadence_rounds),
+            "memory_reflection_min_events": int(memory_reflection_min_events),
+            "memory_reflection_trigger_importance_sum": float(memory_reflection_trigger_importance_sum),
+            "memory_reflection_max_items_per_run": int(memory_reflection_max_items_per_run),
+            "memory_embedding_model": str(memory_embedding_model).strip(),
+            "memory_embedding_async": bool(memory_embedding_async),
+            "memory_importance_mode": str(memory_importance_mode).strip(),
+            "memory_run_id": memory_run_key,
+            "memory_reset_on_start": False,
+            "memory_high_affect_enabled": False,
+            "memory_nuance_planner_enabled": False,
+            "memory_prompt_mode": "subtle_forum",
+            "memory_reply_context_max_chars": 280,
+            "memory_vote_signal_only": True,
+            "forum_post_structure_strict": True,
+            "memory_cross_thread_callback_min_score": 0.8,
         },
     }
+    apply_clock_to_client_simulation(config["simulation"], resolved_clock)
+
+    if experiment_clock_updated:
+        flash(
+            "Experiment clock settings were updated and applied experiment-wide.",
+            "info",
+        )
+        if clock_sync_applied:
+            flash(
+                "Existing client configuration files were synchronized with the new clock settings.",
+                "info",
+            )
 
     # get population agents
     agents = Agent_Population.query.filter_by(population_id=population_id).all()
@@ -774,16 +1346,6 @@ def create_client():
     config["agents"]["round_actions"] = {"min": 1, "max": 3}
     config["agents"]["n_interests"] = {"min": 1, "max": 5}
 
-    # check db type
-    if "database_server.db" in exp.db_name:  # sqlite
-        uid = exp.db_name.split(os.sep)[1]
-    else:
-        uid = exp.db_name.removeprefix("experiments_")
-
-    from y_web.utils.path_utils import get_writable_path
-
-    BASE_DIR = get_writable_path()
-
     with open(
         f"{BASE_DIR}{os.sep}y_web{os.sep}experiments{os.sep}{uid}{os.sep}client_{name}-{population.name}.json",
         "w",
@@ -814,70 +1376,21 @@ def create_client():
     # Create agent population file
     writable_base = get_writable_path()
 
-    if "database_server.db" in exp.db_name:
-        # exp.db_name is like "experiments/uid/database_server.db"
-        filename = os.path.join(
-            writable_base,
-            "y_web",
-            exp.db_name.split("database_server.db")[0],
-            f"{population.name.replace(' ', '')}.json",
-        )
-    else:
-        # Legacy format
-        filename = os.path.join(
-            writable_base,
-            "y_web",
-            "experiments",
-            exp.db_name.replace("experiments_", ""),
-            f"{population.name.replace(' ', '')}.json",
-        )
+    # Use the already-extracted uid from above
+    filename = os.path.join(
+        writable_base,
+        "y_web",
+        "experiments",
+        uid,
+        f"{population.name.replace(' ', '')}.json",
+    )
 
     agents = Agent_Population.query.filter_by(population_id=population.id).all()
     # get the agent details
     agents = [Agent.query.filter_by(id=a.agent_id).first() for a in agents]
 
-    # Assign archetypes to agents based on distribution probabilities
-    num_agents = len(agents)
-    archetype_assignments = []
-
-    if enable_archetypes and num_agents > 0:
-        # Build list of active archetypes and their probabilities
-        active_archetypes = []
-        active_probabilities = []
-
-        if archetype_validator > 0:
-            active_archetypes.append("validator")
-            active_probabilities.append(archetype_validator)
-
-        if archetype_broadcaster > 0:
-            active_archetypes.append("broadcaster")
-            active_probabilities.append(archetype_broadcaster)
-
-        if archetype_explorer > 0:
-            active_archetypes.append("explorer")
-            active_probabilities.append(archetype_explorer)
-
-        # Normalize probabilities if they don't sum to 1
-        if len(active_probabilities) > 0:
-            total_prob = sum(active_probabilities)
-            if total_prob > 0:
-                active_probabilities = [p / total_prob for p in active_probabilities]
-                # Assign archetypes to agents using numpy random choice
-                archetype_assignments = np.random.choice(
-                    active_archetypes, size=num_agents, p=active_probabilities
-                ).tolist()
-            else:
-                # If all probabilities are 0, assign None
-                archetype_assignments = [None] * num_agents
-        else:
-            # No active archetypes
-            archetype_assignments = [None] * num_agents
-    else:
-        # Archetypes disabled, assign None to all agents
-        archetype_assignments = [None] * num_agents
-
     res = {"agents": []}
-    for idx, a in enumerate(agents):
+    for a in agents:
         custom_prompt = Agent_Profile.query.filter_by(agent_id=a.id).first()
 
         if custom_prompt:
@@ -935,63 +1448,63 @@ def create_client():
                 "daily_activity_level": a.daily_activity_level,
                 "profession": a.profession,
                 "activity_profile": activity_profile_name,
-                "archetype": archetype_assignments[idx],
-                "opinions": (
-                    {i: random.random() for i in ints[0]} if opinions_enabled else None
-                ),  # @todo: check initial opinions
             }
         )
 
-    # get the pages associated with the population
-    pages = Page_Population.query.filter_by(population_id=population.id).all()
-    pages = [Page.query.filter_by(id=p.page_id).first() for p in pages]
+    # Forum simulations: disable page accounts (news org pages).
+    if exp.platform_type != "forum":
+        # get the pages associated with the population
+        pages = Page_Population.query.filter_by(population_id=population.id).all()
+        pages = [Page.query.filter_by(id=p.page_id).first() for p in pages]
 
-    for p in pages:
-        # get pages topics
-        page_topics = (
-            db.session.query(Exp_Topic, Topic_List)
-            .join(Topic_List)
-            .filter(Exp_Topic.exp_id == exp_id, Exp_Topic.topic_id == Topic_List.id)
-            .all()
-        )
-        page_topics = [t[1].name for t in page_topics]
-        page_topics = list(set(page_topics) & set(topics))
+        for p in pages:
+            # get pages topics
+            page_topics = (
+                db.session.query(Exp_Topic, Topic_List)
+                .join(Topic_List)
+                .filter(Exp_Topic.exp_id == exp_id, Exp_Topic.topic_id == Topic_List.id)
+                .all()
+            )
+            page_topics = [t[1].name for t in page_topics]
+            page_topics = list(set(page_topics) & set(topics))
 
-        activity_profile_obj = (
-            db.session.query(ActivityProfile).filter_by(id=p.activity_profile).first()
-        )
-        activity_profile_name = (
-            activity_profile_obj.name if activity_profile_obj else "Always On"
-        )
+            activity_profile_obj = (
+                db.session.query(ActivityProfile)
+                .filter_by(id=p.activity_profile)
+                .first()
+            )
+            activity_profile_name = (
+                activity_profile_obj.name if activity_profile_obj else "Always On"
+            )
 
-        res["agents"].append(
-            {
-                "name": p.name,
-                "email": f"{p.name}@ysocial.it",
-                "password": f"{p.name}",
-                "age": 0,
-                "type": user_type,
-                "leaning": p.leaning,
-                "interests": [page_topics, len(page_topics)],
-                "oe": "",
-                "co": "",
-                "ex": "",
-                "ag": "",
-                "ne": "",
-                "rec_sys": "",
-                "frec_sys": "",
-                "language": "english",
-                "owner": exp.owner,
-                "education_level": "",
-                "round_actions": 3,
-                "gender": "",
-                "nationality": "",
-                "toxicity": "none",
-                "is_page": 1,
-                "feed_url": p.feed,
-                "activity_profile": activity_profile_name,
-            }
-        )
+            res["agents"].append(
+                {
+                    "name": p.name,
+                    "email": f"{p.name}@ysocial.it",
+                    "password": f"{p.name}",
+                    "age": 0,
+                    "type": user_type,
+                    "leaning": p.leaning,
+                    "interests": [page_topics, len(page_topics)],
+                    "oe": "",
+                    "co": "",
+                    "ex": "",
+                    "ag": "",
+                    "ne": "",
+                    "rec_sys": "",
+                    "frec_sys": "",
+                    "language": "english",
+                    "owner": exp.owner,
+                    "education_level": "",
+                    "round_actions": 3,
+                    "gender": "",
+                    "nationality": "",
+                    "toxicity": "none",
+                    "is_page": 1,
+                    "feed_url": p.feed,
+                    "activity_profile": activity_profile_name,
+                }
+            )
 
     print(f"Saving agents to {filename}")
     json.dump(res, open(filename, "w"), indent=4)
@@ -1007,17 +1520,9 @@ def create_client():
         # get agent ids for all agents in populations
         agent_ids = [Agent.query.filter_by(id=a.agent_id).first().name for a in agents]
 
-        from y_web.utils.path_utils import get_writable_path
-
         BASE = get_writable_path()
-        dbtypte = get_db_type()
-
-        if dbtypte == "sqlite":
-            exp_folder = exp.db_name.split(os.sep)[1]
-        else:
-            exp_folder = exp.db_name.removeprefix("experiments_")
-
-        network_path = f"{BASE}{os.sep}y_web{os.sep}experiments{os.sep}{exp_folder}{os.sep}{client.name}_network.csv"
+        # Use the already-extracted uid from above
+        network_path = f"{BASE}{os.sep}y_web{os.sep}experiments{os.sep}{uid}{os.sep}{client.name}_network.csv"
 
         if network_file and network_file.filename:
             # Handle uploaded network file
@@ -1161,12 +1666,6 @@ def create_client():
         }
     )
 
-    # Check if opinions annotation is present and redirect to opinion configuration
-    if opinions_enabled:
-        return redirect(
-            url_for("clientsr.opinion_configuration", idexp=exp_id, client_id=client.id)
-        )
-
     # load experiment_details page
     from .experiments_routes import experiment_details
 
@@ -1180,26 +1679,36 @@ def delete_client(uid):
     check_privileges(current_user.username)
 
     client = Client.query.filter_by(id=uid).first()
+    if not client:
+        flash("Client not found.", "error")
+        return redirect(request.referrer or "/admin/experiments")
+
     exp_id = client.id_exp
     pop_id = client.population_id
+
+    # If the client process is still running, terminate it before deleting the DB row.
+    if client.pid:
+        try:
+            terminate_client(client, pause=False)
+        except Exception:
+            traceback.print_exc()
 
     Client_Execution.query.filter_by(client_id=uid).delete()
     db.session.commit()
 
-    # delete association of population and experiment if no other client is using it
-    pop_exp = Population_Experiment.query.filter_by(
-        id_population=client.population_id, id_exp=exp_id
-    ).first()
-    if pop_exp:
-        other_clients = Client.query.filter_by(
-            id_exp=exp_id, population_id=client.population_id
-        ).all()
-        if len(other_clients) == 0:
-            db.session.delete(pop_exp)
-            db.session.commit()
-
     db.session.delete(client)
     db.session.commit()
+
+    # Delete association of population and experiment if no other client uses it.
+    # Important: only delete for this experiment, not globally for the population.
+    remaining_clients = (
+        Client.query.filter_by(id_exp=exp_id, population_id=pop_id).count()
+    )
+    if remaining_clients == 0:
+        Population_Experiment.query.filter_by(
+            id_population=pop_id, id_exp=exp_id
+        ).delete()
+        db.session.commit()
 
     from y_web.utils.path_utils import get_writable_path
 
@@ -1210,10 +1719,6 @@ def delete_client(uid):
         os.remove(path)
     else:
         print(f"File {path} does not exist.")
-
-    # remove agent population
-    Population_Experiment.query.filter_by(id_population=pop_id).delete()
-    db.session.commit()
 
     from .experiments_routes import experiment_details
 
@@ -1228,7 +1733,14 @@ def client_details(uid):
 
     # get client details
     client = Client.query.filter_by(id=uid).first()
+    if not client:
+        flash("Client not found", "error")
+        return redirect(request.referrer or "/admin/experiments")
+
     experiment = Exps.query.filter_by(idexp=client.id_exp).first()
+    if not experiment:
+        flash("Experiment not found", "error")
+        return redirect(request.referrer or "/admin/experiments")
 
     # get population for the client
     population = Population.query.filter_by(id=client.population_id).first()
@@ -1245,12 +1757,11 @@ def client_details(uid):
 
     BASE = get_writable_path()
 
-    dbtypte = get_db_type()
-
-    if dbtypte == "sqlite":
-        exp_folder = experiment.db_name.split(os.sep)[1]
-    else:
-        exp_folder = experiment.db_name.removeprefix("experiments_")
+    # Extract experiment folder using helper function
+    exp_folder = get_experiment_uid_from_db_name(experiment.db_name)
+    if not exp_folder:
+        flash("Invalid experiment database configuration", "error")
+        return redirect(request.referrer or "/admin/experiments")
 
     path = f"{BASE}{os.sep}y_web{os.sep}experiments{os.sep}{exp_folder}{os.sep}client_{client.name}-{population.name}.json"
 
@@ -1260,8 +1771,21 @@ def client_details(uid):
     else:
         config = None
 
+    # Optional cap for how much thread text we feed to the LLM (forum + microblogging).
+    max_thread_context_chars = DEFAULT_MAX_THREAD_CONTEXT_CHARS
+    try:
+        if isinstance(config, dict):
+            max_thread_context_chars = int(
+                config.get("agents", {}).get(
+                    "max_thread_context_chars", DEFAULT_MAX_THREAD_CONTEXT_CHARS
+                )
+                or DEFAULT_MAX_THREAD_CONTEXT_CHARS
+            )
+    except (ValueError, TypeError):
+        max_thread_context_chars = DEFAULT_MAX_THREAD_CONTEXT_CHARS
+
     # open the agent population file to get the number of agents
-    path_agents = f"{BASE}{os.sep}y_web{os.sep}experiments{os.sep}{exp_folder}{os.sep}{population.name}.json"
+    path_agents = f"{BASE}{os.sep}y_web{os.sep}experiments{os.sep}{exp_folder}{os.sep}{population.name.replace(' ', '')}.json"
 
     if os.path.exists(path_agents):
         with open(path_agents, "r") as f:
@@ -1276,15 +1800,6 @@ def client_details(uid):
 
     llms = ",".join(list(set(llms)))
 
-    activity = config["simulation"]["hourly_activity"]
-
-    data = []
-    idx = []
-
-    for x in range(0, 24):
-        idx.append(str(x))
-        data.append(activity[str(x)])
-
     models = get_llm_models()  # Use generic function for any LLM server
 
     llm_backend = llm_backend_status()
@@ -1294,9 +1809,6 @@ def client_details(uid):
 
     return render_template(
         "admin/client_details.html",
-        data=data,
-        idx=idx,
-        activity=activity,
         client=client,
         experiment=experiment,
         population=population,
@@ -1306,6 +1818,7 @@ def client_details(uid):
         frecsys=frecsys,
         crecsys=crecsys,
         llms=llms,
+        max_thread_context_chars=max_thread_context_chars,
     )
 
 
@@ -1315,12 +1828,67 @@ def get_progress(client_id):
 
     For finite clients: returns progress percentage (0-100)
     For infinite clients (expected_duration_rounds = -1): returns elapsed time info
+    Also includes process health status and error detection.
     """
+    import psutil
+    from y_web.utils.path_utils import get_writable_path
+
+    # get client and experiment info for log path
+    client = Client.query.filter_by(id=client_id).first()
+    exp = Exps.query.filter_by(idexp=client.id_exp).first() if client else None
+
     # get client_execution
     client_execution = Client_Execution.query.filter_by(client_id=client_id).first()
 
+    # Check if process is actually running
+    process_alive = False
+    if client and client.pid:
+        try:
+            process = psutil.Process(client.pid)
+            process_alive = process.is_running() and process.status() != psutil.STATUS_ZOMBIE
+        except (psutil.NoSuchProcess, psutil.AccessDenied):
+            process_alive = False
+
+    # Check stderr log for recent errors
+    has_error = False
+    last_error = None
+    if client and exp:
+        try:
+            writable_base = get_writable_path()
+            # Extract experiment folder using helper function
+            exp_folder = get_experiment_uid_from_db_name(exp.db_name)
+            if exp_folder:
+                log_dir = os.path.join(writable_base, "y_web", "experiments", exp_folder)
+            else:
+                log_dir = None
+            if not log_dir:
+                raise ValueError("Could not determine experiment folder")
+            stderr_log = os.path.join(log_dir, f"{client.name}_client_stderr.log")
+            if os.path.exists(stderr_log):
+                with open(stderr_log, "r") as f:
+                    # Read last 50 lines to check for recent errors
+                    lines = f.readlines()[-50:]
+                    for line in reversed(lines):
+                        if "ERROR in client process:" in line:
+                            has_error = True
+                            # Get the error message (next line after ERROR)
+                            idx = lines.index(line)
+                            if idx + 1 < len(lines):
+                                last_error = lines[idx].strip() + " " + lines[idx + 1].strip()
+                            else:
+                                last_error = line.strip()
+                            break
+        except Exception:
+            pass  # Ignore log reading errors
+
     if client_execution is None:
-        return json.dumps({"progress": 0, "infinite": False})
+        return json.dumps({
+            "progress": 0,
+            "infinite": False,
+            "process_alive": process_alive,
+            "has_error": has_error,
+            "last_error": last_error,
+        })
 
     # Check if this is an infinite client (expected_duration_rounds = -1)
     if client_execution.expected_duration_rounds == -1:
@@ -1337,6 +1905,9 @@ def get_progress(client_id):
                 "elapsed_hours": remaining_hours,
                 "last_active_day": client_execution.last_active_day,
                 "last_active_hour": client_execution.last_active_hour,
+                "process_alive": process_alive,
+                "has_error": has_error,
+                "last_error": last_error,
             }
         )
 
@@ -1352,7 +1923,13 @@ def get_progress(client_id):
     else:
         progress = 0
 
-    return json.dumps({"progress": progress, "infinite": False})
+    return json.dumps({
+        "progress": progress,
+        "infinite": False,
+        "process_alive": process_alive,
+        "has_error": has_error,
+        "last_error": last_error,
+    })
 
 
 @clientsr.route("/admin/set_network/<int:uid>", methods=["POST"])
@@ -1386,17 +1963,20 @@ def set_network(uid):
 
     # get the client experiment
     exp = Exps.query.filter_by(idexp=client.id_exp).first()
+    if not exp:
+        flash("Experiment not found", "error")
+        return redirect(request.referrer or "/admin/experiments")
+
     # get the experiment folder
     from y_web.utils.path_utils import get_writable_path
 
     BASE = get_writable_path()
 
-    dbtypte = get_db_type()
-
-    if dbtypte == "sqlite":
-        exp_folder = exp.db_name.split(os.sep)[1]
-    else:
-        exp_folder = exp.db_name.removeprefix("experiments_")
+    # Extract experiment folder using helper function
+    exp_folder = get_experiment_uid_from_db_name(exp.db_name)
+    if not exp_folder:
+        flash("Invalid experiment database configuration", "error")
+        return redirect(request.referrer or "/admin/experiments")
 
     path = f"{BASE}{os.sep}y_web{os.sep}experiments{os.sep}{exp_folder}{os.sep}{client.name}_network.csv"
 
@@ -1421,20 +2001,26 @@ def upload_network(uid):
 
     # get client
     client = Client.query.filter_by(id=uid).first()
+    if not client:
+        flash("Client not found", "error")
+        return redirect(request.referrer or "/admin/experiments")
 
     # get the client experiment
     exp = Exps.query.filter_by(idexp=client.id_exp).first()
+    if not exp:
+        flash("Experiment not found", "error")
+        return redirect(request.referrer or "/admin/experiments")
+
     # get the experiment folder
     from y_web.utils.path_utils import get_writable_path
 
     BASE = get_writable_path()
 
-    dbtypte = get_db_type()
-
-    if dbtypte == "sqlite":
-        exp_folder = exp.db_name.split(os.sep)[1]
-    else:
-        exp_folder = exp.db_name.removeprefix("experiments_")
+    # Extract experiment folder using helper function
+    exp_folder = get_experiment_uid_from_db_name(exp.db_name)
+    if not exp_folder:
+        flash("Invalid experiment database configuration", "error")
+        return redirect(request.referrer or "/admin/experiments")
 
     network = request.files["network_file"]
     network.save(
@@ -1531,6 +2117,9 @@ def download_agent_list(uid):
 
     # get client
     client = Client.query.filter_by(id=uid).first()
+    if not client:
+        flash("Client not found", "error")
+        return redirect(request.referrer or "/admin/experiments")
 
     # get populations associated to the client
     populations = Population_Experiment.query.filter_by(id_exp=client.id_exp).all()
@@ -1542,18 +2131,20 @@ def download_agent_list(uid):
 
     # get the experiment
     exp = Exps.query.filter_by(idexp=client.id_exp).first()
+    if not exp:
+        flash("Experiment not found", "error")
+        return redirect(request.referrer or "/admin/experiments")
 
     from y_web.utils.path_utils import get_writable_path
 
     # get the experiment folder
     BASE = get_writable_path()
 
-    dbtypte = get_db_type()
-
-    if dbtypte == "sqlite":
-        exp_folder = exp.db_name.split(os.sep)[1]
-    else:
-        exp_folder = exp.db_name.removeprefix("experiments_")
+    # Extract experiment folder using helper function
+    exp_folder = get_experiment_uid_from_db_name(exp.db_name)
+    if not exp_folder:
+        flash("Invalid experiment database configuration", "error")
+        return redirect(request.referrer or "/admin/experiments")
 
     with open(
         f"{BASE}{os.sep}y_web{os.sep}experiments{os.sep}{exp_folder}{os.sep}{client.name}_agent_list.csv",
@@ -1583,13 +2174,26 @@ def update_agents_activity(uid):
 
     # get client details
     client = Client.query.filter_by(id=uid).first()
+    if not client:
+        flash("Client not found", "error")
+        return redirect(request.referrer or "/admin/experiments")
+
     experiment = Exps.query.filter_by(idexp=client.id_exp).first()
+    if not experiment:
+        flash("Experiment not found", "error")
+        return redirect(request.referrer or "/admin/experiments")
+
     population = Population.query.filter_by(id=client.population_id).first()
 
     from y_web.utils.path_utils import get_writable_path
 
     BASE = get_writable_path()
-    exp_folder = experiment.db_name.split(os.sep)[1]
+
+    # Extract experiment folder using helper function
+    exp_folder = get_experiment_uid_from_db_name(experiment.db_name)
+    if not exp_folder:
+        flash("Invalid experiment database configuration", "error")
+        return redirect(request.referrer or "/admin/experiments")
 
     path = f"{BASE}{os.sep}y_web{os.sep}experiments{os.sep}{exp_folder}{os.sep}client_{client.name}-{population.name}.json"
 
@@ -1613,13 +2217,26 @@ def reset_agents_activity(uid):
 
     # get client details
     client = Client.query.filter_by(id=uid).first()
+    if not client:
+        flash("Client not found", "error")
+        return redirect(request.referrer or "/admin/experiments")
+
     experiment = Exps.query.filter_by(idexp=client.id_exp).first()
+    if not experiment:
+        flash("Experiment not found", "error")
+        return redirect(request.referrer or "/admin/experiments")
+
     population = Population.query.filter_by(id=client.population_id).first()
 
     from y_web.utils.path_utils import get_writable_path
 
     BASE = get_writable_path()
-    exp_folder = experiment.db_name.split(os.sep)[1]
+
+    # Extract experiment folder using helper function
+    exp_folder = get_experiment_uid_from_db_name(experiment.db_name)
+    if not exp_folder:
+        flash("Invalid experiment database configuration", "error")
+        return redirect(request.referrer or "/admin/experiments")
 
     path = f"{BASE}{os.sep}y_web{os.sep}experiments{os.sep}{exp_folder}{os.sep}client_{client.name}-{population.name}.json"
 
@@ -1657,223 +2274,6 @@ def reset_agents_activity(uid):
     else:
         flash("Configuration file not found.", "error")
 
-    return redirect(request.referrer)
-
-
-@clientsr.route("/admin/update_agent_archetypes/<int:uid>", methods=["POST"])
-@login_required
-def update_agent_archetypes(uid):
-    """Update agent archetypes and transition probabilities."""
-    check_privileges(current_user.username)
-
-    # Get data from form with validation
-    try:
-        archetype_validator = (
-            float(request.form.get("archetype_validator", "0")) / 100.0
-        )
-        archetype_broadcaster = (
-            float(request.form.get("archetype_broadcaster", "0")) / 100.0
-        )
-        archetype_explorer = float(request.form.get("archetype_explorer", "0")) / 100.0
-
-        # Get transition probabilities
-        trans_val_val = float(request.form.get("trans_val_val", "0")) / 100.0
-        trans_val_broad = float(request.form.get("trans_val_broad", "0")) / 100.0
-        trans_val_expl = float(request.form.get("trans_val_expl", "0")) / 100.0
-        trans_broad_broad = float(request.form.get("trans_broad_broad", "0")) / 100.0
-        trans_broad_val = float(request.form.get("trans_broad_val", "0")) / 100.0
-        trans_broad_expl = float(request.form.get("trans_broad_expl", "0")) / 100.0
-        trans_expl_expl = float(request.form.get("trans_expl_expl", "0")) / 100.0
-        trans_expl_val = float(request.form.get("trans_expl_val", "0")) / 100.0
-        trans_expl_broad = float(request.form.get("trans_expl_broad", "0")) / 100.0
-    except (ValueError, TypeError) as e:
-        flash(f"Invalid input values: {str(e)}", "error")
-        return redirect(request.referrer)
-
-    # Validate that percentages sum to approximately 100%
-    archetype_sum = archetype_validator + archetype_broadcaster + archetype_explorer
-    if abs(archetype_sum - 1.0) > 0.01:
-        flash(
-            f"Archetype percentages must sum to 100% (current sum: {archetype_sum * 100:.1f}%)",
-            "error",
-        )
-        return redirect(request.referrer)
-
-    # Validate transition probabilities sum to 100% for each row
-    val_sum = trans_val_val + trans_val_broad + trans_val_expl
-    broad_sum = trans_broad_broad + trans_broad_val + trans_broad_expl
-    expl_sum = trans_expl_expl + trans_expl_val + trans_expl_broad
-
-    if abs(val_sum - 1.0) > 0.01:
-        flash(
-            f"Validator transition probabilities must sum to 100% (current sum: {val_sum * 100:.1f}%)",
-            "error",
-        )
-        return redirect(request.referrer)
-    if abs(broad_sum - 1.0) > 0.01:
-        flash(
-            f"Broadcaster transition probabilities must sum to 100% (current sum: {broad_sum * 100:.1f}%)",
-            "error",
-        )
-        return redirect(request.referrer)
-    if abs(expl_sum - 1.0) > 0.01:
-        flash(
-            f"Explorer transition probabilities must sum to 100% (current sum: {expl_sum * 100:.1f}%)",
-            "error",
-        )
-        return redirect(request.referrer)
-
-    # Get client details
-    client = Client.query.filter_by(id=uid).first()
-    if not client:
-        flash("Client not found.", "error")
-        return redirect(request.referrer)
-
-    # Update client with new values
-    client.archetype_validator = archetype_validator
-    client.archetype_broadcaster = archetype_broadcaster
-    client.archetype_explorer = archetype_explorer
-    client.trans_val_val = trans_val_val
-    client.trans_val_broad = trans_val_broad
-    client.trans_val_expl = trans_val_expl
-    client.trans_broad_broad = trans_broad_broad
-    client.trans_broad_val = trans_broad_val
-    client.trans_broad_expl = trans_broad_expl
-    client.trans_expl_expl = trans_expl_expl
-    client.trans_expl_val = trans_expl_val
-    client.trans_expl_broad = trans_expl_broad
-
-    db.session.commit()
-
-    # Update client configuration JSON file
-    experiment = Exps.query.filter_by(idexp=client.id_exp).first()
-    population = Population.query.filter_by(id=client.population_id).first()
-
-    from y_web.utils.path_utils import get_writable_path
-
-    BASE = get_writable_path()
-    exp_folder = experiment.db_name.split(os.sep)[1]
-
-    path = f"{BASE}{os.sep}y_web{os.sep}experiments{os.sep}{exp_folder}{os.sep}client_{client.name}-{population.name}.json"
-
-    if os.path.exists(path):
-        with open(path, "r") as f:
-            config = json.load(f)
-
-            # Add agent archetypes section if not present
-            if "agent_archetypes" not in config:
-                config["agent_archetypes"] = {}
-
-            config["agent_archetypes"] = {
-                "distribution": {
-                    "validator": archetype_validator,
-                    "broadcaster": archetype_broadcaster,
-                    "explorer": archetype_explorer,
-                },
-                "transitions": {
-                    "validator": {
-                        "validator": trans_val_val,
-                        "broadcaster": trans_val_broad,
-                        "explorer": trans_val_expl,
-                    },
-                    "broadcaster": {
-                        "validator": trans_broad_val,
-                        "broadcaster": trans_broad_broad,
-                        "explorer": trans_broad_expl,
-                    },
-                    "explorer": {
-                        "validator": trans_expl_val,
-                        "broadcaster": trans_expl_broad,
-                        "explorer": trans_expl_expl,
-                    },
-                },
-            }
-
-            # Save the new configuration
-            with open(path, "w") as f:
-                json.dump(config, f, indent=4)
-    else:
-        flash("Configuration file not found.", "error")
-
-    flash("Agent archetypes updated successfully.", "success")
-    return redirect(request.referrer)
-
-
-@clientsr.route("/admin/reset_agent_archetypes/<int:uid>")
-@login_required
-def reset_agent_archetypes(uid):
-    """Reset agent archetypes and transitions to default Bluesky values."""
-    check_privileges(current_user.username)
-
-    # Get client details
-    client = Client.query.filter_by(id=uid).first()
-    if not client:
-        flash("Client not found.", "error")
-        return redirect(request.referrer)
-
-    # Reset to default Bluesky values
-    client.archetype_validator = 0.52
-    client.archetype_broadcaster = 0.20
-    client.archetype_explorer = 0.28
-    client.trans_val_val = 0.853
-    client.trans_val_broad = 0.081
-    client.trans_val_expl = 0.066
-    client.trans_broad_broad = 0.729
-    client.trans_broad_val = 0.195
-    client.trans_broad_expl = 0.075
-    client.trans_expl_expl = 0.490
-    client.trans_expl_val = 0.364
-    client.trans_expl_broad = 0.146
-
-    db.session.commit()
-
-    # Update client configuration JSON file
-    experiment = Exps.query.filter_by(idexp=client.id_exp).first()
-    population = Population.query.filter_by(id=client.population_id).first()
-
-    from y_web.utils.path_utils import get_writable_path
-
-    BASE = get_writable_path()
-    exp_folder = experiment.db_name.split(os.sep)[1]
-
-    path = f"{BASE}{os.sep}y_web{os.sep}experiments{os.sep}{exp_folder}{os.sep}client_{client.name}-{population.name}.json"
-
-    if os.path.exists(path):
-        with open(path, "r") as f:
-            config = json.load(f)
-
-            config["agent_archetypes"] = {
-                "distribution": {
-                    "validator": 0.52,
-                    "broadcaster": 0.20,
-                    "explorer": 0.28,
-                },
-                "transitions": {
-                    "validator": {
-                        "validator": 0.853,
-                        "broadcaster": 0.081,
-                        "explorer": 0.066,
-                    },
-                    "broadcaster": {
-                        "validator": 0.195,
-                        "broadcaster": 0.729,
-                        "explorer": 0.075,
-                    },
-                    "explorer": {
-                        "validator": 0.364,
-                        "broadcaster": 0.146,
-                        "explorer": 0.490,
-                    },
-                },
-            }
-
-            # Save the new configuration
-            with open(path, "w") as f:
-                json.dump(config, f, indent=4)
-    else:
-        flash("Configuration file not found.", "error")
-
-    flash("Agent archetypes reset to default values.", "success")
     return redirect(request.referrer)
 
 
@@ -1942,617 +2342,3 @@ def update_llm(uid):
 
     db.session.commit()
     return redirect(request.referrer)
-
-
-@clientsr.route("/admin/opinion_configuration/<int:idexp>")
-@login_required
-def opinion_configuration(idexp):
-    """Display opinion configuration page for experiments with opinions annotation."""
-    check_privileges(current_user.username)
-
-    # Get client_id from query parameters
-    client_id = request.args.get("client_id", type=int)
-    if not client_id:
-        flash("Client ID is required.", "error")
-        return redirect(url_for("experiments.experiment_details", uid=idexp))
-
-    # Get experiment details
-    exp = Exps.query.filter_by(idexp=idexp).first()
-    if not exp:
-        flash("Experiment not found.", "error")
-        return redirect(url_for("experiments.settings"))
-
-    # Get client details
-    client = Client.query.filter_by(id=client_id).first()
-    if not client or client.id_exp != idexp:
-        flash("Client not found or does not belong to this experiment.", "error")
-        return redirect(url_for("experiments.experiment_details", uid=idexp))
-
-    # Verify that opinions annotation is present
-    annotations = (
-        {an.strip(): None for an in exp.annotations.split(",")}
-        if exp.annotations and exp.annotations.strip()
-        else {}
-    )
-    if "opinions" not in annotations:
-        flash("This experiment does not have opinions annotation.", "warning")
-        return redirect(url_for("experiments.experiment_details", uid=idexp))
-
-    # Get experiment topics
-    topics = Exp_Topic.query.filter_by(exp_id=idexp).all()
-    topics_ids = [t.topic_id for t in topics]
-    topics = db.session.query(Topic_List).filter(Topic_List.id.in_(topics_ids)).all()
-    topics = [{"id": t.id, "name": t.name} for t in topics]
-
-    # Get population and load population JSON file to get actual segment values
-    population = Population.query.filter_by(id=client.population_id).first()
-    if not population:
-        flash("Population not found.", "error")
-        return redirect(url_for("experiments.experiment_details", uid=idexp))
-
-    # Load population JSON file to get actual segment values
-    from y_web.utils import get_db_type
-    from y_web.utils.path_utils import get_writable_path
-
-    writable_base = get_writable_path()
-    dbtype = get_db_type()
-
-    if dbtype == "sqlite":
-        exp_folder = exp.db_name.split(os.sep)[1]
-    else:
-        exp_folder = exp.db_name.removeprefix("experiments_")
-
-    population_file = os.path.join(
-        writable_base,
-        "y_web",
-        "experiments",
-        exp_folder,
-        f"{population.name.replace(' ', '')}.json",
-    )
-
-    # Load age classes from database to map individual ages to age groups
-    age_classes = AgeClass.query.all()
-    age_class_map = {}
-    for ac in age_classes:
-        age_class_map[ac.name] = (ac.age_start, ac.age_end)
-
-    # Read population data to get actual segment values
-    segment_values = {
-        "age": set(),
-        "political_leaning": set(),
-        "gender": set(),
-        "education_level": set(),
-    }
-
-    try:
-        if os.path.exists(population_file):
-            with open(population_file, "r") as f:
-                pop_data = json.load(f)
-                for agent in pop_data.get("agents", []):
-                    if not agent.get("is_page", 0):  # Exclude pages
-                        age = agent.get("age")
-                        if age:
-                            # Map individual age to age class
-                            age_class_found = False
-                            for class_name, (start, end) in age_class_map.items():
-                                if start <= age <= end:
-                                    segment_values["age"].add(class_name)
-                                    age_class_found = True
-                                    break
-                            if not age_class_found:
-                                # If no age class found, use the raw age
-                                segment_values["age"].add(f"{age}")
-
-                        leaning = agent.get("leaning")
-                        if leaning:
-                            segment_values["political_leaning"].add(str(leaning))
-
-                        gender = agent.get("gender")
-                        if gender:
-                            segment_values["gender"].add(str(gender))
-
-                        education = agent.get("education_level")
-                        if education:
-                            segment_values["education_level"].add(str(education))
-            print(f"Successfully loaded population file: {population_file}")
-        else:
-            print(f"Population file does not exist: {population_file}")
-            flash(
-                "Warning: Population file not found. Segment values may be limited.",
-                "warning",
-            )
-    except Exception as e:
-        print(f"Error reading population file: {e}")
-        flash(
-            f"Warning: Error reading population file. Segment values may be limited.",
-            "warning",
-        )
-
-    # Convert sets to sorted lists
-    segment_values = {k: sorted(list(v)) for k, v in segment_values.items()}
-    print(f"Extracted segment values: {segment_values}")
-
-    # Fetch available distribution types from the OpinionDistribution table
-    opinion_distributions = OpinionDistribution.query.all()
-
-    # Create a list of distribution dictionaries with name, type, and parameters
-    distributions = []
-    for dist in opinion_distributions:
-        try:
-            params = json.loads(dist.parameters)
-            distributions.append(
-                {
-                    "id": dist.id,
-                    "name": dist.name,
-                    "type": dist.distribution_type,
-                    "parameters": params,
-                }
-            )
-        except json.JSONDecodeError:
-            print(f"Warning: Invalid JSON parameters for distribution {dist.name}")
-            continue
-
-    # Extract just the names for the dropdown
-    distribution_names = [d["name"] for d in distributions]
-
-    # Fetch opinion groups from the database
-    opinion_groups = OpinionGroup.query.order_by(OpinionGroup.lower_bound).all()
-
-    # Create bins and labels from opinion groups
-    # If no groups exist, use default bins
-    if opinion_groups:
-        # Create bins from group boundaries
-        bins = []
-        labels = []
-        for group in opinion_groups:
-            bins.append(group.lower_bound)
-            labels.append(group.name)
-        # Add the upper bound of the last group
-        bins.append(opinion_groups[-1].upper_bound)
-    else:
-        # Default to 5 bins if no groups defined
-        bins = [0.0, 0.25, 0.5, 0.75, 1.0]
-        labels = ["0.0", "0.25", "0.5", "0.75"]
-
-    # Define available segmentation dimensions
-    segmentation_options = [
-        {"id": "age", "name": "Age Classes"},
-        {"id": "political_leaning", "name": "Political Leaning"},
-        {"id": "gender", "name": "Gender"},
-        {"id": "education_level", "name": "Education Level"},
-    ]
-
-    return render_template(
-        "admin/opinion_configuration.html",
-        experiment=exp,
-        client=client,
-        topics=topics,
-        distributions=distributions,
-        distribution_names=distribution_names,
-        opinion_groups=opinion_groups,
-        bins=bins,
-        labels=labels,
-        segmentation_options=segmentation_options,
-        segment_values=segment_values,
-        llm_agents_enabled=(
-            exp.llm_agents_enabled if hasattr(exp, "llm_agents_enabled") else False
-        ),
-    )
-
-
-@clientsr.route("/admin/set_opinion_distributions", methods=["POST"])
-@login_required
-def set_opinion_distributions():
-    """Handle opinion distribution configuration submission and update population JSON."""
-    check_privileges(current_user.username)
-
-    # Get experiment ID and client ID from form
-    idexp = request.form.get("idexp")
-    client_id = request.form.get("client_id")
-
-    if not idexp:
-        flash("Experiment ID is missing.", "error")
-        return redirect(url_for("experiments.settings"))
-
-    if not client_id:
-        flash("Client ID is missing.", "error")
-        return redirect(url_for("experiments.experiment_details", uid=idexp))
-
-    # Get experiment and client details
-    exp = Exps.query.filter_by(idexp=idexp).first()
-    if not exp:
-        flash("Experiment not found.", "error")
-        return redirect(url_for("experiments.settings"))
-
-    client = Client.query.filter_by(id=client_id).first()
-    if not client or client.id_exp != int(idexp):
-        flash("Client not found or does not belong to this experiment.", "error")
-        return redirect(url_for("experiments.experiment_details", uid=idexp))
-
-    # Get population
-    population = Population.query.filter_by(id=client.population_id).first()
-    if not population:
-        flash("Population not found.", "error")
-        return redirect(url_for("experiments.experiment_details", uid=idexp))
-
-    # Get the selected segmentation dimensions
-    segmentation = request.form.get("segmentation", "")
-    selected_dimensions = [d.strip() for d in segmentation.split(",") if d.strip()]
-
-    # Parse form data to extract topic-segment-distribution mappings
-    # Form fields are named: dist_topic_{topic_id}_segment_{segment_index}
-    # Each select also has data-segment-name attribute with the actual segment name
-    topic_segment_distributions = {}
-
-    for key, value in request.form.items():
-        if key.startswith("dist_topic_"):
-            # Parse the field name: dist_topic_{topic_id}_segment_{segment_index}
-            parts = key.split("_")
-            if len(parts) >= 4:
-                topic_id = int(parts[2])
-                segment_index = int(parts[4])
-                distribution_name = value
-
-                if topic_id not in topic_segment_distributions:
-                    topic_segment_distributions[topic_id] = {}
-
-                topic_segment_distributions[topic_id][segment_index] = distribution_name
-
-    # Get experiment topics
-    topics = Exp_Topic.query.filter_by(exp_id=idexp).all()
-    topics_ids = [t.topic_id for t in topics]
-    topics_list = (
-        db.session.query(Topic_List).filter(Topic_List.id.in_(topics_ids)).all()
-    )
-    topic_id_to_name = {t.id: t.name for t in topics_list}
-
-    # Load age classes for segment identification
-    age_classes = AgeClass.query.all()
-    age_class_map = {}
-    for ac in age_classes:
-        age_class_map[ac.name] = (ac.age_start, ac.age_end)
-
-    # Load population JSON file
-    from y_web.utils import get_db_type
-    from y_web.utils.path_utils import get_writable_path
-
-    writable_base = get_writable_path()
-    dbtype = get_db_type()
-
-    if dbtype == "sqlite":
-        exp_folder = exp.db_name.split(os.sep)[1]
-    else:
-        exp_folder = exp.db_name.removeprefix("experiments_")
-
-    population_file = os.path.join(
-        writable_base,
-        "y_web",
-        "experiments",
-        exp_folder,
-        f"{population.name.replace(' ', '')}.json",
-    )
-
-    if not os.path.exists(population_file):
-        flash(f"Population file not found: {population_file}", "error")
-        return redirect(url_for("experiments.experiment_details", uid=idexp))
-
-    # Load population data
-    try:
-        with open(population_file, "r") as f:
-            pop_data = json.load(f)
-    except Exception as e:
-        flash(f"Error loading population file: {str(e)}", "error")
-        return redirect(url_for("experiments.experiment_details", uid=idexp))
-
-    # Get all opinion distributions from database
-    opinion_distributions = OpinionDistribution.query.all()
-    distributions_map = {}
-    for dist in opinion_distributions:
-        try:
-            params = json.loads(dist.parameters)
-            distributions_map[dist.name] = {
-                "type": dist.distribution_type,
-                "parameters": params,
-            }
-        except json.JSONDecodeError as e:
-            error_msg = (
-                f"Invalid JSON parameters for distribution '{dist.name}': {str(e)}"
-            )
-            print(f"Warning: {error_msg}")
-            flash(error_msg, "warning")
-
-    # Helper function to identify segment for an agent
-    def get_agent_segment(agent_data, dimensions):
-        """Determine the segment for an agent based on selected dimensions."""
-        if not dimensions:
-            return "All Population"
-
-        segment_parts = []
-        for dim in dimensions:
-            if dim == "age":
-                age = agent_data.get("age")
-                if age:
-                    # Map age to age class
-                    age_class_found = False
-                    for class_name, (start, end) in age_class_map.items():
-                        if start <= age <= end:
-                            segment_parts.append(class_name)
-                            age_class_found = True
-                            break
-                    if not age_class_found:
-                        # Use "Other" for ages that don't fit any defined class
-                        segment_parts.append(f"Age-{age}")
-            elif dim == "political_leaning":
-                leaning = agent_data.get("leaning")
-                if leaning:
-                    segment_parts.append(str(leaning))
-            elif dim == "gender":
-                gender = agent_data.get("gender")
-                if gender:
-                    segment_parts.append(str(gender))
-            elif dim == "education_level":
-                education = agent_data.get("education_level")
-                if education:
-                    segment_parts.append(str(education))
-
-        return " - ".join(segment_parts) if segment_parts else "All Population"
-
-    # Helper function to get segment index
-    def get_segment_index(segment_name, dimensions, pop_data_agents):
-        """Get the segment index based on segment name and dimensions."""
-        # Generate all possible segments in the same order as the frontend
-        if not dimensions:
-            return 0
-
-        # Collect unique values for each dimension from the population
-        dimension_values = {dim: set() for dim in dimensions}
-
-        for agent in pop_data_agents:
-            if agent.get("is_page", 0):
-                continue
-
-            for dim in dimensions:
-                if dim == "age":
-                    age = agent.get("age")
-                    if age:
-                        for class_name, (start, end) in age_class_map.items():
-                            if start <= age <= end:
-                                dimension_values[dim].add(class_name)
-                                break
-                elif dim == "political_leaning":
-                    leaning = agent.get("leaning")
-                    if leaning:
-                        dimension_values[dim].add(str(leaning))
-                elif dim == "gender":
-                    gender = agent.get("gender")
-                    if gender:
-                        dimension_values[dim].add(str(gender))
-                elif dim == "education_level":
-                    education = agent.get("education_level")
-                    if education:
-                        dimension_values[dim].add(str(education))
-
-        # Sort values for each dimension
-        dimension_values = {k: sorted(list(v)) for k, v in dimension_values.items()}
-
-        # Generate all segments in order
-        segments = [""]
-        for dim in dimensions:
-            values = dimension_values.get(dim, [])
-            if not values:
-                continue
-
-            new_segments = []
-            for segment in segments:
-                for value in values:
-                    new_segments.append(segment + " - " + value if segment else value)
-            segments = new_segments
-
-        # Find the index of our segment
-        try:
-            return segments.index(segment_name)
-        except ValueError:
-            return 0
-
-    # Helper function to sample from a distribution
-    def sample_from_distribution(distribution_name):
-        """Sample a value from the specified distribution."""
-        if distribution_name not in distributions_map:
-            # Default to uniform random if distribution not found
-            return random.random()
-
-        dist_info = distributions_map[distribution_name]
-        dist_type = dist_info["type"]
-        params = dist_info["parameters"]
-
-        try:
-            if dist_type == "uniform":
-                return np.random.uniform(0, 1)
-            elif dist_type == "normal":
-                loc = params.get("loc", 0.5)
-                scale = params.get("scale", 0.2)
-                # Clip to [0, 1] range
-                value = np.random.normal(loc, scale)
-                return max(0.0, min(1.0, value))
-            elif dist_type == "beta":
-                a = params.get("a", 2)
-                b = params.get("b", 5)
-                return np.random.beta(a, b)
-            elif dist_type == "exponential":
-                scale = params.get("scale", 1)
-                # Scale and clip to [0, 1]
-                value = np.random.exponential(scale)
-                return max(0.0, min(1.0, value))
-            elif dist_type == "gamma":
-                shape = params.get("shape", 2)
-                scale = params.get("scale", 1)
-                # Scale and clip to [0, 1] using DISTRIBUTION_SCALE_FACTOR
-                value = np.random.gamma(shape, scale)
-                return max(0.0, min(1.0, value / DISTRIBUTION_SCALE_FACTOR))
-            elif dist_type == "lognormal":
-                mean = params.get("mean", 0)
-                sigma = params.get("sigma", 1)
-                # Scale and clip to [0, 1] using DISTRIBUTION_SCALE_FACTOR
-                value = np.random.lognormal(mean, sigma)
-                return max(0.0, min(1.0, value / DISTRIBUTION_SCALE_FACTOR))
-            elif dist_type == "bimodal":
-                peak1 = params.get("peak1", 0.2)
-                peak2 = params.get("peak2", 0.8)
-                sigma = params.get("sigma", 0.15)
-                # Randomly choose one of the two peaks
-                if np.random.random() < 0.5:
-                    value = np.random.normal(peak1, sigma)
-                else:
-                    value = np.random.normal(peak2, sigma)
-                return max(0.0, min(1.0, value))
-            elif dist_type == "polarized":
-                # Sample from extremes (0 or 1 with some noise)
-                if np.random.random() < 0.5:
-                    value = np.random.normal(0.0, 0.1)
-                else:
-                    value = np.random.normal(1.0, 0.1)
-                return max(0.0, min(1.0, value))
-            else:
-                # Default to uniform if type not recognized
-                return np.random.uniform(0, 1)
-        except Exception as e:
-            error_msg = (
-                f"Error sampling from distribution '{distribution_name}': {str(e)}"
-            )
-            print(f"Warning: {error_msg}")
-            flash(error_msg, "warning")
-            return random.random()
-
-    # Process each agent in the population
-    updated_count = 0
-    for agent in pop_data.get("agents", []):
-        # Skip pages
-        if agent.get("is_page", 0):
-            continue
-
-        # Get agent's segment
-        agent_segment = get_agent_segment(agent, selected_dimensions)
-        segment_index = get_segment_index(
-            agent_segment, selected_dimensions, pop_data["agents"]
-        )
-
-        # Get agent's interests (topics)
-        interests = agent.get("interests", [])
-        if isinstance(interests, list) and len(interests) > 0:
-            topic_names = interests[0] if isinstance(interests[0], list) else interests
-        else:
-            topic_names = []
-
-        # Initialize or update opinions for this agent
-        if "opinions" not in agent or agent["opinions"] is None:
-            agent["opinions"] = {}
-
-        # For each topic the agent is interested in
-        for topic_name in topic_names:
-            # Find the topic ID
-            topic_id = None
-            for tid, tname in topic_id_to_name.items():
-                if tname == topic_name:
-                    topic_id = tid
-                    break
-
-            if topic_id is None:
-                continue
-
-            # Get the distribution for this topic-segment combination
-            if topic_id in topic_segment_distributions:
-                if segment_index in topic_segment_distributions[topic_id]:
-                    distribution_name = topic_segment_distributions[topic_id][
-                        segment_index
-                    ]
-                    # Sample a value from the distribution
-                    opinion_value = sample_from_distribution(distribution_name)
-                    agent["opinions"][topic_name] = opinion_value
-                    updated_count += 1
-
-    # Save the updated population JSON file
-    try:
-        with open(population_file, "w") as f:
-            json.dump(pop_data, f, indent=4)
-        flash(
-            f"Successfully updated opinions for {updated_count} agent-topic pairs.",
-            "success",
-        )
-    except Exception as e:
-        flash(f"Error saving population file: {str(e)}", "error")
-        return redirect(url_for("experiments.experiment_details", uid=idexp))
-
-    # Update client configuration JSON with opinion dynamics settings
-    # Get opinion update rule from form
-    update_rule = request.form.get("update_rule", "bounded_confidence")
-
-    # Build opinion dynamics configuration based on selected rule
-    opinion_dynamics = {"model_name": update_rule, "parameters": {}}
-
-    if update_rule == "bounded_confidence":
-        # Collect bounded confidence parameters
-        bc_epsilon = request.form.get("bc_epsilon", "0.25")
-        bc_mu = request.form.get("bc_mu", "0.5")
-        bc_theta = request.form.get("bc_theta", "0")
-        bc_cold_start = request.form.get("bc_cold_start", "neutral")
-
-        opinion_dynamics["parameters"] = {
-            "epsilon": float(bc_epsilon),
-            "mu": float(bc_mu),
-            "theta": float(bc_theta),
-            "cold_start": bc_cold_start,
-        }
-    elif update_rule == "llm_evaluation":
-        # Collect LLM evaluation parameters
-        llm_cold_start = request.form.get("llm_cold_start", "neutral")
-        llm_evaluation_scope = request.form.get(
-            "llm_evaluation_scope", "interlocutor_only"
-        )
-
-        opinion_dynamics["parameters"] = {
-            "cold_start": llm_cold_start,
-            "evaluation_scope": llm_evaluation_scope,
-        }
-
-    # Add opinion groups from database
-    opinion_groups = OpinionGroup.query.order_by(OpinionGroup.lower_bound).all()
-    opinion_groups_dict = {}
-    for group in opinion_groups:
-        opinion_groups_dict[group.name.rstrip()] = [
-            group.lower_bound,
-            group.upper_bound,
-        ]
-
-    opinion_dynamics["opinion_groups"] = opinion_groups_dict
-
-    # Load and update client configuration JSON file
-    client_config_file = os.path.join(
-        writable_base,
-        "y_web",
-        "experiments",
-        exp_folder,
-        f"client_{client.name}-{population.name}.json",
-    )
-
-    if os.path.exists(client_config_file):
-        try:
-            with open(client_config_file, "r") as f:
-                client_config = json.load(f)
-
-            # Add opinion_dynamics to simulation section
-            if "simulation" not in client_config:
-                client_config["simulation"] = {}
-
-            client_config["simulation"]["opinion_dynamics"] = opinion_dynamics
-
-            # Save updated configuration
-            with open(client_config_file, "w") as f:
-                json.dump(client_config, f, indent=4)
-
-            flash("Opinion dynamics configuration saved successfully.", "success")
-        except Exception as e:
-            flash(f"Error updating client configuration: {str(e)}", "warning")
-    else:
-        flash(f"Client configuration file not found: {client_config_file}", "warning")
-
-    return redirect(url_for("experiments.experiment_details", uid=idexp))

--- a/y_web/routes_admin/experiments_routes.py
+++ b/y_web/routes_admin/experiments_routes.py
@@ -78,18 +78,18 @@ from y_web.utils.experiment_clock import (
     default_clock_config,
     ensure_experiment_clock,
 )
+from y_web.utils.experiment_helpers import get_experiment_uid_from_db_name
 from y_web.utils.jupyter_utils import stop_process
+from y_web.utils.memory_run_id import (
+    build_memory_run_seed,
+    normalize_client_config_memory_run_id,
+)
 from y_web.utils.miscellanea import (
     check_privileges,
     llm_backend_status,
     ollama_status,
     reload_current_user,
 )
-from y_web.utils.memory_run_id import (
-    build_memory_run_seed,
-    normalize_client_config_memory_run_id,
-)
-from y_web.utils.experiment_helpers import get_experiment_uid_from_db_name
 from y_web.utils.path_utils import get_resource_path
 
 experiments = Blueprint("experiments", __name__)
@@ -760,16 +760,14 @@ def upload_experiment():
                     # Insert initial admin user
                     hashed_pw = generate_password_hash("admin", method="pbkdf2:sha256")
 
-                    stmt = text(
-                        """
+                    stmt = text("""
                         INSERT INTO user_mgmt (username, email, password, user_type, leaning, age,
                                                language, owner, joined_on, frecsys_type,
                                                round_actions, toxicity, is_page, daily_activity_level)
                         VALUES (:username, :email, :password, :user_type, :leaning, :age,
                                 :language, :owner, :joined_on, :frecsys_type,
                                 :round_actions, :toxicity, :is_page, :daily_activity_level)
-                        """
-                    )
+                        """)
 
                     dummy_conn.execute(
                         stmt,
@@ -1461,16 +1459,14 @@ def create_experiment():
                     # Insert initial admin user
                     hashed_pw = generate_password_hash("admin", method="pbkdf2:sha256")
 
-                    stmt = text(
-                        """
+                    stmt = text("""
                                 INSERT INTO user_mgmt (username, email, password, user_type, leaning, age,
                                                        language, owner, joined_on, frecsys_type,
                                                        round_actions, toxicity, is_page, daily_activity_level)
                                 VALUES (:username, :email, :password, :user_type, :leaning, :age,
                                         :language, :owner, :joined_on, :frecsys_type,
                                         :round_actions, :toxicity, :is_page, :daily_activity_level)
-                                """
-                    )
+                                """)
 
                     dummy_conn.execute(
                         stmt,
@@ -1557,17 +1553,17 @@ def create_experiment():
         llm_default=llm_default,
         llm_api_key_default=llm_api_key_default,
         llm_max_tokens_default=_normalize_llm_max_tokens(llm_max_tokens_default),
-        llm_temperature_default=float(llm_temperature_default)
-        if llm_temperature_default
-        else 1.5,
+        llm_temperature_default=(
+            float(llm_temperature_default) if llm_temperature_default else 1.5
+        ),
         llm_v_default=llm_v_default,
         llm_v_api_key_default=llm_v_api_key_default,
-        llm_v_max_tokens_default=int(llm_v_max_tokens_default)
-        if llm_v_max_tokens_default
-        else 300,
-        llm_v_temperature_default=float(llm_v_temperature_default)
-        if llm_v_temperature_default
-        else 0.5,
+        llm_v_max_tokens_default=(
+            int(llm_v_max_tokens_default) if llm_v_max_tokens_default else 300
+        ),
+        llm_v_temperature_default=(
+            float(llm_v_temperature_default) if llm_v_temperature_default else 0.5
+        ),
     )
 
     db.session.add(exp)
@@ -1695,14 +1691,12 @@ def delete_simulation(exp_id):
                 ) as conn:
                     # Terminate existing connections to the database
                     conn.execute(
-                        text(
-                            f"""
+                        text(f"""
                             SELECT pg_terminate_backend(pg_stat_activity.pid)
                             FROM pg_stat_activity
                             WHERE pg_stat_activity.datname = :dbname
                             AND pid <> pg_backend_pid()
-                            """
-                        ),
+                            """),
                         {"dbname": exp.db_name},
                     )
                     # Drop the database
@@ -2448,9 +2442,11 @@ def client_logs(client_id):
                     "call_volume": {},
                     "mean_execution_time": {},
                     "raw_log": raw_log_lines,
-                    "error": "Structured log data not available"
-                    if raw_log_lines
-                    else "Log file not found",
+                    "error": (
+                        "Structured log data not available"
+                        if raw_log_lines
+                        else "Log file not found"
+                    ),
                 }
             )
 
@@ -2827,9 +2823,10 @@ def update_url_feeds(uid):
 @login_required
 def parse_rss_feed():
     """Parse an RSS feed URL and return feed info."""
-    import feedparser
     import re
     from urllib.parse import urlparse
+
+    import feedparser
 
     feed_url = request.json.get("feed_url", "")
     if not feed_url:
@@ -3217,7 +3214,9 @@ def upload_image_feeds(uid):
                     existing = by_subreddit[subreddit]
                     combined = []
                     seen = set()
-                    for label in list(existing.get("interests") or []) + list(feed.get("interests") or []):
+                    for label in list(existing.get("interests") or []) + list(
+                        feed.get("interests") or []
+                    ):
                         label = str(label).strip()
                         if not label or label in seen:
                             continue
@@ -3353,8 +3352,9 @@ def update_feed_limits(uid):
 @login_required
 def parse_image_feed():
     """Parse a Reddit subreddit RSS feed and return image info."""
-    import feedparser
     import re
+
+    import feedparser
 
     subreddit = request.json.get("subreddit", "").strip().lower()
     if not subreddit:
@@ -3368,9 +3368,14 @@ def parse_image_feed():
     try:
         feed = feedparser.parse(feed_url)
         if feed.bozo and not feed.entries:
-            return jsonify(
-                {"error": f"Could not parse r/{subreddit} - subreddit may not exist"}
-            ), 400
+            return (
+                jsonify(
+                    {
+                        "error": f"Could not parse r/{subreddit} - subreddit may not exist"
+                    }
+                ),
+                400,
+            )
 
         if not feed.entries:
             return jsonify({"error": f"No posts found in r/{subreddit}"}), 400
@@ -4893,16 +4898,14 @@ def _create_single_experiment_copy(source_exp, new_exp_name):
                 # Insert initial admin user
                 hashed_pw = generate_password_hash("admin", method="pbkdf2:sha256")
 
-                stmt = text(
-                    """
+                stmt = text("""
                     INSERT INTO user_mgmt (username, email, password, user_type, leaning, age,
                                            language, owner, joined_on, frecsys_type,
                                            round_actions, toxicity, is_page, daily_activity_level)
                     VALUES (:username, :email, :password, :user_type, :leaning, :age,
                             :language, :owner, :joined_on, :frecsys_type,
                             :round_actions, :toxicity, :is_page, :daily_activity_level)
-                    """
-                )
+                    """)
 
                 conn.execute(
                     stmt,

--- a/y_web/routes_admin/experiments_routes.py
+++ b/y_web/routes_admin/experiments_routes.py
@@ -53,8 +53,6 @@ from y_web.models import (
     LogSyncSettings,
     Nationalities,
     Ollama_Pull,
-    OpinionDistribution,
-    OpinionGroup,
     Page,
     Page_Population,
     Population,
@@ -75,6 +73,11 @@ from y_web.utils import (
     terminate_server_process,
 )
 from y_web.utils.desktop_file_handler import send_file_desktop
+from y_web.utils.experiment_clock import (
+    apply_clock_to_client_simulation,
+    default_clock_config,
+    ensure_experiment_clock,
+)
 from y_web.utils.jupyter_utils import stop_process
 from y_web.utils.miscellanea import (
     check_privileges,
@@ -82,36 +85,154 @@ from y_web.utils.miscellanea import (
     ollama_status,
     reload_current_user,
 )
+from y_web.utils.memory_run_id import (
+    build_memory_run_seed,
+    normalize_client_config_memory_run_id,
+)
+from y_web.utils.experiment_helpers import get_experiment_uid_from_db_name
 from y_web.utils.path_utils import get_resource_path
 
 experiments = Blueprint("experiments", __name__)
 
+DEFAULT_OLLAMA_MAX_TOKENS = 768
 
-def get_experiment_uid_from_db_name(db_name):
+
+def _normalize_llm_max_tokens(raw_value):
+    try:
+        parsed = int(raw_value)
+    except (TypeError, ValueError):
+        return DEFAULT_OLLAMA_MAX_TOKENS
+    if parsed <= 0:
+        return DEFAULT_OLLAMA_MAX_TOKENS
+    return parsed
+
+
+def _normalize_username_type(raw_value, default="microblogging"):
+    """Normalize population username_type to supported values."""
+    value = str(raw_value or default).strip().lower()
+    return value if value in {"microblogging", "forum"} else default
+
+
+def _ensure_experiment_prompts_file(base_dir, exp_folder, platform_type):
+    """Ensure prompts.json exists for an experiment, creating it from defaults if needed."""
+    prompts_path = os.path.join(
+        base_dir, f"y_web{os.sep}experiments{os.sep}{exp_folder}{os.sep}prompts.json"
+    )
+    if os.path.exists(prompts_path):
+        return prompts_path
+
+    if platform_type == "microblogging":
+        prompts_src = get_resource_path(os.path.join("data_schema", "prompts.json"))
+    elif platform_type == "forum":
+        prompts_src = get_resource_path(
+            os.path.join("data_schema", "prompts_forum.json")
+        )
+    else:
+        raise ValueError(f"unsupported platform: {platform_type}")
+
+    os.makedirs(os.path.dirname(prompts_path), exist_ok=True)
+    shutil.copyfile(prompts_src, prompts_path)
+    return prompts_path
+
+
+def _repair_population_file_activity_fields(population_file_path, population_id):
     """
-    Extract the experiment UID from the db_name field.
+    Ensure runtime population JSON includes activity fields from admin DB.
 
-    This function handles both SQLite and PostgreSQL formats, and correctly
-    parses paths regardless of which path separator was used when storing.
-
-    Args:
-        db_name: The db_name field from an experiment record
-                 SQLite format: "experiments/uid/database_server.db" or "experiments\\uid\\database_server.db"
-                 PostgreSQL format: "experiments_uid"
-
-    Returns:
-        str: The experiment UID, or None if unable to extract
+    Copy-experiment can carry stale population files; this aligns agent/page
+    activity_profile (by name) and daily_activity_level with current DB records.
     """
-    if db_name.startswith("experiments_"):
-        # PostgreSQL format - UUID is after the underscore
-        return db_name.replace("experiments_", "")
-    elif db_name.startswith("experiments/") or db_name.startswith("experiments\\"):
-        # SQLite format - split using both possible separators
-        # Use regex to split on either forward slash or backslash
-        parts = re.split(r"[/\\]", db_name)
-        if len(parts) >= 2:
-            return parts[1]
-    return None
+    if not os.path.exists(population_file_path):
+        return
+
+    try:
+        with open(population_file_path, "r") as f:
+            data = json.load(f)
+    except Exception as exc:
+        current_app.logger.warning(
+            "Could not read population file %s while repairing activity fields: %s",
+            population_file_path,
+            exc,
+        )
+        return
+
+    agents_payload = data.get("agents")
+    if not isinstance(agents_payload, list):
+        return
+
+    # Build lookup tables from DB for this population.
+    profile_name_by_id = {
+        p.id: p.name for p in db.session.query(ActivityProfile).all() if p and p.name
+    }
+    agent_rows = (
+        db.session.query(Agent)
+        .join(Agent_Population, Agent_Population.agent_id == Agent.id)
+        .filter(Agent_Population.population_id == population_id)
+        .all()
+    )
+    page_rows = (
+        db.session.query(Page)
+        .join(Page_Population, Page_Population.page_id == Page.id)
+        .filter(Page_Population.population_id == population_id)
+        .all()
+    )
+
+    # Agent/page names are expected to be unique per population.
+    agent_lookup = {
+        a.name: (
+            profile_name_by_id.get(a.activity_profile),
+            int(a.daily_activity_level) if a.daily_activity_level is not None else 1,
+        )
+        for a in agent_rows
+        if a and a.name
+    }
+    page_lookup = {
+        p.name: profile_name_by_id.get(p.activity_profile)
+        for p in page_rows
+        if p and p.name
+    }
+
+    changed = False
+    repaired_activity_profile = 0
+    repaired_daily_activity = 0
+
+    for item in agents_payload:
+        if not isinstance(item, dict):
+            continue
+        name = str(item.get("name") or "").strip()
+        is_page = int(item.get("is_page", 0) or 0) == 1
+
+        if is_page:
+            db_profile_name = page_lookup.get(name)
+            if db_profile_name and item.get("activity_profile") != db_profile_name:
+                item["activity_profile"] = db_profile_name
+                repaired_activity_profile += 1
+                changed = True
+            continue
+
+        db_profile_name, db_daily_activity = agent_lookup.get(name, (None, None))
+        if db_profile_name and item.get("activity_profile") != db_profile_name:
+            item["activity_profile"] = db_profile_name
+            repaired_activity_profile += 1
+            changed = True
+
+        if (
+            db_daily_activity is not None
+            and item.get("daily_activity_level") != db_daily_activity
+        ):
+            item["daily_activity_level"] = db_daily_activity
+            repaired_daily_activity += 1
+            changed = True
+
+    if changed:
+        with open(population_file_path, "w") as f:
+            json.dump(data, f, indent=4)
+        current_app.logger.info(
+            "Repaired activity fields in %s (activity_profile=%s, daily_activity_level=%s)",
+            population_file_path,
+            repaired_activity_profile,
+            repaired_daily_activity,
+        )
 
 
 def get_suggested_port():
@@ -509,6 +630,7 @@ def upload_experiment():
 
         with open(config_path, "r") as f:
             experiment_config = json.load(f)
+        experiment_clock = ensure_experiment_clock(experiment_config)
 
         # Use override name if provided, otherwise use name from config
         name = exp_name_override if exp_name_override else experiment_config["name"]
@@ -700,6 +822,25 @@ def upload_experiment():
                     flash(f"Warning: Failed to read client config {item}: {str(e)}")
                     continue
 
+                if isinstance(client_config.get("simulation"), dict):
+                    apply_clock_to_client_simulation(
+                        client_config["simulation"], experiment_clock
+                    )
+                normalize_client_config_memory_run_id(
+                    client_config,
+                    fallback_seed=build_memory_run_seed(
+                        uid,
+                        str(
+                            (client_config.get("simulation") or {}).get("name")
+                            or item.removeprefix("client_").rsplit("-", 1)[0]
+                        ),
+                        str(
+                            (client_config.get("simulation") or {}).get("population")
+                            or item.rsplit("-", 1)[-1].removesuffix(".json")
+                        ),
+                    ),
+                )
+
                 # Update the API endpoint in servers section
                 if "servers" in client_config and "api" in client_config["servers"]:
                     try:
@@ -713,17 +854,21 @@ def upload_experiment():
                             r":(\d+)(/|$)", f":{suggested_port}\\2", old_api
                         )
                         client_config["servers"]["api"] = new_api
-
-                        with open(client_config_path, "w") as f:
-                            json.dump(client_config, f, indent=4)
                     except IOError as e:
                         flash(
-                            f"Warning: Failed to write updated client config {item}: {str(e)}"
+                            f"Warning: Failed to update port in client config {item}: {str(e)}"
                         )
                     except Exception as e:
                         flash(
                             f"Warning: Failed to update port in client config {item}: {str(e)}"
                         )
+                try:
+                    with open(client_config_path, "w") as f:
+                        json.dump(client_config, f, indent=4)
+                except IOError as e:
+                    flash(
+                        f"Warning: Failed to write updated client config {item}: {str(e)}"
+                    )
 
         exp = Exps(
             exp_name=name,
@@ -748,7 +893,7 @@ def upload_experiment():
 
         # Create Jupyter instance record
         jupyter_instance = Jupyter_instances(
-            port=-1, notebook_dir="", exp_id=exp.idexp, status="stopped"
+            port=-1, notebook_dir="", exp_id=exp.idexp, status="stopped", process=-1
         )
         db.session.add(jupyter_instance)
         db.session.commit()
@@ -800,12 +945,27 @@ def upload_experiment():
                 f"{BASE_DIR}{os.sep}y_web{os.sep}experiments{os.sep}{uid}{os.sep}{population_file}"
             )
         )
+        raw_population_username_type = pop.get("username_type")
+        if not raw_population_username_type and isinstance(
+            pop.get("population_data"), dict
+        ):
+            raw_population_username_type = pop["population_data"].get("username_type")
+        population_username_type = _normalize_username_type(
+            raw_population_username_type or exp.platform_type
+        )
 
         # check if the population already exists
         existing_population = Population.query.filter_by(name=original_name).first()
         population_created_or_reused = None  # Track if we need to create agents
 
         if existing_population:
+            existing_username_type = _normalize_username_type(
+                getattr(existing_population, "username_type", "microblogging")
+            )
+            username_type_compatible = (
+                existing_username_type == population_username_type
+            )
+
             # Population exists - need to check if agents are the same
             # Get agent names from uploaded config
             uploaded_agent_names = set()
@@ -833,7 +993,10 @@ def upload_experiment():
                     existing_agent_names.add(page.name)
 
             # Check if agents are the same
-            if uploaded_agent_names == existing_agent_names:
+            if (
+                uploaded_agent_names == existing_agent_names
+                and username_type_compatible
+            ):
                 # Agents are the same - just link existing population to experiment
                 population = existing_population
                 pop_exp = Population_Experiment(
@@ -880,7 +1043,11 @@ def upload_experiment():
                             os.rename(old_client_file, new_client_file)
 
                 # Create new population with unique name
-                population = Population(name=new_name, descr="")
+                population = Population(
+                    name=new_name,
+                    descr="",
+                    username_type=population_username_type,
+                )
                 db.session.add(population)
                 db.session.commit()
 
@@ -894,7 +1061,11 @@ def upload_experiment():
                 population_created_or_reused = None
         else:
             # Create new population and its agents
-            population = Population(name=original_name, descr="")
+            population = Population(
+                name=original_name,
+                descr="",
+                username_type=population_username_type,
+            )
             db.session.add(population)
             db.session.commit()
 
@@ -1112,6 +1283,12 @@ def upload_database():
                 f"{BASE_DIR}{os.sep}y_web{os.sep}experiments{os.sep}{uid}{os.sep}config_server.json"
             )
         )
+        ensure_experiment_clock(experiment)
+        with open(
+            f"{BASE_DIR}{os.sep}y_web{os.sep}experiments{os.sep}{uid}{os.sep}config_server.json",
+            "w",
+        ) as config_file:
+            json.dump(experiment, config_file, indent=4)
         experiment = experiment["name"]
 
         # check if the experiment already exists
@@ -1179,7 +1356,18 @@ def create_experiment():
 
     # Get LLM agents setting (convert to integer for database compatibility)
     llm_agents_enabled = 1 if request.form.get("llm_agents_enabled") == "true" else 0
-    opinions_enabled = request.form.get("opinion_annotation") == "true"
+
+    # Get experiment-wide LLM defaults
+    llm_default = request.form.get("llm_default", "http://127.0.0.1:11434/v1")
+    llm_api_key_default = request.form.get("llm_api_key_default", "NULL")
+    llm_max_tokens_default = request.form.get(
+        "llm_max_tokens_default", DEFAULT_OLLAMA_MAX_TOKENS
+    )
+    llm_temperature_default = request.form.get("llm_temperature_default", 1.5)
+    llm_v_default = request.form.get("llm_v_default", "http://127.0.0.1:11434/v1")
+    llm_v_api_key_default = request.form.get("llm_v_api_key_default", "NULL")
+    llm_v_max_tokens_default = request.form.get("llm_v_max_tokens_default", 300)
+    llm_v_temperature_default = request.form.get("llm_v_temperature_default", 0.5)
 
     # Get annotation settings
     toxicity_annotation = request.form.get("toxicity_annotation") == "true"
@@ -1326,9 +1514,9 @@ def create_experiment():
         ),
         "sentiment_annotation": sentiment_annotation,
         "emotion_annotation": emotion_annotation,
-        "opinions_enabled": opinions_enabled,
         "database_uri": db_uri,
         "topics": [t.strip() for t in topics if t.strip()],
+        "clock": default_clock_config(),
     }
 
     with open(
@@ -1336,6 +1524,8 @@ def create_experiment():
         "w",
     ) as f:
         json.dump(config, f, indent=4)
+
+    _ensure_experiment_prompts_file(BASE_DIR, uid, platform_type)
 
     # add the experiment to the database
 
@@ -1346,8 +1536,6 @@ def create_experiment():
         annotations += "sentiment,"
     if emotion_annotation:
         annotations += "emotion,"
-    if opinions_enabled:
-        annotations += "opinions,"
     # remove trailing comma
     annotations = annotations.rstrip(",")
 
@@ -1366,6 +1554,20 @@ def create_experiment():
         server=host,
         annotations=annotations,
         llm_agents_enabled=llm_agents_enabled,
+        llm_default=llm_default,
+        llm_api_key_default=llm_api_key_default,
+        llm_max_tokens_default=_normalize_llm_max_tokens(llm_max_tokens_default),
+        llm_temperature_default=float(llm_temperature_default)
+        if llm_temperature_default
+        else 1.5,
+        llm_v_default=llm_v_default,
+        llm_v_api_key_default=llm_v_api_key_default,
+        llm_v_max_tokens_default=int(llm_v_max_tokens_default)
+        if llm_v_max_tokens_default
+        else 300,
+        llm_v_temperature_default=float(llm_v_temperature_default)
+        if llm_v_temperature_default
+        else 0.5,
     )
 
     db.session.add(exp)
@@ -1378,11 +1580,32 @@ def create_experiment():
     db.session.add(exp_stats)
     db.session.commit()
 
-    # add first round to the simulation
-    rnd = Rounds(day=0, hour=0)
+    # add first round to the simulation in the experiment DB
+    from y_web.experiment_context import register_experiment_database
 
-    db.session.add(rnd)
-    db.session.commit()
+    register_experiment_database(current_app, exp.idexp, exp.db_name)
+    bind_key = f"db_exp_{exp.idexp}"
+    old_bind = current_app.config["SQLALCHEMY_BINDS"].get("db_exp")
+    current_app.config["SQLALCHEMY_BINDS"]["db_exp"] = current_app.config[
+        "SQLALCHEMY_BINDS"
+    ][bind_key]
+    try:
+        rnd = Rounds(day=0, hour=0)
+        db.session.add(rnd)
+        db.session.commit()
+    except Exception as exc:
+        db.session.rollback()
+        current_app.logger.error(
+            "Failed to create initial round for experiment %s: %s",
+            exp.idexp,
+            exc,
+            exc_info=True,
+        )
+        flash("Failed to initialize experiment database. Please retry.", "error")
+        return redirect(url_for("experiments.settings"))
+    finally:
+        if old_bind is not None:
+            current_app.config["SQLALCHEMY_BINDS"]["db_exp"] = old_bind
 
     for topic in topics:
         # check if the topic already exists in Topics
@@ -1400,7 +1623,7 @@ def create_experiment():
             db.session.commit()
 
     jn_instance = Jupyter_instances(
-        port=-1, notebook_dir="", exp_id=exp.idexp, status="stopped"
+        port=-1, notebook_dir="", exp_id=exp.idexp, status="stopped", process=-1
     )
     db.session.add(jn_instance)
     db.session.commit()
@@ -1426,36 +1649,27 @@ def create_experiment():
 @experiments.route("/admin/delete_simulation/<int:exp_id>")
 @login_required
 def delete_simulation(exp_id):
-    # get the experiment
     """Delete simulation."""
+    # get the experiment
     exp = Exps.query.filter_by(idexp=exp_id).first()
     if exp:
-        # remove the experiment folder
-        # check database type
-        if current_app.config["SQLALCHEMY_BINDS"]["db_exp"].startswith("sqlite"):
-            from y_web.utils.path_utils import get_writable_path
+        from y_web.utils.path_utils import get_writable_path
 
-            BASE_DIR = get_writable_path()
+        BASE_DIR = get_writable_path()
+
+        # Extract experiment folder using helper function
+        exp_folder = get_experiment_uid_from_db_name(exp.db_name)
+        if exp_folder:
             shutil.rmtree(
                 os.path.join(
                     BASE_DIR,
-                    f"y_web{os.sep}experiments{os.sep}{exp.db_name.split(os.sep)[1]}",
-                ),
-                ignore_errors=True,
-            )
-        elif current_app.config["SQLALCHEMY_BINDS"]["db_exp"].startswith("postgresql"):
-            # Remove experiment folder
-            from y_web.utils.path_utils import get_writable_path
-
-            BASE_DIR = get_writable_path()
-            shutil.rmtree(
-                os.path.join(
-                    BASE_DIR,
-                    f"y_web{os.sep}experiments{os.sep}{exp.db_name.removeprefix('experiments_')}",
+                    f"y_web{os.sep}experiments{os.sep}{exp_folder}",
                 ),
                 ignore_errors=True,
             )
 
+        # Drop the PostgreSQL database if using PostgreSQL
+        if current_app.config["SQLALCHEMY_BINDS"]["db_exp"].startswith("postgresql"):
             # Drop the PostgreSQL database
             try:
                 from urllib.parse import urlparse
@@ -1501,43 +1715,37 @@ def delete_simulation(exp_id):
                     f"Error dropping PostgreSQL database: {str(e)}", exc_info=True
                 )
 
-        # delete the experiment
-        db.session.delete(exp)
-        db.session.commit()
-
-        # Delete log metrics and offsets (should cascade but we do it explicitly for safety)
+        # Delete dependents before experiment to satisfy FK constraints
         db.session.query(LogFileOffset).filter_by(exp_id=exp_id).delete()
         db.session.query(ServerLogMetrics).filter_by(exp_id=exp_id).delete()
         db.session.query(ClientLogMetrics).filter_by(exp_id=exp_id).delete()
-        db.session.commit()
-
-        # remove populaiton_experiment
         db.session.query(Population_Experiment).filter_by(id_exp=exp_id).delete()
-        db.session.commit()
-
-        # delete user experiment
         db.session.query(User_Experiment).filter_by(exp_id=exp_id).delete()
+        db.session.query(ExperimentScheduleItem).filter_by(
+            experiment_id=exp_id
+        ).delete()
         db.session.commit()
 
         # get clients ids for the experiment
         clients = db.session.query(Client).filter_by(id_exp=exp_id).all()
         cids = [c.id for c in clients]
 
-        # delete the clients
-        db.session.query(Client).filter_by(id_exp=exp_id).delete()
-        db.session.commit()
-
         # delete exp stats
         db.session.query(Exp_stats).filter_by(exp_id=exp_id).delete()
         db.session.commit()
 
-        for cid in cids:
-            # delete the client executions
-            db.session.query(Client_Execution).filter_by(client_id=cid).delete()
+        # Delete client execution records first (FK constraint)
+        if cids:
+            db.session.query(Client_Execution).filter(
+                Client_Execution.client_id.in_(cids)
+            ).delete(synchronize_session=False)
             db.session.commit()
 
-            db.session.query(Client).filter_by(id=cid).delete()
-            db.session.commit()
+        # Delete clients
+        db.session.query(Client).filter_by(id_exp=exp_id).delete(
+            synchronize_session=False
+        )
+        db.session.commit()
 
         # delete experiment topics
         db.session.query(Exp_Topic).filter_by(exp_id=exp_id).delete()
@@ -1545,11 +1753,16 @@ def delete_simulation(exp_id):
 
         # delete jupyter instances
         instances = db.session.query(Jupyter_instances).filter_by(exp_id=exp_id).all()
-        try:
-            stop_process(instances.process, instances.exp_id)
-        except Exception:
-            pass
+        for instance in instances:
+            try:
+                stop_process(instance.process, instance.exp_id)
+            except Exception:
+                pass
         db.session.query(Jupyter_instances).filter_by(exp_id=exp_id).delete()
+        db.session.commit()
+
+        # delete the experiment last
+        db.session.delete(exp)
         db.session.commit()
 
     return settings()
@@ -1718,6 +1931,9 @@ def experiment_details(uid):
 
     # get experiment details
     experiment = Exps.query.filter_by(idexp=uid).first()
+    if not experiment:
+        flash("Experiment not found", "error")
+        return redirect(url_for("experiments.settings"))
 
     # get experiment populations along with population names and ids
     experiment_populations = (
@@ -1777,6 +1993,45 @@ def experiment_details(uid):
     )
 
 
+@experiments.route("/admin/update_experiment_descr/<int:uid>", methods=["POST"])
+@login_required
+def update_experiment_descr(uid: int):
+    """Update an experiment's description (used as forum "subreddit_vibe")."""
+    priv = check_privileges(current_user.username)
+    if priv is not None:
+        return priv
+
+    user = Admin_users.query.filter_by(username=current_user.username).first()
+    if not user:
+        return jsonify({"success": False, "message": "Forbidden"}), 403
+
+    exp = Exps.query.filter_by(idexp=uid).first()
+    if not exp:
+        return jsonify({"success": False, "message": "Experiment not found"}), 404
+
+    # Keep behavior consistent with experiments_data: researchers only edit their own experiments.
+    if user and user.role == "researcher" and exp.owner != user.username:
+        return jsonify({"success": False, "message": "Forbidden"}), 403
+
+    data = request.get_json(silent=True) or {}
+    exp_descr = (data.get("exp_descr") or request.form.get("exp_descr") or "").strip()
+    exp_descr = exp_descr[:200]  # DB column is String(200)
+
+    try:
+        exp.exp_descr = exp_descr
+        db.session.commit()
+    except Exception as e:
+        db.session.rollback()
+        return (
+            jsonify(
+                {"success": False, "message": f"Failed to update description: {e}"}
+            ),
+            500,
+        )
+
+    return jsonify({"success": True, "exp_descr": exp_descr}), 200
+
+
 @experiments.route("/admin/submit_experiment_logs/<int:exp_id>", methods=["POST"])
 @login_required
 def submit_experiment_logs(exp_id):
@@ -1811,15 +2066,13 @@ def submit_experiment_logs(exp_id):
     # Get experiment folder path
     BASE_DIR = get_writable_path()
 
-    # Extract experiment folder name from db_name
-    # db_name format: "experiments{sep}{folder}{sep}database_server.db"
-    db_name_parts = experiment.db_name.split(os.sep)
-    if len(db_name_parts) < 2:
+    # Extract experiment folder using helper function
+    experiment_folder_name = get_experiment_uid_from_db_name(experiment.db_name)
+    if not experiment_folder_name:
         return jsonify(
             {"success": False, "message": "Invalid experiment database path format."}
         )
 
-    experiment_folder_name = db_name_parts[1]
     experiment_folder = (
         f"{BASE_DIR}{os.sep}y_web{os.sep}experiments{os.sep}{experiment_folder_name}"
     )
@@ -2173,14 +2426,31 @@ def client_logs(client_id):
 
         # Client log file name format: {client_name}_client.log
         log_file = os.path.join(exp_folder, f"{client.name}_client.log")
+        stderr_file = os.path.join(exp_folder, f"{client.name}_client_stderr.log")
 
-        # Check if log file exists
-        if not os.path.exists(log_file):
+        # Check if main log file exists and has content
+        log_file_exists = os.path.exists(log_file) and os.path.getsize(log_file) > 0
+
+        # If main log is empty/missing, try to get recent stderr output
+        raw_log_lines = []
+        if not log_file_exists and os.path.exists(stderr_file):
+            try:
+                with open(stderr_file, "r") as f:
+                    # Read last 100 lines from stderr
+                    lines = f.readlines()
+                    raw_log_lines = [line.rstrip() for line in lines[-100:]]
+            except Exception as e:
+                current_app.logger.warning(f"Could not read stderr log: {e}")
+
+        if not log_file_exists:
             return jsonify(
                 {
                     "call_volume": {},
                     "mean_execution_time": {},
-                    "error": "Log file not found",
+                    "raw_log": raw_log_lines,
+                    "error": "Structured log data not available"
+                    if raw_log_lines
+                    else "Log file not found",
                 }
             )
 
@@ -2245,10 +2515,15 @@ def start_experiment(uid):
 
     # get experiment
     exp = Exps.query.filter_by(idexp=uid).first()
+    if not exp:
+        flash("Experiment not found", "error")
+        return redirect(url_for("experiments.settings"))
 
     # check if the experiment is already running
     if exp.running == 1:
         return experiment_details(uid)
+
+    previous_status = exp.exp_status
 
     # update the experiment status
     db.session.query(Exps).filter_by(idexp=uid).update(
@@ -2257,7 +2532,29 @@ def start_experiment(uid):
     db.session.commit()
 
     # start the yserver
-    start_server(exp)
+    try:
+        start_server(exp)
+    except Exception as e:
+        current_app.logger.error(
+            "Failed to start experiment %s server: %s",
+            uid,
+            e,
+            exc_info=True,
+        )
+        restored_status = (
+            previous_status
+            if previous_status and previous_status != "active"
+            else "stopped"
+        )
+        db.session.query(Exps).filter_by(idexp=uid).update(
+            {Exps.running: 0, Exps.exp_status: restored_status}
+        )
+        db.session.commit()
+        flash(
+            "Failed to start experiment server. Please check server logs and try again.",
+            "error",
+        )
+        return redirect(url_for("experiments.experiment_details", uid=uid))
 
     return experiment_details(uid)
 
@@ -2280,6 +2577,9 @@ def stop_experiment(uid):
 
     # get experiment
     exp = Exps.query.filter_by(idexp=uid).first()
+    if not exp:
+        flash("Experiment not found", "error")
+        return redirect(url_for("experiments.settings"))
 
     # check if the experiment is already running
     if exp.running == 0:
@@ -2331,14 +2631,25 @@ def prompts(uid):
 
     # get experiment details
     experiment = Exps.query.filter_by(idexp=uid).first()
-    # get the prompts file for the experiment
-    prompts = os.path.join(
-        BASE_DIR,
-        f"y_web{os.sep}experiments{os.sep}{experiment.db_name.split(os.sep)[1]}{os.sep}prompts.json",
-    )
+    if not experiment:
+        flash("Experiment not found", "error")
+        return redirect(url_for("experiments.settings"))
 
-    # read the prompts file
-    prompts = json.load(open(prompts))
+    # Extract experiment folder using helper function
+    exp_folder = get_experiment_uid_from_db_name(experiment.db_name)
+    if not exp_folder:
+        flash("Invalid experiment database configuration", "error")
+        return redirect(url_for("experiments.settings"))
+
+    try:
+        prompts_path = _ensure_experiment_prompts_file(
+            BASE_DIR, exp_folder, experiment.platform_type
+        )
+        with open(prompts_path, "r") as prompts_file:
+            prompts = json.load(prompts_file)
+    except Exception as e:
+        flash(f"Could not load prompts file: {e}", "error")
+        return redirect(url_for("experiments.experiment_details", uid=uid))
 
     return render_template("admin/prompts.html", experiment=experiment, prompts=prompts)
 
@@ -2355,23 +2666,780 @@ def update_prompts(uid):
 
     # get experiment details
     experiment = Exps.query.filter_by(idexp=uid).first()
-    # get the prompts file for the experiment
-    prompts_filename = os.path.join(
-        BASE_DIR,
-        f"y_web{os.sep}experiments{os.sep}{experiment.db_name.split(os.sep)[1]}{os.sep}prompts.json",
-    )
+    if not experiment:
+        flash("Experiment not found", "error")
+        return redirect(url_for("experiments.settings"))
 
-    # read the prompts file
-    prompts = json.load(open(prompts_filename))
+    # Extract experiment folder using helper function
+    exp_folder = get_experiment_uid_from_db_name(experiment.db_name)
+    if not exp_folder:
+        flash("Invalid experiment database configuration", "error")
+        return redirect(url_for("experiments.settings"))
+
+    try:
+        prompts_filename = _ensure_experiment_prompts_file(
+            BASE_DIR, exp_folder, experiment.platform_type
+        )
+        with open(prompts_filename, "r") as prompts_file:
+            prompts = json.load(prompts_file)
+    except Exception as e:
+        flash(f"Could not load prompts file: {e}", "error")
+        return redirect(url_for("experiments.experiment_details", uid=uid))
 
     # update the prompts
     for key in request.form.keys():
         prompts[key] = request.form[key]
 
     # write the updated prompts
-    json.dump(prompts, open(prompts_filename, "w"), indent=4)
+    with open(prompts_filename, "w") as prompts_file:
+        json.dump(prompts, prompts_file, indent=4)
 
     return redirect(request.referrer)
+
+
+@experiments.route("/admin/rss_feeds/<int:uid>")
+@login_required
+def rss_feeds(uid):
+    """Display and edit RSS feeds for an experiment."""
+    check_privileges(current_user.username)
+
+    from y_web.utils.path_utils import get_writable_path
+
+    BASE_DIR = get_writable_path()
+    experiment = Exps.query.filter_by(idexp=uid).first()
+    if not experiment:
+        flash("Experiment not found", "error")
+        return redirect(url_for("experiments.settings"))
+
+    # Extract experiment folder using helper function
+    exp_folder = get_experiment_uid_from_db_name(experiment.db_name)
+    if not exp_folder:
+        flash("Invalid experiment database configuration", "error")
+        return redirect(url_for("experiments.settings"))
+
+    rss_feeds_path = os.path.join(
+        BASE_DIR, f"y_web{os.sep}experiments{os.sep}{exp_folder}{os.sep}rss_feeds.json"
+    )
+    url_feeds_path = os.path.join(
+        BASE_DIR, f"y_web{os.sep}experiments{os.sep}{exp_folder}{os.sep}url_feeds.txt"
+    )
+
+    # Load existing feeds
+    rss_feeds_data = []
+    if os.path.exists(rss_feeds_path):
+        try:
+            with open(rss_feeds_path, "r") as f:
+                rss_feeds_data = json.load(f)
+        except (json.JSONDecodeError, IOError):
+            rss_feeds_data = []
+
+    url_feeds_data = []
+    if os.path.exists(url_feeds_path):
+        try:
+            with open(url_feeds_path, "r") as f:
+                url_feeds_data = [line.strip() for line in f if line.strip()]
+        except IOError:
+            url_feeds_data = []
+
+    return render_template(
+        "admin/rss_feeds.html",
+        experiment=experiment,
+        rss_feeds=rss_feeds_data,
+        url_feeds=url_feeds_data,
+    )
+
+
+@experiments.route("/admin/update_rss_feeds/<int:uid>", methods=["POST"])
+@login_required
+def update_rss_feeds(uid):
+    """Update RSS feeds for an experiment."""
+    check_privileges(current_user.username)
+
+    from y_web.utils.path_utils import get_writable_path
+
+    BASE_DIR = get_writable_path()
+    experiment = Exps.query.filter_by(idexp=uid).first()
+    if not experiment:
+        flash("Experiment not found", "error")
+        return redirect(url_for("experiments.settings"))
+
+    # Extract experiment folder using helper function
+    exp_folder = get_experiment_uid_from_db_name(experiment.db_name)
+    if not exp_folder:
+        flash("Invalid experiment database configuration", "error")
+        return redirect(url_for("experiments.settings"))
+
+    rss_feeds_path = os.path.join(
+        BASE_DIR, f"y_web{os.sep}experiments{os.sep}{exp_folder}{os.sep}rss_feeds.json"
+    )
+
+    # Get feeds from form
+    feeds_json = request.form.get("rss_feeds_json", "[]")
+    try:
+        feeds = json.loads(feeds_json)
+    except json.JSONDecodeError:
+        flash("Invalid RSS feeds payload; changes were not saved.", "error")
+        return redirect(request.referrer or url_for("experiments.rss_feeds", uid=uid))
+
+    # Write the updated feeds
+    with open(rss_feeds_path, "w") as f:
+        json.dump(feeds, f, indent=2)
+
+    return redirect(request.referrer)
+
+
+@experiments.route("/admin/update_url_feeds/<int:uid>", methods=["POST"])
+@login_required
+def update_url_feeds(uid):
+    """Update URL feeds for an experiment."""
+    check_privileges(current_user.username)
+
+    from y_web.utils.path_utils import get_writable_path
+
+    BASE_DIR = get_writable_path()
+    experiment = Exps.query.filter_by(idexp=uid).first()
+    if not experiment:
+        flash("Experiment not found", "error")
+        return redirect(url_for("experiments.settings"))
+
+    # Extract experiment folder using helper function
+    exp_folder = get_experiment_uid_from_db_name(experiment.db_name)
+    if not exp_folder:
+        flash("Invalid experiment database configuration", "error")
+        return redirect(url_for("experiments.settings"))
+
+    url_feeds_path = os.path.join(
+        BASE_DIR, f"y_web{os.sep}experiments{os.sep}{exp_folder}{os.sep}url_feeds.txt"
+    )
+
+    # Get URLs from form
+    urls_text = request.form.get("url_feeds_text", "")
+    urls = [line.strip() for line in urls_text.split("\n") if line.strip()]
+
+    # Write the updated URLs
+    with open(url_feeds_path, "w") as f:
+        f.write("\n".join(urls))
+
+    return redirect(request.referrer)
+
+
+@experiments.route("/admin/api/parse_rss_feed", methods=["POST"])
+@login_required
+def parse_rss_feed():
+    """Parse an RSS feed URL and return feed info."""
+    import feedparser
+    import re
+    from urllib.parse import urlparse
+
+    feed_url = request.json.get("feed_url", "")
+    if not feed_url:
+        return jsonify({"error": "No URL provided"}), 400
+
+    try:
+        # Detect Reddit RSS feed
+        # Pattern: reddit.com/r/{subreddit}[/sort].rss
+        reddit_pattern = re.compile(
+            r"^https?://(?:www\.)?reddit\.com/r/([\w]+)(?:/(?:new|hot|top|rising))?\.rss$",
+            re.IGNORECASE,
+        )
+        reddit_match = reddit_pattern.match(feed_url)
+
+        feed = feedparser.parse(feed_url)
+        if feed.bozo and not feed.entries:
+            return jsonify({"error": "Invalid RSS feed URL"}), 400
+
+        parsed_url = urlparse(feed_url)
+        url_site = parsed_url.netloc
+
+        if reddit_match:
+            subreddit = reddit_match.group(1)
+            return jsonify(
+                {
+                    "name": f"r/{subreddit}",
+                    "feed_url": feed_url,
+                    "url_site": "reddit.com",
+                    "description": f"Reddit r/{subreddit} - External article links only",
+                    "entries_count": len(feed.entries),
+                    "is_reddit": True,
+                    "subreddit": subreddit,
+                }
+            )
+
+        return jsonify(
+            {
+                "name": feed.feed.get("title", url_site),
+                "feed_url": feed_url,
+                "url_site": url_site,
+                "description": feed.feed.get("description", ""),
+                "entries_count": len(feed.entries),
+                "is_reddit": False,
+            }
+        )
+    except Exception as e:
+        return jsonify({"error": str(e)}), 400
+
+
+@experiments.route("/admin/upload_rss_feeds/<int:uid>", methods=["POST"])
+@login_required
+def upload_rss_feeds(uid):
+    """Upload bulk RSS feeds from JSON file."""
+    check_privileges(current_user.username)
+
+    from y_web.utils.path_utils import get_writable_path
+
+    BASE_DIR = get_writable_path()
+    experiment = Exps.query.filter_by(idexp=uid).first()
+    if not experiment:
+        return jsonify({"error": "Experiment not found"}), 404
+
+    # Extract experiment folder using helper function
+    exp_folder = get_experiment_uid_from_db_name(experiment.db_name)
+    if not exp_folder:
+        return jsonify({"error": "Invalid experiment database configuration"}), 400
+
+    rss_feeds_path = os.path.join(
+        BASE_DIR, f"y_web{os.sep}experiments{os.sep}{exp_folder}{os.sep}rss_feeds.json"
+    )
+
+    if "file" not in request.files:
+        return jsonify({"error": "No file provided"}), 400
+
+    file = request.files["file"]
+    if file.filename == "":
+        return jsonify({"error": "No file selected"}), 400
+
+    try:
+        content = file.read().decode("utf-8")
+        new_feeds = json.loads(content)
+
+        if not isinstance(new_feeds, list):
+            return jsonify({"error": "JSON must be an array of feeds"}), 400
+
+        mode = request.form.get("mode", "replace")
+
+        if mode == "merge":
+            # Load existing feeds and merge
+            existing_feeds = []
+            if os.path.exists(rss_feeds_path):
+                with open(rss_feeds_path, "r") as f:
+                    existing_feeds = json.load(f)
+
+            # Merge by feed_url (avoid duplicates)
+            existing_urls = {f.get("feed_url") for f in existing_feeds}
+            for feed in new_feeds:
+                if feed.get("feed_url") not in existing_urls:
+                    existing_feeds.append(feed)
+            new_feeds = existing_feeds
+
+        with open(rss_feeds_path, "w") as f:
+            json.dump(new_feeds, f, indent=2)
+
+        return jsonify({"success": True, "count": len(new_feeds)})
+    except json.JSONDecodeError:
+        return jsonify({"error": "Invalid JSON format"}), 400
+    except Exception as e:
+        return jsonify({"error": str(e)}), 400
+
+
+@experiments.route("/admin/upload_url_feeds/<int:uid>", methods=["POST"])
+@login_required
+def upload_url_feeds(uid):
+    """Upload bulk URL feeds from text file."""
+    check_privileges(current_user.username)
+
+    from y_web.utils.path_utils import get_writable_path
+
+    BASE_DIR = get_writable_path()
+    experiment = Exps.query.filter_by(idexp=uid).first()
+    if not experiment:
+        return jsonify({"error": "Experiment not found"}), 404
+
+    # Extract experiment folder using helper function
+    exp_folder = get_experiment_uid_from_db_name(experiment.db_name)
+    if not exp_folder:
+        return jsonify({"error": "Invalid experiment database configuration"}), 400
+
+    url_feeds_path = os.path.join(
+        BASE_DIR, f"y_web{os.sep}experiments{os.sep}{exp_folder}{os.sep}url_feeds.txt"
+    )
+
+    if "file" not in request.files:
+        return jsonify({"error": "No file provided"}), 400
+
+    file = request.files["file"]
+    if file.filename == "":
+        return jsonify({"error": "No file selected"}), 400
+
+    try:
+        content = file.read().decode("utf-8")
+
+        # Try to parse as JSON array first
+        try:
+            urls = json.loads(content)
+            if isinstance(urls, list):
+                urls = [str(u).strip() for u in urls if u]
+            else:
+                urls = [line.strip() for line in content.split("\n") if line.strip()]
+        except json.JSONDecodeError:
+            # Parse as plain text (one URL per line)
+            urls = [line.strip() for line in content.split("\n") if line.strip()]
+
+        mode = request.form.get("mode", "replace")
+
+        if mode == "merge":
+            # Load existing URLs and merge
+            existing_urls = set()
+            if os.path.exists(url_feeds_path):
+                with open(url_feeds_path, "r") as f:
+                    existing_urls = {line.strip() for line in f if line.strip()}
+
+            urls = list(existing_urls | set(urls))
+
+        with open(url_feeds_path, "w") as f:
+            f.write("\n".join(urls))
+
+        return jsonify({"success": True, "count": len(urls)})
+    except Exception as e:
+        return jsonify({"error": str(e)}), 400
+
+
+# ============================================================================
+# Image Feeds Management (for standalone image sharing from Reddit subreddits)
+# ============================================================================
+
+
+@experiments.route("/admin/image_feeds/<int:uid>")
+@login_required
+def image_feeds(uid):
+    """Display and edit image feeds for an experiment."""
+    check_privileges(current_user.username)
+
+    from y_web.utils.path_utils import get_writable_path
+
+    BASE_DIR = get_writable_path()
+    experiment = Exps.query.filter_by(idexp=uid).first()
+    if not experiment:
+        flash("Experiment not found", "error")
+        return redirect(url_for("experiments.settings"))
+
+    # Extract experiment folder using helper function
+    exp_folder = get_experiment_uid_from_db_name(experiment.db_name)
+    if not exp_folder:
+        flash("Invalid experiment database configuration", "error")
+        return redirect(url_for("experiments.settings"))
+
+    image_feeds_path = os.path.join(
+        BASE_DIR,
+        f"y_web{os.sep}experiments{os.sep}{exp_folder}{os.sep}image_feeds.json",
+    )
+
+    # Load existing image feeds
+    image_feeds_data = []
+    if os.path.exists(image_feeds_path):
+        try:
+            with open(image_feeds_path, "r") as f:
+                image_feeds_data = json.load(f)
+        except (json.JSONDecodeError, IOError):
+            image_feeds_data = []
+
+    # Default interests list
+    available_interests = [
+        "humor",
+        "entertainment",
+        "fun",
+        "memes",
+        "photography",
+        "travel",
+        "nature",
+        "general",
+        "animals",
+        "pets",
+        "wholesome",
+        "cute",
+        "technology",
+        "gaming",
+        "science",
+        "geek",
+        "art",
+        "design",
+        "creative",
+        "music",
+        "sports",
+        "fitness",
+        "food",
+        "cooking",
+        "movies",
+        "tv",
+        "celebrities",
+        "news",
+        "politics",
+        "history",
+        "education",
+        "books",
+    ]
+
+    return render_template(
+        "admin/image_feeds.html",
+        experiment=experiment,
+        image_feeds=image_feeds_data,
+        available_interests=sorted(available_interests),
+    )
+
+
+@experiments.route("/admin/update_image_feeds/<int:uid>", methods=["POST"])
+@login_required
+def update_image_feeds(uid):
+    """Update image feeds for an experiment."""
+    check_privileges(current_user.username)
+
+    from y_web.utils.path_utils import get_writable_path
+
+    BASE_DIR = get_writable_path()
+    experiment = Exps.query.filter_by(idexp=uid).first()
+    if not experiment:
+        flash("Experiment not found", "error")
+        return redirect(url_for("experiments.settings"))
+
+    # Extract experiment folder using helper function
+    exp_folder = get_experiment_uid_from_db_name(experiment.db_name)
+    if not exp_folder:
+        flash("Invalid experiment database configuration", "error")
+        return redirect(url_for("experiments.settings"))
+
+    image_feeds_path = os.path.join(
+        BASE_DIR,
+        f"y_web{os.sep}experiments{os.sep}{exp_folder}{os.sep}image_feeds.json",
+    )
+
+    # Get feeds from form
+    feeds_json = request.form.get("image_feeds_json", "[]")
+    try:
+        feeds = json.loads(feeds_json)
+    except json.JSONDecodeError:
+        flash("Invalid image feeds payload; changes were not saved.", "error")
+        return redirect(request.referrer or url_for("experiments.image_feeds", uid=uid))
+
+    # Write the updated feeds
+    with open(image_feeds_path, "w") as f:
+        json.dump(feeds, f, indent=2)
+
+    return redirect(request.referrer)
+
+
+@experiments.route("/admin/upload_image_feeds/<int:uid>", methods=["POST"])
+@login_required
+def upload_image_feeds(uid):
+    """Upload bulk image feeds from JSON file."""
+    check_privileges(current_user.username)
+
+    from y_web.utils.path_utils import get_writable_path
+
+    BASE_DIR = get_writable_path()
+    experiment = Exps.query.filter_by(idexp=uid).first()
+    if not experiment:
+        return jsonify({"error": "Experiment not found"}), 404
+
+    exp_folder = get_experiment_uid_from_db_name(experiment.db_name)
+    if not exp_folder:
+        return jsonify({"error": "Invalid experiment database configuration"}), 400
+
+    image_feeds_path = os.path.join(
+        BASE_DIR,
+        f"y_web{os.sep}experiments{os.sep}{exp_folder}{os.sep}image_feeds.json",
+    )
+
+    if "file" not in request.files:
+        return jsonify({"error": "No file provided"}), 400
+
+    file = request.files["file"]
+    if file.filename == "":
+        return jsonify({"error": "No file selected"}), 400
+
+    try:
+        content = file.read().decode("utf-8")
+        new_feeds = json.loads(content)
+        if not isinstance(new_feeds, list):
+            return jsonify({"error": "JSON must be an array of image feeds"}), 400
+
+        normalized_feeds = []
+        seen_subreddits = set()
+        for item in new_feeds:
+            if not isinstance(item, dict):
+                continue
+            subreddit = str(item.get("subreddit", "")).strip().lower()
+            subreddit = subreddit[2:] if subreddit.startswith("r/") else subreddit
+            interests = item.get("interests") or []
+            if not subreddit:
+                continue
+            if not isinstance(interests, list):
+                interests = [str(interests).strip()] if str(interests).strip() else []
+            clean_interests = []
+            seen_interests = set()
+            for interest in interests:
+                label = str(interest).strip()
+                if not label or label in seen_interests:
+                    continue
+                seen_interests.add(label)
+                clean_interests.append(label)
+            if subreddit in seen_subreddits:
+                continue
+            seen_subreddits.add(subreddit)
+            normalized_feeds.append(
+                {
+                    "subreddit": subreddit,
+                    "interests": clean_interests,
+                }
+            )
+
+        mode = request.form.get("mode", "replace")
+        if mode == "merge":
+            existing_feeds = []
+            if os.path.exists(image_feeds_path):
+                with open(image_feeds_path, "r") as f:
+                    existing_feeds = json.load(f)
+            merged = []
+            by_subreddit = {}
+            for feed in existing_feeds:
+                if not isinstance(feed, dict):
+                    continue
+                subreddit = str(feed.get("subreddit", "")).strip().lower()
+                if not subreddit:
+                    continue
+                merged_feed = {
+                    "subreddit": subreddit,
+                    "interests": list(feed.get("interests") or []),
+                }
+                merged.append(merged_feed)
+                by_subreddit[subreddit] = merged_feed
+            for feed in normalized_feeds:
+                subreddit = feed["subreddit"]
+                if subreddit in by_subreddit:
+                    existing = by_subreddit[subreddit]
+                    combined = []
+                    seen = set()
+                    for label in list(existing.get("interests") or []) + list(feed.get("interests") or []):
+                        label = str(label).strip()
+                        if not label or label in seen:
+                            continue
+                        seen.add(label)
+                        combined.append(label)
+                    existing["interests"] = combined
+                else:
+                    merged.append(feed)
+                    by_subreddit[subreddit] = feed
+            normalized_feeds = merged
+
+        with open(image_feeds_path, "w") as f:
+            json.dump(normalized_feeds, f, indent=2)
+
+        return jsonify({"success": True, "count": len(normalized_feeds)})
+    except json.JSONDecodeError:
+        return jsonify({"error": "Invalid JSON format"}), 400
+    except Exception as e:
+        return jsonify({"error": str(e)}), 400
+
+
+# Default feed limits for when config doesn't have them
+DEFAULT_FEED_LIMITS = {
+    "rss_entries_per_feed": 100,
+    "reddit_entries_per_feed": 200,
+    "reddit_pages": 2,
+    "reddit_rate_limit_seconds": 2,
+    "db_fallback_limit": 50,
+    "image_entries_per_feed": 100,
+}
+
+
+@experiments.route("/admin/feed_limits/<uid>", methods=["GET"])
+@login_required
+def feed_limits(uid):
+    """Display and edit feed retrieval limits for an experiment."""
+    check_privileges(current_user.username)
+
+    from y_web.utils.path_utils import get_writable_path
+
+    BASE_DIR = get_writable_path()
+    experiment = Exps.query.filter_by(idexp=uid).first()
+    if not experiment:
+        flash("Experiment not found", "error")
+        return redirect(url_for("experiments.settings"))
+
+    # Extract experiment folder using helper function
+    exp_folder = get_experiment_uid_from_db_name(experiment.db_name)
+    if not exp_folder:
+        flash("Invalid experiment database configuration", "error")
+        return redirect(url_for("experiments.settings"))
+
+    config_path = os.path.join(
+        BASE_DIR, f"y_web{os.sep}experiments{os.sep}{exp_folder}{os.sep}config.json"
+    )
+
+    # Load existing config and extract feed_limits
+    feed_limits_data = dict(DEFAULT_FEED_LIMITS)  # Start with defaults
+    if os.path.exists(config_path):
+        try:
+            with open(config_path, "r") as f:
+                config = json.load(f)
+                if "feed_limits" in config:
+                    feed_limits_data.update(config["feed_limits"])
+        except (json.JSONDecodeError, IOError):
+            pass
+
+    return render_template(
+        "admin/feed_limits.html",
+        experiment=experiment,
+        feed_limits=feed_limits_data,
+    )
+
+
+@experiments.route("/admin/update_feed_limits/<uid>", methods=["POST"])
+@login_required
+def update_feed_limits(uid):
+    """Update feed limits for an experiment."""
+    check_privileges(current_user.username)
+
+    from y_web.utils.path_utils import get_writable_path
+
+    BASE_DIR = get_writable_path()
+    experiment = Exps.query.filter_by(idexp=uid).first()
+    if not experiment:
+        flash("Experiment not found", "error")
+        return redirect(url_for("experiments.settings"))
+
+    # Extract experiment folder using helper function
+    exp_folder = get_experiment_uid_from_db_name(experiment.db_name)
+    if not exp_folder:
+        flash("Invalid experiment database configuration", "error")
+        return redirect(url_for("experiments.settings"))
+
+    config_path = os.path.join(
+        BASE_DIR, f"y_web{os.sep}experiments{os.sep}{exp_folder}{os.sep}config.json"
+    )
+
+    # Load existing config
+    config = {}
+    if os.path.exists(config_path):
+        try:
+            with open(config_path, "r") as f:
+                config = json.load(f)
+        except (json.JSONDecodeError, IOError):
+            config = {}
+
+    # Update feed_limits from form
+    feed_limits = {
+        "rss_entries_per_feed": int(request.form.get("rss_entries_per_feed", 100)),
+        "reddit_entries_per_feed": int(
+            request.form.get("reddit_entries_per_feed", 200)
+        ),
+        "reddit_pages": int(request.form.get("reddit_pages", 2)),
+        "reddit_rate_limit_seconds": float(
+            request.form.get("reddit_rate_limit_seconds", 2)
+        ),
+        "db_fallback_limit": int(request.form.get("db_fallback_limit", 50)),
+        "image_entries_per_feed": int(request.form.get("image_entries_per_feed", 100)),
+    }
+
+    config["feed_limits"] = feed_limits
+
+    # Write the updated config
+    with open(config_path, "w") as f:
+        json.dump(config, f, indent=2)
+
+    flash("Feed limits updated successfully.", "success")
+    return redirect(request.referrer or f"/admin/feed_limits/{uid}")
+
+
+@experiments.route("/admin/api/parse_image_feed", methods=["POST"])
+@login_required
+def parse_image_feed():
+    """Parse a Reddit subreddit RSS feed and return image info."""
+    import feedparser
+    import re
+
+    subreddit = request.json.get("subreddit", "").strip().lower()
+    if not subreddit:
+        return jsonify({"error": "No subreddit provided"}), 400
+
+    # Remove r/ prefix if present
+    subreddit = subreddit.lstrip("r/")
+
+    feed_url = f"https://www.reddit.com/r/{subreddit}.rss"
+
+    try:
+        feed = feedparser.parse(feed_url)
+        if feed.bozo and not feed.entries:
+            return jsonify(
+                {"error": f"Could not parse r/{subreddit} - subreddit may not exist"}
+            ), 400
+
+        if not feed.entries:
+            return jsonify({"error": f"No posts found in r/{subreddit}"}), 400
+
+        # Image URL patterns
+        image_pattern = re.compile(r"\.(jpg|jpeg|png|gif|webp)(\?.*)?$", re.IGNORECASE)
+        image_hosts = ["i.redd.it", "i.imgur.com", "preview.redd.it"]
+
+        images = []
+        nsfw_count = 0
+
+        for entry in feed.entries[:50]:
+            # Skip NSFW posts
+            is_nsfw = False
+            # Check for NSFW in various fields
+            if hasattr(entry, "over_18") and entry.over_18:
+                is_nsfw = True
+            elif "[nsfw]" in entry.get("title", "").lower():
+                is_nsfw = True
+            elif hasattr(entry, "tags"):
+                for tag in entry.tags:
+                    if tag.get("term", "").lower() == "nsfw":
+                        is_nsfw = True
+                        break
+
+            if is_nsfw:
+                nsfw_count += 1
+                continue
+
+            # Try to extract image URL
+            image_url = None
+
+            # Method 1: Direct link to image
+            link = entry.get("link", "")
+            if image_pattern.search(link) or any(host in link for host in image_hosts):
+                image_url = link
+
+            # Method 2: media_content
+            if not image_url and hasattr(entry, "media_content"):
+                for media in entry.media_content:
+                    url = media.get("url", "")
+                    if image_pattern.search(url) or any(
+                        host in url for host in image_hosts
+                    ):
+                        image_url = url
+                        break
+
+            # Method 3: media_thumbnail
+            if not image_url and hasattr(entry, "media_thumbnail"):
+                for thumb in entry.media_thumbnail:
+                    url = thumb.get("url", "")
+                    if url:
+                        image_url = url
+                        break
+
+            if image_url:
+                images.append(image_url)
+
+        return jsonify(
+            {
+                "subreddit": subreddit,
+                "feed_url": feed_url,
+                "image_count": len(images),
+                "nsfw_filtered": nsfw_count,
+                "sample_images": images[:5],  # Return first 5 as samples
+            }
+        )
+    except Exception as e:
+        return jsonify({"error": str(e)}), 400
 
 
 @experiments.route("/admin/download_experiment/<int:eid>", methods=["POST", "GET"])
@@ -2391,24 +3459,26 @@ def download_experiment_file(eid):
 
     # get experiment details
     experiment = Exps.query.filter_by(idexp=eid).first()
+    if not experiment:
+        flash("Experiment not found", "error")
+        return redirect(url_for("experiments.settings"))
+
+    # Extract experiment folder using helper function
+    exp_folder = get_experiment_uid_from_db_name(experiment.db_name)
+    if not exp_folder:
+        flash("Invalid experiment database configuration", "error")
+        return redirect(url_for("experiments.settings"))
 
     # Determine database type
     db_type = "sqlite"
     if current_app.config["SQLALCHEMY_DATABASE_URI"].startswith("postgresql"):
         db_type = "postgresql"
 
-    # Get folder path based on database type
-    if db_type == "sqlite":
-        folder = os.path.join(
-            BASE_DIR,
-            f"y_web{os.sep}experiments{os.sep}{experiment.db_name.split(os.sep)[1]}",
-        )
-    else:
-        # PostgreSQL: extract UUID from db_name (format: experiments_uuid)
-        folder = os.path.join(
-            BASE_DIR,
-            f"y_web{os.sep}experiments{os.sep}{experiment.db_name.removeprefix('experiments_')}",
-        )
+    # Get folder path
+    folder = os.path.join(
+        BASE_DIR,
+        f"y_web{os.sep}experiments{os.sep}{exp_folder}",
+    )
 
     # For PostgreSQL, create an SQLite copy of the database
     if db_type == "postgresql":
@@ -2580,18 +3650,16 @@ def download_experiments_bulk():
             if not experiment:
                 continue
 
-            # Get folder path based on database type
-            if db_type == "sqlite":
-                folder = os.path.join(
-                    BASE_DIR,
-                    f"y_web{os.sep}experiments{os.sep}{experiment.db_name.split(os.sep)[1]}",
-                )
-            else:
-                # PostgreSQL: extract UUID from db_name (format: experiments_uuid)
-                folder = os.path.join(
-                    BASE_DIR,
-                    f"y_web{os.sep}experiments{os.sep}{experiment.db_name.removeprefix('experiments_')}",
-                )
+            # Extract experiment folder using helper function
+            exp_folder = get_experiment_uid_from_db_name(experiment.db_name)
+            if not exp_folder:
+                continue
+
+            # Get folder path
+            folder = os.path.join(
+                BASE_DIR,
+                f"y_web{os.sep}experiments{os.sep}{exp_folder}",
+            )
 
             if not os.path.exists(folder):
                 continue
@@ -2747,14 +3815,14 @@ def miscellanea():
 
     # Get telemetry and watchdog settings for the current admin user
     telemetry_enabled = getattr(user, "telemetry_enabled", True)
-    watchdog_interval = 15  # Default watchdog interval
+    watchdog_interval = 1  # Default watchdog interval
 
     # Try to get watchdog interval from the watchdog status
     try:
         from y_web.utils.process_watchdog import get_watchdog_status
 
         status = get_watchdog_status()
-        watchdog_interval = status.get("run_interval_minutes", 15)
+        watchdog_interval = status.get("run_interval_minutes", 1)
     except ImportError:
         # process_watchdog module not available
         pass
@@ -3692,20 +4760,14 @@ def _create_single_experiment_copy(source_exp, new_exp_name):
 
     # Determine database type
     db_type = "sqlite"
-    if current_app.config["SQLALCHEMY_DATABASE_URI"].startswith("postgresql"):
+    db_uri = current_app.config.get("SQLALCHEMY_DATABASE_URI", "")
+    if isinstance(db_uri, str) and db_uri.startswith("postgresql"):
         db_type = "postgresql"
 
-    # Extract source experiment folder
-    if db_type == "sqlite":
-        # Source: experiments/old_uid/database_server.db -> old_uid
-        source_parts = source_exp.db_name.split(os.sep)
-        if len(source_parts) >= 2:
-            source_uid = source_parts[1]
-        else:
-            return False
-    else:
-        # PostgreSQL: experiments_old_uid -> old_uid
-        source_uid = source_exp.db_name.replace("experiments_", "")
+    # Extract source experiment folder using helper function
+    source_uid = get_experiment_uid_from_db_name(source_exp.db_name)
+    if not source_uid:
+        return False
 
     from y_web.utils.path_utils import get_writable_path
 
@@ -3876,6 +4938,7 @@ def _create_single_experiment_copy(source_exp, new_exp_name):
 
     with open(config_path, "r") as f:
         config = json.load(f)
+    experiment_clock = ensure_experiment_clock(config)
 
     # Update all necessary fields
     config["name"] = new_exp_name
@@ -3908,6 +4971,24 @@ def _create_single_experiment_copy(source_exp, new_exp_name):
             try:
                 with open(client_config_path, "r") as f:
                     client_config = json.load(f)
+                if isinstance(client_config.get("simulation"), dict):
+                    apply_clock_to_client_simulation(
+                        client_config["simulation"], experiment_clock
+                    )
+                normalize_client_config_memory_run_id(
+                    client_config,
+                    fallback_seed=build_memory_run_seed(
+                        new_uid,
+                        str(
+                            (client_config.get("simulation") or {}).get("name")
+                            or item.removeprefix("client_").rsplit("-", 1)[0]
+                        ),
+                        str(
+                            (client_config.get("simulation") or {}).get("population")
+                            or item.rsplit("-", 1)[-1].removesuffix(".json")
+                        ),
+                    ),
+                )
 
                 # Update the API endpoint in servers section
                 if "servers" in client_config and "api" in client_config["servers"]:
@@ -3919,9 +5000,8 @@ def _create_single_experiment_copy(source_exp, new_exp_name):
 
                     new_api = re.sub(r":(\d+)(/|$)", f":{suggested_port}\\2", old_api)
                     client_config["servers"]["api"] = new_api
-
-                    with open(client_config_path, "w") as f:
-                        json.dump(client_config, f, indent=4)
+                with open(client_config_path, "w") as f:
+                    json.dump(client_config, f, indent=4)
             except Exception as e:
                 # Continue anyway - this is not critical enough to fail the entire copy
                 current_app.logger.warning(
@@ -4029,10 +5109,24 @@ def _create_single_experiment_copy(source_exp, new_exp_name):
 
     # Create Jupyter instance record
     jupyter_instance = Jupyter_instances(
-        port=-1, notebook_dir="", exp_id=new_exp.idexp, status="stopped"
+        port=-1, notebook_dir="", exp_id=new_exp.idexp, status="stopped", process=-1
     )
     db.session.add(jupyter_instance)
     db.session.commit()
+
+    # Repair copied population JSON files so runtime activity profiles always match DB.
+    # This avoids stale files causing zero-active-agent runs after copy.
+    copied_populations = (
+        db.session.query(Population)
+        .join(
+            Population_Experiment, Population_Experiment.id_population == Population.id
+        )
+        .filter(Population_Experiment.id_exp == new_exp.idexp)
+        .all()
+    )
+    for pop in copied_populations:
+        pop_file = os.path.join(new_folder, f"{pop.name.replace(' ', '')}.json")
+        _repair_population_file_activity_fields(pop_file, pop.id)
 
     return True
 
@@ -4611,7 +5705,16 @@ def start_schedule():
             db.session.commit()
 
             # Start the server
-            start_server(exp)
+            try:
+                start_server(exp)
+            except Exception as e:
+                msg = f"Failed to start server for '{exp.exp_name}': {e}"
+                logs.append(msg)
+                db.session.add(ExperimentScheduleLog(message=msg, log_type="error"))
+                exp.running = 0
+                exp.exp_status = "stopped"
+                db.session.commit()
+                continue
             started_count += 1
 
             # Wait for server to be ready
@@ -4878,7 +5981,16 @@ def check_schedule_progress():
             exp.running = 1
             exp.exp_status = "active"
             db.session.commit()
-            start_server(exp)
+            try:
+                start_server(exp)
+            except Exception as e:
+                msg = f"Failed to start server for '{exp.exp_name}': {e}"
+                logs.append(msg)
+                db.session.add(ExperimentScheduleLog(message=msg, log_type="error"))
+                exp.running = 0
+                exp.exp_status = "stopped"
+                db.session.commit()
+                continue
 
             # Wait for server to be ready
             logs.append(f"Waiting for server '{exp.exp_name}' to be ready...")
@@ -5225,749 +6337,3 @@ def cleanup_completed_groups():
         add_schedule_log(f"Cleaned up {count} completed group(s)", "info")
 
     return jsonify({"success": True, "removed_count": count})
-
-
-# ========================================
-# Opinion Dynamics Routes
-# ========================================
-
-
-@experiments.route("/admin/opinion_groups_data")
-@login_required
-def opinion_groups_data():
-    """Display opinion groups data page."""
-    query = OpinionGroup.query
-
-    # search filter
-    search = request.args.get("search")
-    if search:
-        query = query.filter(db.or_(OpinionGroup.name.like(f"%{search}%")))
-    total = query.count()
-
-    # sorting
-    sort = request.args.get("sort")
-    if sort:
-        order = []
-        for s in sort.split(","):
-            direction = s[0]
-            name = s[1:]
-            if name not in ["name", "lower_bound", "upper_bound"]:
-                name = "name"
-            col = getattr(OpinionGroup, name)
-            if direction == "-":
-                col = col.desc()
-            order.append(col)
-        if order:
-            query = query.order_by(*order)
-
-    # pagination
-    start = request.args.get("start", type=int, default=-1)
-    length = request.args.get("length", type=int, default=-1)
-    if start != -1 and length != -1:
-        query = query.offset(start).limit(length)
-
-    # response
-    res = query.all()
-
-    res = {
-        "data": [
-            {
-                "id": group.id,
-                "name": group.name,
-                "lower_bound": group.lower_bound,
-                "upper_bound": group.upper_bound,
-            }
-            for group in res
-        ],
-        "total": total,
-    }
-
-    return res
-
-
-@experiments.route("/admin/opinion_groups_data", methods=["POST"])
-@login_required
-def update_opinion_group():
-    """Update opinion group data (for inline editing)."""
-    check_privileges(current_user.username)
-
-    data = request.get_json()
-    group_id = data.get("id")
-    group = OpinionGroup.query.filter_by(id=group_id).first()
-
-    if not group:
-        return jsonify({"success": False, "message": "Opinion group not found"}), 404
-
-    # Update fields if provided
-    if "name" in data:
-        group.name = data["name"]
-    if "lower_bound" in data:
-        try:
-            lower_bound = float(data["lower_bound"])
-            if not (0 <= lower_bound <= 1):
-                return (
-                    jsonify(
-                        {"success": False, "message": "Lower bound must be in [0, 1]"}
-                    ),
-                    400,
-                )
-            group.lower_bound = lower_bound
-        except ValueError:
-            return (
-                jsonify({"success": False, "message": "Invalid lower_bound value"}),
-                400,
-            )
-    if "upper_bound" in data:
-        try:
-            upper_bound = float(data["upper_bound"])
-            if not (0 <= upper_bound <= 1):
-                return (
-                    jsonify(
-                        {"success": False, "message": "Upper bound must be in [0, 1]"}
-                    ),
-                    400,
-                )
-            group.upper_bound = upper_bound
-        except ValueError:
-            return (
-                jsonify({"success": False, "message": "Invalid upper_bound value"}),
-                400,
-            )
-
-    # Validate that lower_bound <= upper_bound
-    if group.lower_bound > group.upper_bound:
-        return (
-            jsonify(
-                {"success": False, "message": "Lower bound must be <= upper bound"}
-            ),
-            400,
-        )
-
-    # Check for overlaps with other existing groups
-    existing_groups = OpinionGroup.query.filter(OpinionGroup.id != group_id).all()
-    for existing in existing_groups:
-        # Check if the updated group overlaps with any other existing group
-        # Two ranges [a1, a2] and [b1, b2] overlap if: a1 < b2 AND b1 < a2
-        if (
-            group.lower_bound < existing.upper_bound
-            and existing.lower_bound < group.upper_bound
-        ):
-            return (
-                jsonify(
-                    {
-                        "success": False,
-                        "message": f"Overlaps with '{existing.name}' [{existing.lower_bound}, {existing.upper_bound}]",
-                    }
-                ),
-                400,
-            )
-
-    db.session.commit()
-    return jsonify({"success": True})
-
-
-@experiments.route("/admin/create_opinion_group", methods=["POST"])
-@login_required
-def create_opinion_group():
-    """Create opinion group."""
-    check_privileges(current_user.username)
-
-    name = request.form.get("name")
-    lower_bound = request.form.get("lower_bound")
-    upper_bound = request.form.get("upper_bound")
-
-    try:
-        lower_bound = float(lower_bound)
-        upper_bound = float(upper_bound)
-    except (ValueError, TypeError):
-        flash("Invalid bound values. Must be numbers.", "error")
-        return redirect(request.referrer)
-
-    # Validate bounds are in [0, 1] and lower <= upper
-    if not (0 <= lower_bound <= 1 and 0 <= upper_bound <= 1):
-        flash("Bounds must be in the range [0, 1].", "error")
-        return redirect(request.referrer)
-
-    if lower_bound > upper_bound:
-        flash("Lower bound must be less than or equal to upper bound.", "error")
-        return redirect(request.referrer)
-
-    # Check for overlaps with existing groups
-    existing_groups = OpinionGroup.query.all()
-    for existing in existing_groups:
-        # Check if the new group overlaps with any existing group
-        # Two ranges [a1, a2] and [b1, b2] overlap if: a1 < b2 AND b1 < a2
-        if lower_bound < existing.upper_bound and existing.lower_bound < upper_bound:
-            flash(
-                f"Opinion group overlaps with existing group '{existing.name}' "
-                f"[{existing.lower_bound}, {existing.upper_bound}]. "
-                "Groups must not overlap.",
-                "error",
-            )
-            return redirect(request.referrer)
-
-    group = OpinionGroup(name=name, lower_bound=lower_bound, upper_bound=upper_bound)
-    db.session.add(group)
-    db.session.commit()
-
-    return redirect(request.referrer)
-
-
-@experiments.route("/admin/delete_opinion_group/<int:group_id>", methods=["DELETE"])
-@login_required
-def delete_opinion_group(group_id):
-    """Delete opinion group."""
-    check_privileges(current_user.username)
-
-    group = OpinionGroup.query.filter_by(id=group_id).first()
-    if not group:
-        return jsonify({"success": False, "message": "Opinion group not found"}), 404
-
-    db.session.delete(group)
-    db.session.commit()
-    return jsonify({"success": True})
-
-
-@experiments.route("/admin/opinion_distributions_data")
-@login_required
-def opinion_distributions_data():
-    """Display opinion distributions data page."""
-    query = OpinionDistribution.query
-
-    # search filter
-    search = request.args.get("search")
-    if search:
-        query = query.filter(
-            db.or_(
-                OpinionDistribution.name.like(f"%{search}%"),
-                OpinionDistribution.distribution_type.like(f"%{search}%"),
-            )
-        )
-    total = query.count()
-
-    # sorting
-    sort = request.args.get("sort")
-    if sort:
-        order = []
-        for s in sort.split(","):
-            direction = s[0]
-            name = s[1:]
-            if name not in ["name", "distribution_type"]:
-                name = "name"
-            col = getattr(OpinionDistribution, name)
-            if direction == "-":
-                col = col.desc()
-            order.append(col)
-        if order:
-            query = query.order_by(*order)
-
-    # pagination
-    start = request.args.get("start", type=int, default=-1)
-    length = request.args.get("length", type=int, default=-1)
-    if start != -1 and length != -1:
-        query = query.offset(start).limit(length)
-
-    # response
-    res = query.all()
-
-    res = {
-        "data": [
-            {
-                "id": dist.id,
-                "name": dist.name,
-                "distribution_type": dist.distribution_type,
-                "parameters": dist.parameters,
-            }
-            for dist in res
-        ],
-        "total": total,
-    }
-
-    return res
-
-
-@experiments.route("/admin/opinion_distributions_data", methods=["POST"])
-@login_required
-def update_opinion_distribution():
-    """Update opinion distribution data (for inline editing)."""
-    check_privileges(current_user.username)
-
-    data = request.get_json()
-    dist_id = data.get("id")
-    dist = OpinionDistribution.query.filter_by(id=dist_id).first()
-
-    if not dist:
-        return (
-            jsonify({"success": False, "message": "Opinion distribution not found"}),
-            404,
-        )
-
-    # Update fields if provided
-    if "name" in data:
-        dist.name = data["name"]
-
-    db.session.commit()
-    return jsonify({"success": True})
-
-
-@experiments.route("/admin/create_opinion_distribution", methods=["POST"])
-@login_required
-def create_opinion_distribution():
-    """Create opinion distribution."""
-    check_privileges(current_user.username)
-
-    name = request.form.get("name")
-    distribution_type = request.form.get("distribution_type")
-    parameters = request.form.get("parameters")  # JSON string
-
-    # Validate JSON parameters
-    try:
-        json.loads(parameters)
-    except (json.JSONDecodeError, TypeError):
-        flash("Invalid parameters format. Must be valid JSON.", "error")
-        return redirect(request.referrer)
-
-    dist = OpinionDistribution(
-        name=name, distribution_type=distribution_type, parameters=parameters
-    )
-    db.session.add(dist)
-    db.session.commit()
-
-    return redirect(request.referrer)
-
-
-@experiments.route(
-    "/admin/delete_opinion_distribution/<int:dist_id>", methods=["DELETE"]
-)
-@login_required
-def delete_opinion_distribution(dist_id):
-    """Delete opinion distribution."""
-    check_privileges(current_user.username)
-
-    dist = OpinionDistribution.query.filter_by(id=dist_id).first()
-    if not dist:
-        return (
-            jsonify({"success": False, "message": "Opinion distribution not found"}),
-            404,
-        )
-
-    db.session.delete(dist)
-    db.session.commit()
-    return jsonify({"success": True})
-
-
-# ============================================================================
-# Image feeds and feed retrieval limits
-# ============================================================================
-
-DEFAULT_FEED_LIMITS = {
-    "rss_entries_per_feed": 100,
-    "reddit_entries_per_feed": 200,
-    "reddit_pages": 2,
-    "reddit_rate_limit_seconds": 2,
-    "db_fallback_limit": 50,
-    "image_entries_per_feed": 100,
-}
-
-
-@experiments.route("/admin/image_feeds/<int:uid>")
-@login_required
-def image_feeds(uid):
-    """Display and edit image feeds for an experiment."""
-    check_privileges(current_user.username)
-
-    from y_web.utils.path_utils import get_writable_path
-
-    base_dir = get_writable_path()
-    experiment = Exps.query.filter_by(idexp=uid).first()
-    if not experiment:
-        flash("Experiment not found", "error")
-        return redirect(url_for("experiments.settings"))
-
-    exp_folder = get_experiment_uid_from_db_name(experiment.db_name)
-    if not exp_folder:
-        flash("Invalid experiment database configuration", "error")
-        return redirect(url_for("experiments.settings"))
-
-    image_feeds_path = os.path.join(
-        base_dir,
-        f"y_web{os.sep}experiments{os.sep}{exp_folder}{os.sep}image_feeds.json",
-    )
-
-    image_feeds_data = []
-    if os.path.exists(image_feeds_path):
-        try:
-            with open(image_feeds_path, "r") as f:
-                image_feeds_data = json.load(f)
-        except (json.JSONDecodeError, IOError):
-            image_feeds_data = []
-
-    available_interests = [
-        "humor",
-        "entertainment",
-        "fun",
-        "memes",
-        "photography",
-        "travel",
-        "nature",
-        "general",
-        "animals",
-        "pets",
-        "wholesome",
-        "cute",
-        "technology",
-        "gaming",
-        "science",
-        "geek",
-        "art",
-        "design",
-        "creative",
-        "music",
-        "sports",
-        "fitness",
-        "food",
-        "cooking",
-        "movies",
-        "tv",
-        "celebrities",
-        "news",
-        "politics",
-        "history",
-        "education",
-        "books",
-    ]
-
-    return render_template(
-        "admin/image_feeds.html",
-        experiment=experiment,
-        image_feeds=image_feeds_data,
-        available_interests=sorted(available_interests),
-    )
-
-
-@experiments.route("/admin/update_image_feeds/<int:uid>", methods=["POST"])
-@login_required
-def update_image_feeds(uid):
-    """Update image feeds for an experiment."""
-    check_privileges(current_user.username)
-
-    from y_web.utils.path_utils import get_writable_path
-
-    base_dir = get_writable_path()
-    experiment = Exps.query.filter_by(idexp=uid).first()
-    if not experiment:
-        flash("Experiment not found", "error")
-        return redirect(url_for("experiments.settings"))
-
-    exp_folder = get_experiment_uid_from_db_name(experiment.db_name)
-    if not exp_folder:
-        flash("Invalid experiment database configuration", "error")
-        return redirect(url_for("experiments.settings"))
-
-    image_feeds_path = os.path.join(
-        base_dir,
-        f"y_web{os.sep}experiments{os.sep}{exp_folder}{os.sep}image_feeds.json",
-    )
-
-    feeds_json = request.form.get("image_feeds_json", "[]")
-    try:
-        feeds = json.loads(feeds_json)
-    except json.JSONDecodeError:
-        flash("Invalid image feeds payload; changes were not saved.", "error")
-        return redirect(request.referrer or url_for("experiments.image_feeds", uid=uid))
-
-    with open(image_feeds_path, "w") as f:
-        json.dump(feeds, f, indent=2)
-
-    return redirect(request.referrer or url_for("experiments.image_feeds", uid=uid))
-
-
-@experiments.route("/admin/upload_image_feeds/<int:uid>", methods=["POST"])
-@login_required
-def upload_image_feeds(uid):
-    """Upload bulk image feeds from a JSON file."""
-    check_privileges(current_user.username)
-
-    from y_web.utils.path_utils import get_writable_path
-
-    base_dir = get_writable_path()
-    experiment = Exps.query.filter_by(idexp=uid).first()
-    if not experiment:
-        return jsonify({"error": "Experiment not found"}), 404
-
-    exp_folder = get_experiment_uid_from_db_name(experiment.db_name)
-    if not exp_folder:
-        return jsonify({"error": "Invalid experiment database configuration"}), 400
-
-    image_feeds_path = os.path.join(
-        base_dir,
-        f"y_web{os.sep}experiments{os.sep}{exp_folder}{os.sep}image_feeds.json",
-    )
-
-    if "file" not in request.files:
-        return jsonify({"error": "No file provided"}), 400
-
-    file = request.files["file"]
-    if file.filename == "":
-        return jsonify({"error": "No file selected"}), 400
-
-    try:
-        content = file.read().decode("utf-8")
-        new_feeds = json.loads(content)
-        if not isinstance(new_feeds, list):
-            return jsonify({"error": "JSON must be an array of image feeds"}), 400
-
-        normalized_feeds = []
-        seen_subreddits = set()
-        for item in new_feeds:
-            if not isinstance(item, dict):
-                continue
-            subreddit = str(item.get("subreddit", "")).strip().lower()
-            subreddit = subreddit[2:] if subreddit.startswith("r/") else subreddit
-            interests = item.get("interests") or []
-            if not subreddit:
-                continue
-            if not isinstance(interests, list):
-                label = str(interests).strip()
-                interests = [label] if label else []
-
-            clean_interests = []
-            seen_interests = set()
-            for interest in interests:
-                label = str(interest).strip()
-                if not label or label in seen_interests:
-                    continue
-                seen_interests.add(label)
-                clean_interests.append(label)
-
-            if subreddit in seen_subreddits:
-                continue
-            seen_subreddits.add(subreddit)
-            normalized_feeds.append(
-                {"subreddit": subreddit, "interests": clean_interests}
-            )
-
-        mode = request.form.get("mode", "replace")
-        if mode == "merge":
-            existing_feeds = []
-            if os.path.exists(image_feeds_path):
-                with open(image_feeds_path, "r") as f:
-                    existing_feeds = json.load(f)
-
-            merged = []
-            by_subreddit = {}
-            for feed in existing_feeds:
-                if not isinstance(feed, dict):
-                    continue
-                subreddit = str(feed.get("subreddit", "")).strip().lower()
-                if not subreddit:
-                    continue
-                merged_feed = {
-                    "subreddit": subreddit,
-                    "interests": list(feed.get("interests") or []),
-                }
-                merged.append(merged_feed)
-                by_subreddit[subreddit] = merged_feed
-
-            for feed in normalized_feeds:
-                subreddit = feed["subreddit"]
-                if subreddit in by_subreddit:
-                    existing = by_subreddit[subreddit]
-                    combined = []
-                    seen = set()
-                    for label in list(existing.get("interests") or []) + list(
-                        feed.get("interests") or []
-                    ):
-                        label = str(label).strip()
-                        if not label or label in seen:
-                            continue
-                        seen.add(label)
-                        combined.append(label)
-                    existing["interests"] = combined
-                else:
-                    merged.append(feed)
-                    by_subreddit[subreddit] = feed
-            normalized_feeds = merged
-
-        with open(image_feeds_path, "w") as f:
-            json.dump(normalized_feeds, f, indent=2)
-
-        return jsonify({"success": True, "count": len(normalized_feeds)})
-    except json.JSONDecodeError:
-        return jsonify({"error": "Invalid JSON format"}), 400
-    except Exception as exc:
-        return jsonify({"error": str(exc)}), 400
-
-
-@experiments.route("/admin/feed_limits/<uid>", methods=["GET"])
-@login_required
-def feed_limits(uid):
-    """Display and edit feed retrieval limits for an experiment."""
-    check_privileges(current_user.username)
-
-    from y_web.utils.path_utils import get_writable_path
-
-    base_dir = get_writable_path()
-    experiment = Exps.query.filter_by(idexp=uid).first()
-    if not experiment:
-        flash("Experiment not found", "error")
-        return redirect(url_for("experiments.settings"))
-
-    exp_folder = get_experiment_uid_from_db_name(experiment.db_name)
-    if not exp_folder:
-        flash("Invalid experiment database configuration", "error")
-        return redirect(url_for("experiments.settings"))
-
-    config_path = os.path.join(
-        base_dir, f"y_web{os.sep}experiments{os.sep}{exp_folder}{os.sep}config.json"
-    )
-
-    feed_limits_data = dict(DEFAULT_FEED_LIMITS)
-    if os.path.exists(config_path):
-        try:
-            with open(config_path, "r") as f:
-                config = json.load(f)
-            if "feed_limits" in config:
-                feed_limits_data.update(config["feed_limits"])
-        except (json.JSONDecodeError, IOError):
-            pass
-
-    return render_template(
-        "admin/feed_limits.html",
-        experiment=experiment,
-        feed_limits=feed_limits_data,
-    )
-
-
-@experiments.route("/admin/update_feed_limits/<uid>", methods=["POST"])
-@login_required
-def update_feed_limits(uid):
-    """Update feed retrieval limits for an experiment."""
-    check_privileges(current_user.username)
-
-    from y_web.utils.path_utils import get_writable_path
-
-    base_dir = get_writable_path()
-    experiment = Exps.query.filter_by(idexp=uid).first()
-    if not experiment:
-        flash("Experiment not found", "error")
-        return redirect(url_for("experiments.settings"))
-
-    exp_folder = get_experiment_uid_from_db_name(experiment.db_name)
-    if not exp_folder:
-        flash("Invalid experiment database configuration", "error")
-        return redirect(url_for("experiments.settings"))
-
-    config_path = os.path.join(
-        base_dir, f"y_web{os.sep}experiments{os.sep}{exp_folder}{os.sep}config.json"
-    )
-
-    config = {}
-    if os.path.exists(config_path):
-        try:
-            with open(config_path, "r") as f:
-                config = json.load(f)
-        except (json.JSONDecodeError, IOError):
-            config = {}
-
-    feed_limits = {
-        "rss_entries_per_feed": int(request.form.get("rss_entries_per_feed", 100)),
-        "reddit_entries_per_feed": int(
-            request.form.get("reddit_entries_per_feed", 200)
-        ),
-        "reddit_pages": int(request.form.get("reddit_pages", 2)),
-        "reddit_rate_limit_seconds": float(
-            request.form.get("reddit_rate_limit_seconds", 2)
-        ),
-        "db_fallback_limit": int(request.form.get("db_fallback_limit", 50)),
-        "image_entries_per_feed": int(request.form.get("image_entries_per_feed", 100)),
-    }
-
-    config["feed_limits"] = feed_limits
-    with open(config_path, "w") as f:
-        json.dump(config, f, indent=2)
-
-    flash("Feed limits updated successfully.", "success")
-    return redirect(request.referrer or f"/admin/feed_limits/{uid}")
-
-
-@experiments.route("/admin/api/parse_image_feed", methods=["POST"])
-@login_required
-def parse_image_feed():
-    """Parse a Reddit subreddit RSS feed and return image info."""
-    import feedparser
-
-    subreddit = request.json.get("subreddit", "").strip().lower()
-    if not subreddit:
-        return jsonify({"error": "No subreddit provided"}), 400
-
-    subreddit = subreddit.lstrip("r/")
-    feed_url = f"https://www.reddit.com/r/{subreddit}.rss"
-
-    try:
-        feed = feedparser.parse(feed_url)
-        if feed.bozo and not feed.entries:
-            return jsonify(
-                {"error": f"Could not parse r/{subreddit} - subreddit may not exist"}
-            ), 400
-
-        if not feed.entries:
-            return jsonify({"error": f"No posts found in r/{subreddit}"}), 400
-
-        image_pattern = re.compile(r"\.(jpg|jpeg|png|gif|webp)(\?.*)?$", re.IGNORECASE)
-        image_hosts = ["i.redd.it", "i.imgur.com", "preview.redd.it"]
-
-        images = []
-        nsfw_count = 0
-
-        for entry in feed.entries[:50]:
-            is_nsfw = False
-            if hasattr(entry, "over_18") and entry.over_18:
-                is_nsfw = True
-            elif "[nsfw]" in entry.get("title", "").lower():
-                is_nsfw = True
-            elif hasattr(entry, "tags"):
-                for tag in entry.tags:
-                    if tag.get("term", "").lower() == "nsfw":
-                        is_nsfw = True
-                        break
-
-            if is_nsfw:
-                nsfw_count += 1
-                continue
-
-            image_url = None
-            link = entry.get("link", "")
-            if image_pattern.search(link) or any(host in link for host in image_hosts):
-                image_url = link
-
-            if not image_url and hasattr(entry, "media_content"):
-                for media in entry.media_content:
-                    url = media.get("url", "")
-                    if image_pattern.search(url) or any(
-                        host in url for host in image_hosts
-                    ):
-                        image_url = url
-                        break
-
-            if not image_url and hasattr(entry, "media_thumbnail"):
-                for thumb in entry.media_thumbnail:
-                    url = thumb.get("url", "")
-                    if url:
-                        image_url = url
-                        break
-
-            if image_url:
-                images.append(image_url)
-
-        return jsonify(
-            {
-                "subreddit": subreddit,
-                "feed_url": feed_url,
-                "image_count": len(images),
-                "nsfw_filtered": nsfw_count,
-                "sample_images": images[:5],
-            }
-        )
-    except Exception as exc:
-        return jsonify({"error": str(exc)}), 400

--- a/y_web/routes_admin/tutorial_routes.py
+++ b/y_web/routes_admin/tutorial_routes.py
@@ -483,16 +483,14 @@ def create_tutorial_experiment():
                         dummy_conn.execute(text(schema_sql))
 
                     hashed_pw = generate_password_hash("admin", method="pbkdf2:sha256")
-                    stmt = text(
-                        """
+                    stmt = text("""
                         INSERT INTO user_mgmt (username, email, password, user_type, leaning, age,
                                                language, owner, joined_on, frecsys_type,
                                                round_actions, toxicity, is_page, daily_activity_level)
                         VALUES (:username, :email, :password, :user_type, :leaning, :age,
                                 :language, :owner, :joined_on, :frecsys_type,
                                 :round_actions, :toxicity, :is_page, :daily_activity_level)
-                        """
-                    )
+                        """)
                     dummy_conn.execute(
                         stmt,
                         {

--- a/y_web/routes_api/__init__.py
+++ b/y_web/routes_api/__init__.py
@@ -1,0 +1,1 @@
+# Package initializer for API routes.

--- a/y_web/routes_api/interview.py
+++ b/y_web/routes_api/interview.py
@@ -7,15 +7,15 @@ from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional, Tuple
 
 import requests
-from flask import Blueprint, jsonify, request, current_app
+from flask import Blueprint, current_app, jsonify, request
 from flask_login import current_user, login_required
 from sqlalchemy import case, desc, func, or_
 
 from y_web import db
 from y_web.models import (
+    Admin_users,
     AdminInterviewMessage,
     AdminInterviewSession,
-    Admin_users,
     Exps,
     Interests,
     Post,
@@ -28,23 +28,24 @@ from y_web.models import (
 from y_web.utils.experiment_helpers import get_experiment_uid_from_db_name
 from y_web.utils.path_utils import get_writable_path
 
-
 api_interview = Blueprint("api_interview", __name__, url_prefix="/api/interview")
 
 _MEMORY_MODE_LEGACY = "legacy"
 _MEMORY_MODE_SEMANTIC = "semantic"
 _MEMORY_MODE_LEGACY_FALLBACK = "legacy_fallback"
 _INTERVIEW_MEMORY_MODE_DEFAULT = (
-    os.environ.get("INTERVIEW_MEMORY_MODE_DEFAULT", _MEMORY_MODE_SEMANTIC).strip().lower()
+    os.environ.get("INTERVIEW_MEMORY_MODE_DEFAULT", _MEMORY_MODE_SEMANTIC)
+    .strip()
+    .lower()
 )
 if _INTERVIEW_MEMORY_MODE_DEFAULT not in {_MEMORY_MODE_LEGACY, _MEMORY_MODE_SEMANTIC}:
     _INTERVIEW_MEMORY_MODE_DEFAULT = _MEMORY_MODE_SEMANTIC
-_INTERVIEW_MEMORY_DEFAULT_QUERY = (
-    "Most important recent memories, relationships, norms, and ongoing threads for this agent."
-)
+_INTERVIEW_MEMORY_DEFAULT_QUERY = "Most important recent memories, relationships, norms, and ongoing threads for this agent."
 
 
-def _parse_timeout_series(raw: Optional[str], default: Tuple[float, ...]) -> Tuple[float, ...]:
+def _parse_timeout_series(
+    raw: Optional[str], default: Tuple[float, ...]
+) -> Tuple[float, ...]:
     values: List[float] = []
     for part in str(raw or "").split(","):
         token = part.strip()
@@ -179,7 +180,9 @@ def _build_change_db_path_for_exp(exp: Exps) -> str:
         return full_path[1:].replace("\\", "/")
 
     old_db_name = db_uri_main.split("/")[-1]
-    return db_uri_main.replace(old_db_name, str(getattr(exp, "db_name", "") or "").strip())
+    return db_uri_main.replace(
+        old_db_name, str(getattr(exp, "db_name", "") or "").strip()
+    )
 
 
 def _ensure_experiment_server_db_binding(exp: Exps) -> Dict[str, Any]:
@@ -221,7 +224,9 @@ def _iter_run_ids_from_server_log(
     if not uid:
         return []
 
-    log_path = get_writable_path(os.path.join("y_web", "experiments", uid, "_server.log"))
+    log_path = get_writable_path(
+        os.path.join("y_web", "experiments", uid, "_server.log")
+    )
     if not os.path.exists(log_path):
         return []
 
@@ -356,9 +361,14 @@ def _detect_run_id_from_server_log(
         if agent_user_id is None or not probe_memory_coverage:
             best = {"run_id": rid}
             break
-        cov = _probe_run_memory_coverage(exp, run_id=rid, agent_user_id=int(agent_user_id))
+        cov = _probe_run_memory_coverage(
+            exp, run_id=rid, agent_user_id=int(agent_user_id)
+        )
         candidates_checked.append(cov)
-        if int(cov.get("returned_k") or 0) > 0 or int(cov.get("candidate_count") or 0) > 0:
+        if (
+            int(cov.get("returned_k") or 0) > 0
+            or int(cov.get("candidate_count") or 0) > 0
+        ):
             best = {"run_id": rid, "coverage": cov}
             break
 
@@ -377,7 +387,11 @@ def _detect_run_id_from_server_log(
         "selected_reason": (
             "memory_coverage_positive"
             if best.get("coverage")
-            else ("latest_agent_run" if probe_memory_coverage else "latest_agent_run_unprobed")
+            else (
+                "latest_agent_run"
+                if probe_memory_coverage
+                else "latest_agent_run_unprobed"
+            )
         ),
         "candidates_checked": candidates_checked,
     }
@@ -391,7 +405,9 @@ def _get_current_round_id() -> int:
         return 0
 
 
-def _get_top_interests_for_user(user_id: int, *, window_rounds: int = 50, limit: int = 10) -> List[str]:
+def _get_top_interests_for_user(
+    user_id: int, *, window_rounds: int = 50, limit: int = 10
+) -> List[str]:
     cur = _get_current_round_id()
     base = max(0, cur - int(window_rounds))
 
@@ -499,7 +515,9 @@ def _interview_debug_enabled(payload: Optional[Dict[str, Any]] = None) -> bool:
     return _as_bool(os.environ.get("INTERVIEW_DEBUG_TRACE"), False)
 
 
-def _build_memory_snapshot_legacy(exp: Exps, *, run_id: Optional[str], agent_user_id: int) -> Dict[str, Any]:
+def _build_memory_snapshot_legacy(
+    exp: Exps, *, run_id: Optional[str], agent_user_id: int
+) -> Dict[str, Any]:
     snap: Dict[str, Any] = {
         "run_id": run_id,
         "agent_user_id": int(agent_user_id),
@@ -611,8 +629,16 @@ def _build_memory_snapshot_legacy(exp: Exps, *, run_id: Optional[str], agent_use
             {
                 "other_user_id": int(other_id),
                 "other_username": other_username,
-                "social_card": other_ctx.get("social_card") if isinstance(other_ctx, dict) else None,
-                "recent_pair_events": other_ctx.get("recent_pair_events") if isinstance(other_ctx, dict) else None,
+                "social_card": (
+                    other_ctx.get("social_card")
+                    if isinstance(other_ctx, dict)
+                    else None
+                ),
+                "recent_pair_events": (
+                    other_ctx.get("recent_pair_events")
+                    if isinstance(other_ctx, dict)
+                    else None
+                ),
             }
         )
 
@@ -654,7 +680,9 @@ def _build_memory_snapshot_legacy(exp: Exps, *, run_id: Optional[str], agent_use
         threads.append(
             {
                 "thread_root_id": int(thread_root_id),
-                "thread_card": tctx.get("thread_card") if isinstance(tctx, dict) else None,
+                "thread_card": (
+                    tctx.get("thread_card") if isinstance(tctx, dict) else None
+                ),
             }
         )
 
@@ -764,7 +792,9 @@ def _build_memory_snapshot(
 ) -> Dict[str, Any]:
     requested_mode = _normalize_memory_mode(memory_mode)
     if requested_mode == _MEMORY_MODE_LEGACY:
-        legacy = _build_memory_snapshot_legacy(exp, run_id=run_id, agent_user_id=agent_user_id)
+        legacy = _build_memory_snapshot_legacy(
+            exp, run_id=run_id, agent_user_id=agent_user_id
+        )
         legacy["memory_mode_requested"] = requested_mode
         legacy["memory_mode_used"] = _MEMORY_MODE_LEGACY
         return legacy
@@ -780,7 +810,9 @@ def _build_memory_snapshot(
         semantic["memory_mode_used"] = _MEMORY_MODE_SEMANTIC
         return semantic
     except Exception as exc:
-        legacy = _build_memory_snapshot_legacy(exp, run_id=run_id, agent_user_id=agent_user_id)
+        legacy = _build_memory_snapshot_legacy(
+            exp, run_id=run_id, agent_user_id=agent_user_id
+        )
         legacy["memory_mode_requested"] = requested_mode
         legacy["memory_mode_used"] = _MEMORY_MODE_LEGACY_FALLBACK
         legacy["fallback_reason"] = str(exc)
@@ -832,10 +864,14 @@ def _format_memory_pack(snapshot: Dict[str, Any], *, max_chars: int = 4500) -> s
                 score_s = f"{float(score):.2f}"
             except Exception:
                 score_s = "?"
-            text = _truncate_middle(str(it.get("text_humanized") or it.get("text") or "").strip(), 260)
+            text = _truncate_middle(
+                str(it.get("text_humanized") or it.get("text") or "").strip(), 260
+            )
             support_ids = it.get("supporting_event_ids")
             target_user_id = it.get("target_user_id")
-            target_username = _clean_username(it.get("target_username") or it.get("other_username"))
+            target_username = _clean_username(
+                it.get("target_username") or it.get("other_username")
+            )
             target_post_id = it.get("target_post_id")
             actor_user_id = it.get("actor_user_id")
             actor_username = _clean_username(it.get("actor_username"))
@@ -863,7 +899,9 @@ def _format_memory_pack(snapshot: Dict[str, Any], *, max_chars: int = 4500) -> s
                     f"- [{item_type}] round={round_id} score={score_s}{ids_s} supports={sid}: {text}"
                 )
             else:
-                parts.append(f"- [{item_type}] round={round_id} score={score_s}{ids_s}: {text}")
+                parts.append(
+                    f"- [{item_type}] round={round_id} score={score_s}{ids_s}: {text}"
+                )
 
     if retrieval_meta:
         returned_k = retrieval_meta.get("returned_k")
@@ -878,8 +916,12 @@ def _format_memory_pack(snapshot: Dict[str, Any], *, max_chars: int = 4500) -> s
         except Exception:
             returned_k_int = 0
         if bool(degraded_mode) or returned_k_int <= 0:
-            parts.append("- Reliability warning: memory retrieval is weak for this query.")
-            parts.append("- Do not infer specific prior interactions from memory alone.")
+            parts.append(
+                "- Reliability warning: memory retrieval is weak for this query."
+            )
+            parts.append(
+                "- Do not infer specific prior interactions from memory alone."
+            )
 
     # Keep legacy rendering for backward compatibility and semantic fallback mode.
     rels = snapshot.get("relationships")
@@ -896,7 +938,13 @@ def _format_memory_pack(snapshot: Dict[str, Any], *, max_chars: int = 4500) -> s
             sc = r.get("social_card") or {}
             if isinstance(sc, dict):
                 vals = []
-                for k in ["affinity", "conflict", "humor", "trust", "last_relation_label"]:
+                for k in [
+                    "affinity",
+                    "conflict",
+                    "humor",
+                    "trust",
+                    "last_relation_label",
+                ]:
                     if k in sc and sc.get(k) is not None:
                         vals.append(f"{k}={sc.get(k)}")
                 summary = (sc.get("summary_text") or "").strip()
@@ -954,7 +1002,11 @@ def _format_memory_pack(snapshot: Dict[str, Any], *, max_chars: int = 4500) -> s
                 if isinstance(participants_top, str):
                     participants_top_str = participants_top.strip()
                 else:
-                    participants_top_str = json.dumps(participants_top) if participants_top is not None else ""
+                    participants_top_str = (
+                        json.dumps(participants_top)
+                        if participants_top is not None
+                        else ""
+                    )
             except Exception:
                 participants_top_str = str(participants_top or "")
 
@@ -962,7 +1014,9 @@ def _format_memory_pack(snapshot: Dict[str, Any], *, max_chars: int = 4500) -> s
                 if isinstance(entry_points, str):
                     entry_points_str = entry_points.strip()
                 else:
-                    entry_points_str = json.dumps(entry_points) if entry_points is not None else ""
+                    entry_points_str = (
+                        json.dumps(entry_points) if entry_points is not None else ""
+                    )
             except Exception:
                 entry_points_str = str(entry_points or "")
 
@@ -970,7 +1024,9 @@ def _format_memory_pack(snapshot: Dict[str, Any], *, max_chars: int = 4500) -> s
             if my_role:
                 parts.append(f"  my_role: {my_role}")
             if participants_top_str.strip():
-                parts.append(f"  participants_top: {participants_top_str.strip()[:400]}")
+                parts.append(
+                    f"  participants_top: {participants_top_str.strip()[:400]}"
+                )
             if entry_points_str.strip():
                 parts.append(f"  entry_points: {entry_points_str.strip()[:200]}")
             if last_seen_round_id is not None:
@@ -1145,7 +1201,9 @@ def _extract_query_terms(admin_text: str, *, max_terms: int = 8) -> List[str]:
     # Expand lightweight aliases to improve lexical fallback recall.
     out: List[str] = list(base_terms)
     for t in base_terms:
-        alias_candidates = _INTERVIEW_QUERY_TERM_ALIASES.get(str(t).strip().lower()) or []
+        alias_candidates = (
+            _INTERVIEW_QUERY_TERM_ALIASES.get(str(t).strip().lower()) or []
+        )
         for alias in alias_candidates:
             alias_clean = str(alias or "").strip().lower()
             if not alias_clean or alias_clean in seen:
@@ -1202,7 +1260,9 @@ def _evaluate_query_hit_text(text: str, terms: List[str]) -> Dict[str, Any]:
         if t in text_l:
             matched_terms.append(t)
     matched_terms = list(dict.fromkeys(matched_terms))
-    informative_terms = [t for t in matched_terms if t not in _INTERVIEW_WEAK_QUERY_TERMS]
+    informative_terms = [
+        t for t in matched_terms if t not in _INTERVIEW_WEAK_QUERY_TERMS
+    ]
     score = (2 * len(informative_terms)) + len(matched_terms)
     return {
         "matched_terms": matched_terms,
@@ -1232,7 +1292,9 @@ def _build_contextual_admin_query_text(
 
     try:
         rows = (
-            AdminInterviewMessage.query.filter_by(session_id=int(session_id), role="admin")
+            AdminInterviewMessage.query.filter_by(
+                session_id=int(session_id), role="admin"
+            )
             .order_by(AdminInterviewMessage.id.desc())
             .limit(max(1, int(max_admin_msgs) + 1))
             .all()
@@ -1271,14 +1333,18 @@ def _get_reaction_counts_for_posts(post_ids: List[int]) -> Dict[int, Dict[str, i
         return {}
 
     # Default to 0/0 for requested ids.
-    counts: Dict[int, Dict[str, int]] = {int(pid): {"likes": 0, "dislikes": 0} for pid in ids}
+    counts: Dict[int, Dict[str, int]] = {
+        int(pid): {"likes": 0, "dislikes": 0} for pid in ids
+    }
 
     try:
         q = (
             db.session.query(
                 Reactions.post_id.label("post_id"),
                 func.sum(case((Reactions.type == "like", 1), else_=0)).label("likes"),
-                func.sum(case((Reactions.type == "dislike", 1), else_=0)).label("dislikes"),
+                func.sum(case((Reactions.type == "dislike", 1), else_=0)).label(
+                    "dislikes"
+                ),
             )
             .filter(Reactions.post_id.in_(ids))
             .group_by(Reactions.post_id)
@@ -1312,7 +1378,9 @@ def _post_to_fact(
         "post_id": pid,
         "thread_root_id": int(getattr(p, "thread_id", 0) or 0) or None,
         "comment_to": (
-            int(getattr(p, "comment_to", -1) or -1) if getattr(p, "comment_to", None) is not None else None
+            int(getattr(p, "comment_to", -1) or -1)
+            if getattr(p, "comment_to", None) is not None
+            else None
         ),
         "round": int(getattr(p, "round", 0) or 0) or None,
         "reaction_count": int(getattr(p, "reaction_count", 0) or 0),
@@ -1353,7 +1421,9 @@ def _build_facts_snapshot(
         if not parent_ids:
             return []
 
-        parent_map = {int(getattr(p, "id")): p for p in parent_list if getattr(p, "id", None)}
+        parent_map = {
+            int(getattr(p, "id")): p for p in parent_list if getattr(p, "id", None)
+        }
 
         # Reading signal: replies up to this cursor were seen in notifications inbox.
         last_seen_reply_id = 0
@@ -1393,7 +1463,11 @@ def _build_facts_snapshot(
         except Exception:
             reply_posts = []
 
-        reply_ids = [int(getattr(rp, "id", 0) or 0) for rp in reply_posts if int(getattr(rp, "id", 0) or 0) > 0]
+        reply_ids = [
+            int(getattr(rp, "id", 0) or 0)
+            for rp in reply_posts
+            if int(getattr(rp, "id", 0) or 0) > 0
+        ]
         reacted_ids: set[int] = set()
         direct_reply_ids: set[int] = set()
 
@@ -1406,7 +1480,9 @@ def _build_facts_snapshot(
                     .all()
                 )
                 reacted_ids = {
-                    int(getattr(r, "post_id", 0) or 0) for r in reacted_rows if int(getattr(r, "post_id", 0) or 0) > 0
+                    int(getattr(r, "post_id", 0) or 0)
+                    for r in reacted_rows
+                    if int(getattr(r, "post_id", 0) or 0) > 0
                 }
             except Exception:
                 reacted_ids = set()
@@ -1428,16 +1504,30 @@ def _build_facts_snapshot(
 
         try:
             author_ids = sorted(
-                {int(getattr(rp, "user_id", 0) or 0) for rp in reply_posts if int(getattr(rp, "user_id", 0) or 0) > 0}
+                {
+                    int(getattr(rp, "user_id", 0) or 0)
+                    for rp in reply_posts
+                    if int(getattr(rp, "user_id", 0) or 0) > 0
+                }
             )
-            users = User_mgmt.query.filter(User_mgmt.id.in_(author_ids)).all() if author_ids else []
-            author_name_by_id = {int(u.id): getattr(u, "username", None) for u in users if u is not None}
+            users = (
+                User_mgmt.query.filter(User_mgmt.id.in_(author_ids)).all()
+                if author_ids
+                else []
+            )
+            author_name_by_id = {
+                int(u.id): getattr(u, "username", None) for u in users if u is not None
+            }
         except Exception:
             author_name_by_id = {}
 
         seen_counts: Dict[int, int] = {pid: 0 for pid in parent_ids}
-        seen_examples_map: Dict[int, List[Dict[str, Any]]] = {pid: [] for pid in parent_ids}
-        seen_reply_ids_by_parent: Dict[int, set[int]] = {pid: set() for pid in parent_ids}
+        seen_examples_map: Dict[int, List[Dict[str, Any]]] = {
+            pid: [] for pid in parent_ids
+        }
+        seen_reply_ids_by_parent: Dict[int, set[int]] = {
+            pid: set() for pid in parent_ids
+        }
 
         for rp in reply_posts:
             rid = int(getattr(rp, "id", 0) or 0)
@@ -1483,9 +1573,12 @@ def _build_facts_snapshot(
             out.append(
                 {
                     "post_id": pid,
-                    "thread_root_id": int(getattr(parent_post, "thread_id", 0) or 0) or None,
+                    "thread_root_id": int(getattr(parent_post, "thread_id", 0) or 0)
+                    or None,
                     "round": int(getattr(parent_post, "round", 0) or 0) or None,
-                    "text": _truncate_middle(str(getattr(parent_post, "tweet", "") or ""), 220),
+                    "text": _truncate_middle(
+                        str(getattr(parent_post, "tweet", "") or ""), 220
+                    ),
                     "total_reply_count": int(total_counts.get(pid, 0) or 0),
                     "seen_reply_count": int(seen_counts.get(pid, 0) or 0),
                     "seen_reply_examples": seen_examples_map.get(pid) or [],
@@ -1536,7 +1629,11 @@ def _build_facts_snapshot(
     query_hits = []
     if terms:
         try:
-            conds = [Post.tweet.ilike(f"%{t}%") for t in terms[:8] if isinstance(t, str) and t.strip()]
+            conds = [
+                Post.tweet.ilike(f"%{t}%")
+                for t in terms[:8]
+                if isinstance(t, str) and t.strip()
+            ]
             if conds:
                 q_hits = (
                     Post.query.filter(Post.user_id == int(agent_user_id))
@@ -1553,7 +1650,9 @@ def _build_facts_snapshot(
     try:
         thread_ids = [int(x) for x in (query_ids.get("thread_ids") or []) if int(x) > 0]
         post_ids = [int(x) for x in (query_ids.get("post_ids") or []) if int(x) > 0]
-        comment_ids = [int(x) for x in (query_ids.get("comment_ids") or []) if int(x) > 0]
+        comment_ids = [
+            int(x) for x in (query_ids.get("comment_ids") or []) if int(x) > 0
+        ]
     except Exception:
         thread_ids, post_ids, comment_ids = [], [], []
 
@@ -1623,10 +1722,18 @@ def _build_facts_snapshot(
         reverse=True,
     )
     if hit_eval_rows:
-        pid_order = [int(r.get("post_id") or 0) for r in hit_eval_rows if int(r.get("post_id") or 0) > 0]
+        pid_order = [
+            int(r.get("post_id") or 0)
+            for r in hit_eval_rows
+            if int(r.get("post_id") or 0) > 0
+        ]
         by_pid = {int(getattr(p, "id", 0) or 0): p for p in query_hits if p is not None}
-        query_hits = [by_pid[pid] for pid in pid_order if pid in by_pid][: max(int(query_hits_limit), 8)]
-    query_hits_viable_count = sum(1 for r in hit_eval_rows if int(r.get("informative_matches") or 0) > 0)
+        query_hits = [by_pid[pid] for pid in pid_order if pid in by_pid][
+            : max(int(query_hits_limit), 8)
+        ]
+    query_hits_viable_count = sum(
+        1 for r in hit_eval_rows if int(r.get("informative_matches") or 0) > 0
+    )
     snap["query_hit_evaluations"] = hit_eval_rows[:8]
     snap["query_hits_viable_count"] = int(query_hits_viable_count)
 
@@ -1635,7 +1742,7 @@ def _build_facts_snapshot(
     comment_context: Dict[int, Dict[str, Any]] = {}
     try:
         comment_posts = []
-        for p in (recent_comments or []):
+        for p in recent_comments or []:
             if p is None:
                 continue
             try:
@@ -1643,7 +1750,7 @@ def _build_facts_snapshot(
                     comment_posts.append(p)
             except Exception:
                 continue
-        for p in (query_hits or []):
+        for p in query_hits or []:
             if p is None:
                 continue
             try:
@@ -1677,12 +1784,18 @@ def _build_facts_snapshot(
             parent_map: Dict[int, Post] = {}
             if parent_ids:
                 parents = Post.query.filter(Post.id.in_(parent_ids)).all()
-                parent_map = {int(getattr(pp, "id", 0) or 0): pp for pp in parents if pp is not None}
+                parent_map = {
+                    int(getattr(pp, "id", 0) or 0): pp
+                    for pp in parents
+                    if pp is not None
+                }
 
             op_map: Dict[int, Post] = {}
             if thread_root_ids:
                 ops = Post.query.filter(Post.id.in_(thread_root_ids)).all()
-                op_map = {int(getattr(op, "id", 0) or 0): op for op in ops if op is not None}
+                op_map = {
+                    int(getattr(op, "id", 0) or 0): op for op in ops if op is not None
+                }
 
             user_ids = set()
             for pp in parent_map.values():
@@ -1703,7 +1816,11 @@ def _build_facts_snapshot(
             username_by_id: Dict[int, Optional[str]] = {}
             if user_ids:
                 users = User_mgmt.query.filter(User_mgmt.id.in_(sorted(user_ids))).all()
-                username_by_id = {int(u.id): getattr(u, "username", None) for u in users if u is not None}
+                username_by_id = {
+                    int(u.id): getattr(u, "username", None)
+                    for u in users
+                    if u is not None
+                }
 
             for pid, p in comment_posts_by_id.items():
                 parent_id = int(getattr(p, "comment_to", -1) or -1)
@@ -1730,19 +1847,31 @@ def _build_facts_snapshot(
                 comment_context[pid] = {
                     "parent_post_id": int(parent_id) if parent_id > 0 else None,
                     "parent_user_id": parent_user_id,
-                    "parent_username": username_by_id.get(parent_user_id) if parent_user_id is not None else None,
+                    "parent_username": (
+                        username_by_id.get(parent_user_id)
+                        if parent_user_id is not None
+                        else None
+                    ),
                     "parent_text": (
-                        _truncate_middle(str(getattr(parent_post, "tweet", "") or ""), 220)
+                        _truncate_middle(
+                            str(getattr(parent_post, "tweet", "") or ""), 220
+                        )
                         if parent_post is not None
                         else None
                     ),
-                    "thread_op_post_id": int(thread_root_id) if thread_root_id > 0 else None,
+                    "thread_op_post_id": (
+                        int(thread_root_id) if thread_root_id > 0 else None
+                    ),
                     "thread_op_user_id": thread_op_user_id,
                     "thread_op_username": (
-                        username_by_id.get(thread_op_user_id) if thread_op_user_id is not None else None
+                        username_by_id.get(thread_op_user_id)
+                        if thread_op_user_id is not None
+                        else None
                     ),
                     "thread_op_text": (
-                        _truncate_middle(str(getattr(thread_op_post, "tweet", "") or ""), 180)
+                        _truncate_middle(
+                            str(getattr(thread_op_post, "tweet", "") or ""), 180
+                        )
                         if thread_op_post is not None
                         else None
                     ),
@@ -1756,14 +1885,26 @@ def _build_facts_snapshot(
         for p in lst:
             if p is not None:
                 all_posts.append(p)
-    post_ids = sorted({int(getattr(p, "id", 0) or 0) for p in all_posts if getattr(p, "id", None) is not None})
+    post_ids = sorted(
+        {
+            int(getattr(p, "id", 0) or 0)
+            for p in all_posts
+            if getattr(p, "id", None) is not None
+        }
+    )
     counts = _get_reaction_counts_for_posts(post_ids)
 
-    snap["top_posts"] = [_post_to_fact(p, counts, comment_context) for p in (top_posts or [])]
-    snap["recent_comments"] = [_post_to_fact(p, counts, comment_context) for p in (recent_comments or [])]
+    snap["top_posts"] = [
+        _post_to_fact(p, counts, comment_context) for p in (top_posts or [])
+    ]
+    snap["recent_comments"] = [
+        _post_to_fact(p, counts, comment_context) for p in (recent_comments or [])
+    ]
     snap["replies_to_recent_comments"] = replies_to_recent_comments
     snap["replies_to_top_posts"] = replies_to_top_posts
-    snap["query_hits"] = [_post_to_fact(p, counts, comment_context) for p in (query_hits or [])]
+    snap["query_hits"] = [
+        _post_to_fact(p, counts, comment_context) for p in (query_hits or [])
+    ]
     return snap
 
 
@@ -1775,7 +1916,9 @@ def _format_facts_pack(snapshot: Dict[str, Any], *, max_chars: int = 3500) -> st
 
     terms = snapshot.get("query_terms") or []
     if isinstance(terms, list) and terms:
-        parts.append("Query terms: " + ", ".join([str(t) for t in terms[:8] if str(t).strip()]))
+        parts.append(
+            "Query terms: " + ", ".join([str(t) for t in terms[:8] if str(t).strip()])
+        )
     query_ids = snapshot.get("query_id_filters") or {}
     if isinstance(query_ids, dict):
         tids = query_ids.get("thread_ids") or []
@@ -1818,7 +1961,11 @@ def _format_facts_pack(snapshot: Dict[str, Any], *, max_chars: int = 3500) -> st
                 f"likes={likes} dislikes={dislikes} reactions={rc}: {txt}"
             )
             if parent_post_id is not None or op_post_id is not None:
-                parent_label = f"@{parent_username}" if parent_username else f"user_id={parent_user_id}"
+                parent_label = (
+                    f"@{parent_username}"
+                    if parent_username
+                    else f"user_id={parent_user_id}"
+                )
                 op_label = f"@{op_username}" if op_username else f"user_id={op_user_id}"
                 parts.append(
                     f"  reply_target: parent_post_id={parent_post_id} parent={parent_label} "
@@ -1857,20 +2004,32 @@ def _format_facts_pack(snapshot: Dict[str, Any], *, max_chars: int = 3500) -> st
                         continue
                     who = ex.get("username") or f"user_id={ex.get('user_id')}"
                     via = ex.get("seen_via") or []
-                    via_s = ",".join([str(v) for v in via if str(v).strip()]) if isinstance(via, list) else ""
+                    via_s = (
+                        ",".join([str(v) for v in via if str(v).strip()])
+                        if isinstance(via, list)
+                        else ""
+                    )
                     parts.append(
                         f"  - by @{who} reply_post_id={ex.get('reply_post_id')} "
                         f"round={ex.get('round')} seen_via={via_s}: {ex.get('text')}"
                     )
 
-    _fmt_seen_replies("Replies you've seen to your top threads", snapshot.get("replies_to_top_posts"), limit=3)
+    _fmt_seen_replies(
+        "Replies you've seen to your top threads",
+        snapshot.get("replies_to_top_posts"),
+        limit=3,
+    )
     _fmt_seen_replies(
         "Replies you've seen to your recent comments",
         snapshot.get("replies_to_recent_comments"),
         limit=5,
     )
 
-    _fmt_posts("Your posts/comments matching the admin's question", snapshot.get("query_hits"), limit=5)
+    _fmt_posts(
+        "Your posts/comments matching the admin's question",
+        snapshot.get("query_hits"),
+        limit=5,
+    )
 
     out = "\n".join([p for p in parts if p is not None]).strip()
     if len(out) <= max_chars:
@@ -1914,7 +2073,9 @@ def _build_evidence_guard(
         memory_returned_k = 0
     memory_degraded = bool(retrieval_meta.get("degraded_mode", False))
 
-    strict_no_inference = bool(memory_degraded or (memory_returned_k <= 0 and query_hits_viable_n <= 0))
+    strict_no_inference = bool(
+        memory_degraded or (memory_returned_k <= 0 and query_hits_viable_n <= 0)
+    )
 
     lines = ["EVIDENCE STATUS (for this answer):"]
     lines.append(
@@ -1930,7 +2091,7 @@ def _build_evidence_guard(
     lines.append(f"- strict_no_inference={strict_no_inference}")
     if strict_no_inference:
         lines.append(
-            "- For activity-specific questions, answer \"can't confirm\" unless exact evidence is present."
+            '- For activity-specific questions, answer "can\'t confirm" unless exact evidence is present.'
         )
         lines.append(
             "- Do not introduce new movie/book titles, usernames, or thread narratives not in evidence."
@@ -1984,7 +2145,7 @@ def _extract_semantic_candidates(
         return []
 
     query_terms = []
-    for t in (facts.get("query_terms") or []):
+    for t in facts.get("query_terms") or []:
         ts = str(t or "").strip().lower()
         if ts:
             query_terms.append(ts)
@@ -2018,11 +2179,16 @@ def _extract_semantic_candidates(
             }
         )
 
-    rows.sort(key=lambda r: (int(r.get("term_hits") or 0), float(r.get("score") or 0.0)), reverse=True)
+    rows.sort(
+        key=lambda r: (int(r.get("term_hits") or 0), float(r.get("score") or 0.0)),
+        reverse=True,
+    )
     return rows[: max(1, int(max_candidates))]
 
 
-def _extract_facts_candidates(*, facts_snapshot: Dict[str, Any], max_candidates: int = 2) -> List[Dict[str, Any]]:
+def _extract_facts_candidates(
+    *, facts_snapshot: Dict[str, Any], max_candidates: int = 2
+) -> List[Dict[str, Any]]:
     facts = facts_snapshot if isinstance(facts_snapshot, dict) else {}
     rows = facts.get("query_hits")
     if not isinstance(rows, list) or not rows:
@@ -2102,7 +2268,9 @@ def _build_retrieval_trace(
                 "round_id": it.get("round_id"),
                 "thread_root_id": it.get("thread_root_id"),
                 "target_post_id": it.get("target_post_id"),
-                "text": _truncate_middle(str(it.get("text_humanized") or it.get("text") or ""), 120),
+                "text": _truncate_middle(
+                    str(it.get("text_humanized") or it.get("text") or ""), 120
+                ),
             }
         )
 
@@ -2220,7 +2388,9 @@ def _sanitize_interview_reply(
                     "candidate_count": len(semantic_candidates),
                     "known_ids_count": len(known_ids),
                 }
-            facts_candidates = _extract_facts_candidates(facts_snapshot=facts_snapshot, max_candidates=2)
+            facts_candidates = _extract_facts_candidates(
+                facts_snapshot=facts_snapshot, max_candidates=2
+            )
             if facts_candidates:
                 candidate_bits = []
                 for c in facts_candidates:
@@ -2278,7 +2448,9 @@ def _sanitize_interview_reply(
                 "candidate_count": len(semantic_candidates),
                 "known_ids_count": len(known_ids),
             }
-        facts_candidates = _extract_facts_candidates(facts_snapshot=facts_snapshot, max_candidates=2)
+        facts_candidates = _extract_facts_candidates(
+            facts_snapshot=facts_snapshot, max_candidates=2
+        )
         if facts_candidates:
             candidate_bits = []
             for c in facts_candidates:
@@ -2297,7 +2469,11 @@ def _sanitize_interview_reply(
                 "known_ids_count": len(known_ids),
             }
 
-    return text, {"sanitized": False, "reason": "pass", "known_ids_count": len(known_ids)}
+    return text, {
+        "sanitized": False,
+        "reason": "pass",
+        "known_ids_count": len(known_ids),
+    }
 
 
 def _resolve_llm_backend(
@@ -2517,7 +2693,9 @@ def api_interview_create_session(exp_id: int):
         db.session.commit()
     except Exception as exc:
         db.session.rollback()
-        return _json_error(f"Failed to create interview session: {exc}", 500, code="db_error")
+        return _json_error(
+            f"Failed to create interview session: {exc}", 500, code="db_error"
+        )
 
     sys_msg = AdminInterviewMessage(
         session_id=sess.id,
@@ -2560,7 +2738,9 @@ def api_interview_create_session(exp_id: int):
             "db_binding": db_binding,
             "backend_mode": mode,
             "memory_preloaded": preload_memory,
-            "memory_mode_requested": memory_snapshot.get("memory_mode_requested", memory_mode),
+            "memory_mode_requested": memory_snapshot.get(
+                "memory_mode_requested", memory_mode
+            ),
             "memory_mode_used": memory_snapshot.get("memory_mode_used"),
             "llm_model": model,
             "llm_base_url": base_url,
@@ -2568,7 +2748,11 @@ def api_interview_create_session(exp_id: int):
             "interests": interests,
             "memory_snapshot": memory_snapshot,
             "messages": [
-                {"id": int(sys_msg.id), "role": sys_msg.role, "content": sys_msg.content}
+                {
+                    "id": int(sys_msg.id),
+                    "role": sys_msg.role,
+                    "content": sys_msg.content,
+                }
             ],
         }
     )
@@ -2644,7 +2828,9 @@ def api_interview_refresh_context(exp_id: int, session_id: int):
     db_binding = _ensure_experiment_server_db_binding(exp)
 
     payload = request.get_json(silent=True) or {}
-    query_text = (payload.get("query_text") or "").strip() or _INTERVIEW_MEMORY_DEFAULT_QUERY
+    query_text = (
+        payload.get("query_text") or ""
+    ).strip() or _INTERVIEW_MEMORY_DEFAULT_QUERY
     memory_mode = _extract_requested_memory_mode(sess.memory_snapshot_json)
 
     memory_snapshot = _build_memory_snapshot(
@@ -2705,7 +2891,9 @@ def api_interview_send_message(exp_id: int, session_id: int):
         if not agent_user:
             return _json_error("Agent not found", 404, code="not_found")
 
-        contextual_query_text = _build_contextual_admin_query_text(int(sess.id), content)
+        contextual_query_text = _build_contextual_admin_query_text(
+            int(sess.id), content
+        )
 
         if auto_refresh:
             memory_snapshot = _build_memory_snapshot(
@@ -2757,50 +2945,48 @@ def api_interview_send_message(exp_id: int, session_id: int):
 
         persona = (sess.persona_snapshot or "").strip()
         system_message = (
-        "You are being interviewed by a researcher (the experiment admin).\n"
-        "They are evaluating your persona, memory, and social behavior in the simulation.\n"
-        "Stay fully in character. Speak casually and naturally (Reddit-style, not corporate).\n\n"
-        "Truthfulness rules (very important):\n"
-        "- Do NOT guess or invent actions, posts, comments, votes, or other users' replies.\n"
-        "- Use FACTS PACK as ground truth for what you posted/commented, who replied to you, and how many likes/dislikes it got.\n"
-        "- Reply sections in FACTS PACK are \"replies you've seen\" (read/commented/voted), so treat them as seen evidence only.\n"
-        "- For \"who did you reply to / who was OP\" questions, use reply_target fields in FACTS PACK "
-        "(parent=..., thread_op=...). If username is present, answer with it.\n"
-        "- For \"what was their original comment\" questions, use parent_text when available.\n"
-        "- Treat AGENT_UNVERIFIED transcript lines as potentially wrong prior drafts. Never use them as evidence.\n"
-        "- When the admin asks about a specific topic/person/keyword, use the 'matching the admin's question' section.\n"
-        "  If that section is empty, you have no evidence that you wrote about it.\n"
-        "- If FACTS PACK shows '(none)' for a section, treat it as no evidence. Do not invent.\n"
-        "- Use MEMORY PACK for subjective context: retrieved memories, relationships, community vibe, and thread summaries.\n"
-        "- If you cannot find evidence in FACTS PACK or MEMORY PACK, say you don't remember / can't confirm.\n"
-        "- Never introduce a new specific title/name/event unless it appears in evidence or the admin's latest message.\n"
-        "- If you previously said something wrong in this interview, explicitly correct yourself.\n\n"
-        "Style:\n"
-        "- Answer the admin directly.\n"
-        "- For questions about your actions (\"Did you post/comment/vote…?\"), start with a direct yes/no (or \"can't confirm\"), then justify.\n"
-        "- Keep it concise.\n"
-        "- If the admin's question is ambiguous, ask ONE short clarifying question to help you identify the right evidence "
-        "(e.g., which username/topic/thread_root_id/approx round range they mean).\n"
-        "- End your reply with ONE short follow-up question that helps the researcher continue the interview.\n"
-        "  Prefer clarification questions when needed; otherwise ask if they want you to expand on a specific detail.\n"
-        "- Avoid generic small-talk questions; only ask interview-relevant questions.\n"
-        "- Prefer @username in natural prose when a username is present in evidence.\n"
-        "- Include ids only when the admin asks for verification or when ids are needed to disambiguate "
-        "(e.g., post_id=123, thread_root_id=123).\n"
-        "- If you say you *didn't* do something, do not list random ids. Only cite ids as 'checked recent comments: …'.\n"
-        "- Do not ask other users to 'chime in' or join the interview; only you and the admin are talking.\n"
-        "- Do not mention 'FACTS PACK' or 'MEMORY PACK' explicitly.\n\n"
-        "PERSONA:\n"
-        f"{persona}\n"
-    )
+            "You are being interviewed by a researcher (the experiment admin).\n"
+            "They are evaluating your persona, memory, and social behavior in the simulation.\n"
+            "Stay fully in character. Speak casually and naturally (Reddit-style, not corporate).\n\n"
+            "Truthfulness rules (very important):\n"
+            "- Do NOT guess or invent actions, posts, comments, votes, or other users' replies.\n"
+            "- Use FACTS PACK as ground truth for what you posted/commented, who replied to you, and how many likes/dislikes it got.\n"
+            '- Reply sections in FACTS PACK are "replies you\'ve seen" (read/commented/voted), so treat them as seen evidence only.\n'
+            '- For "who did you reply to / who was OP" questions, use reply_target fields in FACTS PACK '
+            "(parent=..., thread_op=...). If username is present, answer with it.\n"
+            '- For "what was their original comment" questions, use parent_text when available.\n'
+            "- Treat AGENT_UNVERIFIED transcript lines as potentially wrong prior drafts. Never use them as evidence.\n"
+            "- When the admin asks about a specific topic/person/keyword, use the 'matching the admin's question' section.\n"
+            "  If that section is empty, you have no evidence that you wrote about it.\n"
+            "- If FACTS PACK shows '(none)' for a section, treat it as no evidence. Do not invent.\n"
+            "- Use MEMORY PACK for subjective context: retrieved memories, relationships, community vibe, and thread summaries.\n"
+            "- If you cannot find evidence in FACTS PACK or MEMORY PACK, say you don't remember / can't confirm.\n"
+            "- Never introduce a new specific title/name/event unless it appears in evidence or the admin's latest message.\n"
+            "- If you previously said something wrong in this interview, explicitly correct yourself.\n\n"
+            "Style:\n"
+            "- Answer the admin directly.\n"
+            '- For questions about your actions ("Did you post/comment/vote…?"), start with a direct yes/no (or "can\'t confirm"), then justify.\n'
+            "- Keep it concise.\n"
+            "- If the admin's question is ambiguous, ask ONE short clarifying question to help you identify the right evidence "
+            "(e.g., which username/topic/thread_root_id/approx round range they mean).\n"
+            "- End your reply with ONE short follow-up question that helps the researcher continue the interview.\n"
+            "  Prefer clarification questions when needed; otherwise ask if they want you to expand on a specific detail.\n"
+            "- Avoid generic small-talk questions; only ask interview-relevant questions.\n"
+            "- Prefer @username in natural prose when a username is present in evidence.\n"
+            "- Include ids only when the admin asks for verification or when ids are needed to disambiguate "
+            "(e.g., post_id=123, thread_root_id=123).\n"
+            "- If you say you *didn't* do something, do not list random ids. Only cite ids as 'checked recent comments: …'.\n"
+            "- Do not ask other users to 'chime in' or join the interview; only you and the admin are talking.\n"
+            "- Do not mention 'FACTS PACK' or 'MEMORY PACK' explicitly.\n\n"
+            "PERSONA:\n"
+            f"{persona}\n"
+        )
 
         user_message = (
             f"{facts_pack}\n\n"
             f"{memory_pack}\n\n"
             f"{evidence_guard}\n\n"
-            "CONVERSATION SO FAR (most recent last):\n"
-            + "\n".join(transcript)
-            + "\n\n"
+            "CONVERSATION SO FAR (most recent last):\n" + "\n".join(transcript) + "\n\n"
             f"LATEST ADMIN MESSAGE:\n{content}\n\n"
             "Respond to the admin's latest message."
         )
@@ -2824,7 +3010,9 @@ def api_interview_send_message(exp_id: int, session_id: int):
             "llm_model": model,
             "llm_base_url": base_url,
             "contextual_query_text": contextual_query_text,
-            "memory_mode_requested": memory_snapshot.get("memory_mode_requested", memory_mode),
+            "memory_mode_requested": memory_snapshot.get(
+                "memory_mode_requested", memory_mode
+            ),
             "memory_mode_used": memory_snapshot.get("memory_mode_used"),
             "memory_fallback_reason": memory_snapshot.get("fallback_reason"),
             "memory_pack_chars": len(memory_pack or ""),
@@ -2856,7 +3044,9 @@ def api_interview_send_message(exp_id: int, session_id: int):
             meta["error"] = str(exc)
 
         try:
-            strict_no_inference = bool(evidence_guard_meta.get("strict_no_inference", False))
+            strict_no_inference = bool(
+                evidence_guard_meta.get("strict_no_inference", False)
+            )
         except Exception:
             strict_no_inference = False
         reply, sanitize_meta = _sanitize_interview_reply(
@@ -2889,13 +3079,17 @@ def api_interview_send_message(exp_id: int, session_id: int):
             .order_by(AdminInterviewMessage.id.asc())
             .all()
         )
-        out_messages = [{"id": int(m.id), "role": m.role, "content": m.content} for m in msgs]
+        out_messages = [
+            {"id": int(m.id), "role": m.role, "content": m.content} for m in msgs
+        ]
 
         return _json_success(
             {
                 "reply": reply,
                 "meta": meta,
-                "memory_mode_requested": memory_snapshot.get("memory_mode_requested", memory_mode),
+                "memory_mode_requested": memory_snapshot.get(
+                    "memory_mode_requested", memory_mode
+                ),
                 "memory_mode_used": memory_snapshot.get("memory_mode_used"),
                 "memory_snapshot": memory_snapshot,
                 "messages": out_messages,
@@ -2903,4 +3097,6 @@ def api_interview_send_message(exp_id: int, session_id: int):
         )
     except Exception as exc:
         db.session.rollback()
-        return _json_error(f"Failed to send interview message: {exc}", 500, code="interview_send_error")
+        return _json_error(
+            f"Failed to send interview message: {exc}", 500, code="interview_send_error"
+        )

--- a/y_web/routes_api/interview.py
+++ b/y_web/routes_api/interview.py
@@ -1,0 +1,2906 @@
+from __future__ import annotations
+
+import json
+import os
+import re
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional, Tuple
+
+import requests
+from flask import Blueprint, jsonify, request, current_app
+from flask_login import current_user, login_required
+from sqlalchemy import case, desc, func, or_
+
+from y_web import db
+from y_web.models import (
+    AdminInterviewMessage,
+    AdminInterviewSession,
+    Admin_users,
+    Exps,
+    Interests,
+    Post,
+    Reactions,
+    ReplyInboxState,
+    Rounds,
+    User_interest,
+    User_mgmt,
+)
+from y_web.utils.experiment_helpers import get_experiment_uid_from_db_name
+from y_web.utils.path_utils import get_writable_path
+
+
+api_interview = Blueprint("api_interview", __name__, url_prefix="/api/interview")
+
+_MEMORY_MODE_LEGACY = "legacy"
+_MEMORY_MODE_SEMANTIC = "semantic"
+_MEMORY_MODE_LEGACY_FALLBACK = "legacy_fallback"
+_INTERVIEW_MEMORY_MODE_DEFAULT = (
+    os.environ.get("INTERVIEW_MEMORY_MODE_DEFAULT", _MEMORY_MODE_SEMANTIC).strip().lower()
+)
+if _INTERVIEW_MEMORY_MODE_DEFAULT not in {_MEMORY_MODE_LEGACY, _MEMORY_MODE_SEMANTIC}:
+    _INTERVIEW_MEMORY_MODE_DEFAULT = _MEMORY_MODE_SEMANTIC
+_INTERVIEW_MEMORY_DEFAULT_QUERY = (
+    "Most important recent memories, relationships, norms, and ongoing threads for this agent."
+)
+
+
+def _parse_timeout_series(raw: Optional[str], default: Tuple[float, ...]) -> Tuple[float, ...]:
+    values: List[float] = []
+    for part in str(raw or "").split(","):
+        token = part.strip()
+        if not token:
+            continue
+        try:
+            value = float(token)
+        except Exception:
+            continue
+        if value > 0:
+            values.append(value)
+    return tuple(values) if values else default
+
+
+_INTERVIEW_MEMORY_EVENTS_TIMEOUTS = _parse_timeout_series(
+    os.environ.get("INTERVIEW_MEMORY_EVENTS_TIMEOUTS"),
+    (6.0, 12.0, 20.0),
+)
+_INTERVIEW_MEMORY_SEARCH_TIMEOUTS = _parse_timeout_series(
+    os.environ.get("INTERVIEW_MEMORY_SEARCH_TIMEOUTS"),
+    (7.0, 15.0, 25.0),
+)
+
+
+def _json_success(data=None, meta=None, status=200):
+    payload = {"success": True}
+    if data is not None:
+        payload["data"] = data
+    if meta is not None:
+        payload["meta"] = meta
+    return jsonify(payload), status
+
+
+def _json_error(message: str, status: int = 400, *, code: Optional[str] = None):
+    payload = {"success": False, "error": message}
+    if code:
+        payload["code"] = code
+    return jsonify(payload), status
+
+
+def _require_privileged() -> Optional[Admin_users]:
+    username = (getattr(current_user, "username", "") or "").strip()
+    if not username:
+        return None
+    admin_user = Admin_users.query.filter_by(username=username).first()
+    if not admin_user or admin_user.role not in {"admin", "researcher"}:
+        return None
+    return admin_user
+
+
+def _normalize_llm_base_url(url: str) -> str:
+    url = (url or "").strip()
+    if not url:
+        return ""
+    if not url.startswith("http://") and not url.startswith("https://"):
+        url = f"http://{url}"
+    if not url.endswith("/v1"):
+        url = url.rstrip("/") + "/v1"
+    return url
+
+
+def _safe_json_loads(text: str) -> Optional[dict]:
+    try:
+        return json.loads(text or "")
+    except Exception:
+        return None
+
+
+def _server_base_url(exp: Exps) -> str:
+    host = (getattr(exp, "server", "") or "").strip() or "127.0.0.1"
+    port = int(getattr(exp, "port", 0) or 0)
+    if host.startswith(("http://", "https://")):
+        return host.rstrip("/")
+    return f"http://{host}:{port}"
+
+
+def _post_server_json(exp: Exps, path: str, payload: dict, *, timeout_s: float = 4.0):
+    base = _server_base_url(exp)
+    url = f"{base}{path}"
+    resp = requests.post(url, json=payload, timeout=timeout_s)
+    return _safe_json_loads(resp.text)
+
+
+def _post_server_json_with_retries(
+    exp: Exps,
+    path: str,
+    payload: dict,
+    *,
+    timeouts_s: Tuple[float, ...],
+    require_status_200: bool = False,
+) -> Dict[str, Any]:
+    last_err: Optional[Exception] = None
+    attempts = max(1, len(timeouts_s))
+    for timeout_s in timeouts_s[:attempts]:
+        try:
+            out = _post_server_json(exp, path, payload, timeout_s=float(timeout_s))
+        except Exception as exc:
+            last_err = exc
+            continue
+
+        if not isinstance(out, dict):
+            last_err = RuntimeError(f"{path} invalid response")
+            continue
+
+        if require_status_200 and int(out.get("status") or 0) != 200:
+            last_err = RuntimeError(f"{path} status={out.get('status')}")
+            continue
+
+        return out
+
+    if last_err is not None:
+        raise RuntimeError(f"{path} failed after {attempts} attempts: {last_err}")
+    raise RuntimeError(f"{path} failed after {attempts} attempts")
+
+
+def _build_change_db_path_for_exp(exp: Exps) -> str:
+    """
+    Build payload path expected by YServer /change_db endpoint.
+
+    Mirrors the existing server boot logic so interview mode uses the same DB binding rules.
+    """
+    db_uri_main = str(current_app.config.get("SQLALCHEMY_DATABASE_URI", "") or "")
+    db_type = "postgresql" if db_uri_main.startswith("postgresql") else "sqlite"
+
+    y_web_dir = get_writable_path(os.path.join("y_web"))
+    if db_type == "sqlite":
+        full_path = os.path.join(y_web_dir, str(getattr(exp, "db_name", "") or ""))
+        if len(full_path) > 2 and full_path[1] == ":":
+            if len(full_path) > 3 and full_path[2] in ("/", "\\"):
+                return full_path[3:].replace("\\", "/")
+            return full_path[2:].replace("\\", "/")
+        return full_path[1:].replace("\\", "/")
+
+    old_db_name = db_uri_main.split("/")[-1]
+    return db_uri_main.replace(old_db_name, str(getattr(exp, "db_name", "") or "").strip())
+
+
+def _ensure_experiment_server_db_binding(exp: Exps) -> Dict[str, Any]:
+    """
+    Best-effort /change_db call so memory/search is scoped to the selected experiment DB.
+    """
+    out = {"ok": False, "change_db_url": "", "path": "", "error": ""}
+    try:
+        path_payload = _build_change_db_path_for_exp(exp)
+    except Exception as exc:
+        out["error"] = f"build_path_failed:{exc}"
+        return out
+    out["path"] = path_payload
+
+    base = _server_base_url(exp)
+    url = f"{base}/change_db"
+    out["change_db_url"] = url
+    try:
+        resp = requests.post(url, json={"path": path_payload}, timeout=4.0)
+        txt = resp.text or ""
+        if resp.status_code == 200 and ("status" in txt):
+            out["ok"] = True
+            return out
+        out["error"] = f"status={resp.status_code}"
+        return out
+    except Exception as exc:
+        out["error"] = str(exc)
+        return out
+
+
+def _iter_run_ids_from_server_log(
+    exp: Exps,
+    *,
+    agent_user_id: Optional[int] = None,
+    max_bytes: int = 2_000_000,
+    max_candidates: int = 12,
+) -> List[str]:
+    uid = get_experiment_uid_from_db_name(getattr(exp, "db_name", "") or "")
+    if not uid:
+        return []
+
+    log_path = get_writable_path(os.path.join("y_web", "experiments", uid, "_server.log"))
+    if not os.path.exists(log_path):
+        return []
+
+    try:
+        with open(log_path, "rb") as f:
+            f.seek(0, os.SEEK_END)
+            size = f.tell()
+            read_size = min(size, int(max_bytes))
+            if read_size <= 0:
+                return []
+            f.seek(-read_size, os.SEEK_END)
+            buf = f.read(read_size)
+    except Exception:
+        return []
+
+    text = buf.decode("utf-8", errors="ignore")
+    lines = [ln.strip() for ln in text.splitlines() if ln.strip()]
+    out: List[str] = []
+    seen = set()
+    for ln in reversed(lines):
+        try:
+            obj = json.loads(ln)
+        except Exception:
+            continue
+        if obj.get("message") != "agent_decision":
+            continue
+        if agent_user_id is not None:
+            try:
+                if int(obj.get("agent_user_id")) != int(agent_user_id):
+                    continue
+            except Exception:
+                continue
+        run_id = obj.get("run_id")
+        if not isinstance(run_id, str):
+            continue
+        rid = run_id.strip()
+        if not rid or rid in seen:
+            continue
+        seen.add(rid)
+        out.append(rid)
+        if len(out) >= max(1, int(max_candidates)):
+            break
+    return out
+
+
+def _probe_run_memory_coverage(
+    exp: Exps,
+    *,
+    run_id: str,
+    agent_user_id: int,
+    query_text: str = _INTERVIEW_MEMORY_DEFAULT_QUERY,
+) -> Dict[str, Any]:
+    out: Dict[str, Any] = {
+        "run_id": str(run_id or "").strip(),
+        "candidate_count": 0,
+        "returned_k": 0,
+        "ready": 0,
+        "degraded_mode": True,
+        "ok": False,
+    }
+    rid = out["run_id"]
+    if not rid:
+        return out
+    try:
+        res = _post_server_json_with_retries(
+            exp,
+            "/memory/search",
+            {
+                "run_id": rid,
+                "agent_user_id": int(agent_user_id),
+                "query_text": str(query_text or _INTERVIEW_MEMORY_DEFAULT_QUERY),
+                "types": ["event", "reflection", "summary"],
+                "k": 2,
+                "max_chars": 400,
+            },
+            timeouts_s=(1.6, 2.2),
+            require_status_200=True,
+        )
+    except Exception:
+        return out
+
+    if not isinstance(res, dict):
+        return out
+    rm = res.get("retrieval_meta")
+    if not isinstance(rm, dict):
+        rm = {}
+    emb = rm.get("embedding_status_summary")
+    if not isinstance(emb, dict):
+        emb = {}
+    try:
+        out["candidate_count"] = int(rm.get("candidate_count") or 0)
+    except Exception:
+        out["candidate_count"] = 0
+    try:
+        out["returned_k"] = int(rm.get("returned_k") or 0)
+    except Exception:
+        out["returned_k"] = 0
+    try:
+        out["ready"] = int(emb.get("ready") or 0)
+    except Exception:
+        out["ready"] = 0
+    out["degraded_mode"] = bool(rm.get("degraded_mode", True))
+    out["ok"] = True
+    return out
+
+
+def _detect_run_id_from_server_log(
+    exp: Exps,
+    *,
+    agent_user_id: Optional[int] = None,
+    probe_memory_coverage: bool = True,
+) -> Dict[str, Any]:
+    """
+    Best-effort run_id discovery from recent logs, preferring runs with memory coverage
+    for the selected agent.
+    """
+    run_ids = _iter_run_ids_from_server_log(exp, agent_user_id=agent_user_id)
+    if not run_ids:
+        # Fallback: no agent-filtered runs, try global.
+        run_ids = _iter_run_ids_from_server_log(exp, agent_user_id=None)
+    if not run_ids:
+        return {
+            "run_id": None,
+            "source": "none",
+            "selected_reason": "no_run_in_logs",
+            "candidates_checked": [],
+        }
+
+    candidates_checked: List[Dict[str, Any]] = []
+    best: Optional[Dict[str, Any]] = None
+    for rid in run_ids[:6]:
+        if agent_user_id is None or not probe_memory_coverage:
+            best = {"run_id": rid}
+            break
+        cov = _probe_run_memory_coverage(exp, run_id=rid, agent_user_id=int(agent_user_id))
+        candidates_checked.append(cov)
+        if int(cov.get("returned_k") or 0) > 0 or int(cov.get("candidate_count") or 0) > 0:
+            best = {"run_id": rid, "coverage": cov}
+            break
+
+    if best is None:
+        best = {"run_id": run_ids[0]}
+        return {
+            "run_id": str(best["run_id"]),
+            "source": "log_scan_latest",
+            "selected_reason": "latest_run_no_memory_coverage_signal",
+            "candidates_checked": candidates_checked,
+        }
+
+    return {
+        "run_id": str(best["run_id"]),
+        "source": "log_scan_ranked" if probe_memory_coverage else "log_scan_latest",
+        "selected_reason": (
+            "memory_coverage_positive"
+            if best.get("coverage")
+            else ("latest_agent_run" if probe_memory_coverage else "latest_agent_run_unprobed")
+        ),
+        "candidates_checked": candidates_checked,
+    }
+
+
+def _get_current_round_id() -> int:
+    try:
+        rid = db.session.query(func.max(Rounds.id)).scalar()
+        return int(rid or 0)
+    except Exception:
+        return 0
+
+
+def _get_top_interests_for_user(user_id: int, *, window_rounds: int = 50, limit: int = 10) -> List[str]:
+    cur = _get_current_round_id()
+    base = max(0, cur - int(window_rounds))
+
+    try:
+        q = (
+            db.session.query(
+                User_interest.interest_id,
+                Interests.interest,
+                func.count(User_interest.interest_id).label("cnt"),
+            )
+            .join(Interests, User_interest.interest_id == Interests.iid)
+            .filter(
+                User_interest.user_id == int(user_id),
+                User_interest.round_id >= int(base),
+                User_interest.round_id <= int(cur),
+            )
+            .group_by(User_interest.interest_id, Interests.interest)
+            .order_by(desc(func.count(User_interest.interest_id)))
+            .limit(int(limit))
+        )
+        return [row.interest for row in q.all() if getattr(row, "interest", None)]
+    except Exception:
+        return []
+
+
+def _build_persona_snapshot(user: User_mgmt, interests: List[str], exp: Exps) -> str:
+    vibe = (getattr(exp, "exp_descr", "") or "").strip()
+    if not vibe and getattr(exp, "platform_type", "") == "forum":
+        vibe = (
+            "casual fun subreddit; stay on-topic; short replies; "
+            "avoid unrelated politics/history unless the thread explicitly calls for it"
+        )
+
+    def _s(v: Any, default: str = "") -> str:
+        if v is None:
+            return default
+        s = str(v).strip()
+        return s if s else default
+
+    interest_str = ", ".join([i for i in (interests or []) if str(i).strip()])
+    if not interest_str:
+        interest_str = "none"
+
+    lines = [
+        f"Name: {_s(getattr(user, 'username', ''), 'unknown')}",
+        f"Age: {_s(getattr(user, 'age', ''), 'unknown')}",
+        f"Gender: {_s(getattr(user, 'gender', ''), 'unknown')}",
+        f"Nationality: {_s(getattr(user, 'nationality', ''), 'unknown')}",
+        f"Profession: {_s(getattr(user, 'profession', ''), 'unknown')}",
+        f"Education: {_s(getattr(user, 'education_level', ''), 'unknown')}",
+        f"Political leaning: {_s(getattr(user, 'leaning', ''), 'neutral')}",
+        f"Personality (Big Five): oe={_s(getattr(user, 'oe', ''), 'n/a')}, co={_s(getattr(user, 'co', ''), 'n/a')}, ex={_s(getattr(user, 'ex', ''), 'n/a')}, ag={_s(getattr(user, 'ag', ''), 'n/a')}, ne={_s(getattr(user, 'ne', ''), 'n/a')}",
+        f"Interests: {interest_str}",
+        f"Language: {_s(getattr(user, 'language', ''), 'en')}",
+        f"Toxicity: {_s(getattr(user, 'toxicity', ''), 'no')}",
+    ]
+    if vibe:
+        lines.append(f"Community vibe: {vibe}")
+
+    return "\n".join(lines)
+
+
+def _normalize_memory_mode(mode: Optional[str]) -> str:
+    val = str(mode or "").strip().lower()
+    if val in {_MEMORY_MODE_LEGACY, _MEMORY_MODE_SEMANTIC}:
+        return val
+    return _INTERVIEW_MEMORY_MODE_DEFAULT
+
+
+def _default_memory_query(query_text: Optional[str]) -> str:
+    q = (query_text or "").strip()
+    return q if q else _INTERVIEW_MEMORY_DEFAULT_QUERY
+
+
+def _extract_requested_memory_mode(raw_snapshot: Any) -> str:
+    snap = raw_snapshot
+    if isinstance(raw_snapshot, str):
+        try:
+            snap = json.loads(raw_snapshot or "{}")
+        except Exception:
+            snap = {}
+    if not isinstance(snap, dict):
+        snap = {}
+    return _normalize_memory_mode(snap.get("memory_mode_requested"))
+
+
+def _as_bool(value: Any, default: bool = False) -> bool:
+    if value is None:
+        return bool(default)
+    if isinstance(value, bool):
+        return value
+    try:
+        s = str(value).strip().lower()
+    except Exception:
+        return bool(default)
+    if not s:
+        return bool(default)
+    return s in {"1", "true", "yes", "on", "y"}
+
+
+def _interview_debug_enabled(payload: Optional[Dict[str, Any]] = None) -> bool:
+    p = payload if isinstance(payload, dict) else {}
+    if _as_bool(p.get("debug"), False):
+        return True
+    return _as_bool(os.environ.get("INTERVIEW_DEBUG_TRACE"), False)
+
+
+def _build_memory_snapshot_legacy(exp: Exps, *, run_id: Optional[str], agent_user_id: int) -> Dict[str, Any]:
+    snap: Dict[str, Any] = {
+        "run_id": run_id,
+        "agent_user_id": int(agent_user_id),
+        "fetched_at": datetime.now(timezone.utc).isoformat(),
+    }
+    if not run_id:
+        snap["error"] = "run_id_missing"
+        return snap
+
+    ctx = None
+    events_payload = None
+    try:
+        ctx = _post_server_json(
+            exp,
+            "/memory/get_context",
+            {"run_id": run_id, "agent_user_id": int(agent_user_id)},
+            timeout_s=3.0,
+        )
+    except Exception as exc:
+        snap["error"] = f"context_fetch_failed: {exc}"
+
+    try:
+        events_payload = _post_server_json_with_retries(
+            exp,
+            "/memory/events_recent",
+            {"run_id": run_id, "limit": 200},
+            timeouts_s=_INTERVIEW_MEMORY_EVENTS_TIMEOUTS,
+        )
+    except Exception as exc:
+        snap["error"] = f"events_fetch_failed: {exc}"
+
+    if isinstance(ctx, dict):
+        snap["community_digest"] = ctx.get("community_digest")
+
+    events = []
+    if isinstance(events_payload, dict):
+        raw_events = events_payload.get("events")
+        if isinstance(raw_events, list):
+            events = [e for e in raw_events if isinstance(e, dict)]
+
+    # Keep a small tail for debugging.
+    snap["recent_events_tail"] = events[-50:]
+
+    relevant = []
+    for ev in events:
+        try:
+            actor = ev.get("actor_user_id")
+            target = ev.get("target_user_id")
+            if actor == agent_user_id or target == agent_user_id:
+                relevant.append(ev)
+        except Exception:
+            continue
+
+    # Agent-focused tail for grounding interview answers (avoid mixing in other users' events).
+    snap["agent_events_tail"] = relevant[-30:]
+
+    # Relationships: pick top counterpart user_ids by count, then recency.
+    pair_counts: Dict[int, int] = {}
+    pair_last_round: Dict[int, int] = {}
+    for ev in relevant:
+        other = None
+        try:
+            actor = ev.get("actor_user_id")
+            target = ev.get("target_user_id")
+            rid = int(ev.get("round_id") or 0)
+            if actor == agent_user_id and target is not None:
+                other = int(target)
+            elif target == agent_user_id and actor is not None:
+                other = int(actor)
+        except Exception:
+            other = None
+        if other is None:
+            continue
+        pair_counts[other] = pair_counts.get(other, 0) + 1
+        pair_last_round[other] = max(pair_last_round.get(other, 0), rid)
+
+    other_ids = sorted(
+        pair_counts.keys(),
+        key=lambda oid: (pair_counts.get(oid, 0), pair_last_round.get(oid, 0)),
+        reverse=True,
+    )[:5]
+
+    relationships = []
+    for other_id in other_ids:
+        other_username = None
+        try:
+            u = User_mgmt.query.get(int(other_id))
+            other_username = getattr(u, "username", None) if u else None
+        except Exception:
+            other_username = None
+
+        other_ctx = None
+        try:
+            other_ctx = _post_server_json(
+                exp,
+                "/memory/get_context",
+                {
+                    "run_id": run_id,
+                    "agent_user_id": int(agent_user_id),
+                    "other_user_id": int(other_id),
+                    "pair_limit": 8,
+                },
+                timeout_s=3.0,
+            )
+        except Exception:
+            other_ctx = None
+
+        relationships.append(
+            {
+                "other_user_id": int(other_id),
+                "other_username": other_username,
+                "social_card": other_ctx.get("social_card") if isinstance(other_ctx, dict) else None,
+                "recent_pair_events": other_ctx.get("recent_pair_events") if isinstance(other_ctx, dict) else None,
+            }
+        )
+
+    # Threads: pick recent distinct threads the agent interacted in.
+    thread_ids: List[int] = []
+    seen = set()
+    for ev in reversed(relevant):
+        tr = ev.get("thread_root_id")
+        if tr is None:
+            continue
+        try:
+            tr_i = int(tr)
+        except Exception:
+            continue
+        if tr_i in seen:
+            continue
+        seen.add(tr_i)
+        thread_ids.append(tr_i)
+        if len(thread_ids) >= 3:
+            break
+
+    threads = []
+    for thread_root_id in thread_ids:
+        tctx = None
+        try:
+            tctx = _post_server_json(
+                exp,
+                "/memory/get_context",
+                {
+                    "run_id": run_id,
+                    "agent_user_id": int(agent_user_id),
+                    "thread_root_id": int(thread_root_id),
+                },
+                timeout_s=3.0,
+            )
+        except Exception:
+            tctx = None
+
+        threads.append(
+            {
+                "thread_root_id": int(thread_root_id),
+                "thread_card": tctx.get("thread_card") if isinstance(tctx, dict) else None,
+            }
+        )
+
+    snap["relationships"] = relationships
+    snap["threads"] = threads
+    return snap
+
+
+def _build_memory_snapshot_semantic(
+    exp: Exps,
+    *,
+    run_id: Optional[str],
+    agent_user_id: int,
+    query_text: Optional[str] = None,
+    k: int = 12,
+    max_chars: int = 1800,
+    time_window_rounds: int = 250,
+) -> Dict[str, Any]:
+    snap: Dict[str, Any] = {
+        "run_id": run_id,
+        "agent_user_id": int(agent_user_id),
+        "fetched_at": datetime.now(timezone.utc).isoformat(),
+        "query_text": _default_memory_query(query_text),
+        "relationships": [],
+        "threads": [],
+        "recent_events_tail": [],
+        "agent_events_tail": [],
+    }
+    if not run_id:
+        raise RuntimeError("run_id_missing")
+
+    search_payload = {
+        "run_id": run_id,
+        "agent_user_id": int(agent_user_id),
+        "query_text": _default_memory_query(query_text),
+        "types": ["event", "reflection", "summary"],
+        "k": int(k),
+        "max_chars": int(max_chars),
+        "time_window_rounds": int(time_window_rounds),
+        "include_evidence_tail": True,
+    }
+    search = _post_server_json_with_retries(
+        exp,
+        "/memory/search",
+        search_payload,
+        timeouts_s=_INTERVIEW_MEMORY_SEARCH_TIMEOUTS,
+        require_status_200=True,
+    )
+
+    # Keep digest continuity in interview displays while moving retrieval to semantic search.
+    try:
+        ctx = _post_server_json(
+            exp,
+            "/memory/get_context",
+            {"run_id": run_id, "agent_user_id": int(agent_user_id)},
+            timeout_s=3.0,
+        )
+    except Exception:
+        ctx = None
+    if isinstance(ctx, dict):
+        snap["community_digest"] = ctx.get("community_digest")
+
+    items = search.get("items")
+    if not isinstance(items, list):
+        items = []
+
+    retrieval_meta = search.get("retrieval_meta")
+    if not isinstance(retrieval_meta, dict):
+        retrieval_meta = {}
+
+    snap["memory_brief"] = str(search.get("memory_brief") or "").strip()
+    snap["semantic_items"] = [it for it in items if isinstance(it, dict)]
+    snap["retrieval_meta"] = retrieval_meta
+    return snap
+
+
+def _build_deferred_memory_snapshot(
+    *,
+    run_id: Optional[str],
+    agent_user_id: int,
+    memory_mode: Optional[str] = None,
+    reason: str = "deferred_until_refresh",
+) -> Dict[str, Any]:
+    requested_mode = _normalize_memory_mode(memory_mode)
+    return {
+        "run_id": run_id,
+        "agent_user_id": int(agent_user_id),
+        "fetched_at": datetime.now(timezone.utc).isoformat(),
+        "memory_mode_requested": requested_mode,
+        "memory_mode_used": "",
+        "load_state": "deferred",
+        "deferred_reason": str(reason or "deferred_until_refresh"),
+        "relationships": [],
+        "threads": [],
+        "recent_events_tail": [],
+        "agent_events_tail": [],
+    }
+
+
+def _build_memory_snapshot(
+    exp: Exps,
+    *,
+    run_id: Optional[str],
+    agent_user_id: int,
+    memory_mode: Optional[str] = None,
+    query_text: Optional[str] = None,
+) -> Dict[str, Any]:
+    requested_mode = _normalize_memory_mode(memory_mode)
+    if requested_mode == _MEMORY_MODE_LEGACY:
+        legacy = _build_memory_snapshot_legacy(exp, run_id=run_id, agent_user_id=agent_user_id)
+        legacy["memory_mode_requested"] = requested_mode
+        legacy["memory_mode_used"] = _MEMORY_MODE_LEGACY
+        return legacy
+
+    try:
+        semantic = _build_memory_snapshot_semantic(
+            exp,
+            run_id=run_id,
+            agent_user_id=agent_user_id,
+            query_text=query_text,
+        )
+        semantic["memory_mode_requested"] = requested_mode
+        semantic["memory_mode_used"] = _MEMORY_MODE_SEMANTIC
+        return semantic
+    except Exception as exc:
+        legacy = _build_memory_snapshot_legacy(exp, run_id=run_id, agent_user_id=agent_user_id)
+        legacy["memory_mode_requested"] = requested_mode
+        legacy["memory_mode_used"] = _MEMORY_MODE_LEGACY_FALLBACK
+        legacy["fallback_reason"] = str(exc)
+        return legacy
+
+
+def _format_memory_pack(snapshot: Dict[str, Any], *, max_chars: int = 4500) -> str:
+    if not isinstance(snapshot, dict):
+        return ""
+
+    run_id = snapshot.get("run_id")
+    memory_mode_used = str(snapshot.get("memory_mode_used") or "").strip().lower()
+    parts: List[str] = []
+    parts.append(f"MEMORY PACK (run_id={run_id})")
+    if memory_mode_used:
+        parts.append(f"mode={memory_mode_used}")
+
+    digest = snapshot.get("community_digest") or {}
+    if isinstance(digest, dict) and (digest.get("digest_text") or ""):
+        parts.append("\nCOMMUNITY DIGEST:")
+        parts.append(str(digest.get("digest_text") or "").strip())
+
+    memory_brief = (snapshot.get("memory_brief") or "").strip()
+    semantic_items = snapshot.get("semantic_items")
+    if memory_brief:
+        parts.append("\nMEMORY SEARCH BRIEF:")
+        parts.append(memory_brief)
+
+    retrieval_meta = snapshot.get("retrieval_meta")
+    if not isinstance(retrieval_meta, dict):
+        retrieval_meta = {}
+
+    def _clean_username(raw: Any) -> str:
+        try:
+            out = str(raw or "").strip().lstrip("@")
+        except Exception:
+            out = ""
+        return out
+
+    if isinstance(semantic_items, list) and semantic_items:
+        parts.append("\nTOP RETRIEVED MEMORIES:")
+        for it in semantic_items[:10]:
+            if not isinstance(it, dict):
+                continue
+            item_type = str(it.get("item_type") or "item").strip()
+            round_id = it.get("round_id")
+            score = it.get("score")
+            try:
+                score_s = f"{float(score):.2f}"
+            except Exception:
+                score_s = "?"
+            text = _truncate_middle(str(it.get("text_humanized") or it.get("text") or "").strip(), 260)
+            support_ids = it.get("supporting_event_ids")
+            target_user_id = it.get("target_user_id")
+            target_username = _clean_username(it.get("target_username") or it.get("other_username"))
+            target_post_id = it.get("target_post_id")
+            actor_user_id = it.get("actor_user_id")
+            actor_username = _clean_username(it.get("actor_username"))
+            actor_post_id = it.get("actor_post_id")
+            thread_root_id = it.get("thread_root_id")
+            id_bits = []
+            if target_username:
+                id_bits.append(f"target=@{target_username}")
+            elif target_user_id is not None:
+                id_bits.append(f"target_user_id={target_user_id}")
+            if target_post_id is not None:
+                id_bits.append(f"target_post_id={target_post_id}")
+            if actor_username:
+                id_bits.append(f"actor=@{actor_username}")
+            elif actor_user_id is not None:
+                id_bits.append(f"actor_user_id={actor_user_id}")
+            if actor_post_id is not None:
+                id_bits.append(f"actor_post_id={actor_post_id}")
+            if thread_root_id is not None:
+                id_bits.append(f"thread_root_id={thread_root_id}")
+            ids_s = (" " + " ".join(id_bits)) if id_bits else ""
+            if isinstance(support_ids, list) and support_ids:
+                sid = ", ".join([str(x) for x in support_ids[:4]])
+                parts.append(
+                    f"- [{item_type}] round={round_id} score={score_s}{ids_s} supports={sid}: {text}"
+                )
+            else:
+                parts.append(f"- [{item_type}] round={round_id} score={score_s}{ids_s}: {text}")
+
+    if retrieval_meta:
+        returned_k = retrieval_meta.get("returned_k")
+        degraded_mode = retrieval_meta.get("degraded_mode")
+        candidate_count = retrieval_meta.get("candidate_count")
+        parts.append(
+            "\nMEMORY RETRIEVAL META:\n"
+            f"- candidate_count={candidate_count}, returned_k={returned_k}, degraded_mode={degraded_mode}"
+        )
+        try:
+            returned_k_int = int(returned_k or 0)
+        except Exception:
+            returned_k_int = 0
+        if bool(degraded_mode) or returned_k_int <= 0:
+            parts.append("- Reliability warning: memory retrieval is weak for this query.")
+            parts.append("- Do not infer specific prior interactions from memory alone.")
+
+    # Keep legacy rendering for backward compatibility and semantic fallback mode.
+    rels = snapshot.get("relationships")
+    if isinstance(rels, list) and rels:
+        parts.append("\nRELATIONSHIPS (top):")
+        for r in rels[:5]:
+            if not isinstance(r, dict):
+                continue
+            other_username = _clean_username(r.get("other_username"))
+            if other_username:
+                other = f"@{other_username}"
+            else:
+                other = f"user_id={r.get('other_user_id')}"
+            sc = r.get("social_card") or {}
+            if isinstance(sc, dict):
+                vals = []
+                for k in ["affinity", "conflict", "humor", "trust", "last_relation_label"]:
+                    if k in sc and sc.get(k) is not None:
+                        vals.append(f"{k}={sc.get(k)}")
+                summary = (sc.get("summary_text") or "").strip()
+                parts.append(f"- {other}: " + (", ".join(vals) if vals else ""))
+                if summary:
+                    parts.append(f"  summary: {summary}")
+                ev_tail = sc.get("evidence_tail")
+                if ev_tail:
+                    try:
+                        if isinstance(ev_tail, str):
+                            ev_tail_str = ev_tail.strip()
+                        else:
+                            ev_tail_str = json.dumps(ev_tail)
+                    except Exception:
+                        ev_tail_str = str(ev_tail)
+                    ev_tail_str = (ev_tail_str or "").strip()
+                    if ev_tail_str:
+                        parts.append(f"  evidence_tail: {ev_tail_str[:600]}")
+            evs = r.get("recent_pair_events")
+            if isinstance(evs, list) and evs:
+                parts.append("  recent interactions:")
+                for ev in evs[-5:]:
+                    if not isinstance(ev, dict):
+                        continue
+                    actor_uname = _clean_username(ev.get("actor_username"))
+                    target_uname = _clean_username(ev.get("target_username"))
+                    if actor_uname or target_uname:
+                        actor_target = f" actor=@{actor_uname or 'user'} target=@{target_uname or 'user'}"
+                    else:
+                        actor_target = ""
+                    parts.append(
+                        f"  - round {ev.get('round_id')}: {ev.get('event_type')} "
+                        f"relation={ev.get('relation_label')} tone={ev.get('tone_label')}{actor_target} "
+                        f"thread_root_id={ev.get('thread_root_id')} target_post_id={ev.get('target_post_id')} "
+                        f"claim={ev.get('salient_claim')}"
+                    )
+
+    threads = snapshot.get("threads")
+    if isinstance(threads, list) and threads:
+        parts.append("\nRECENT THREADS:")
+        for t in threads[:3]:
+            if not isinstance(t, dict):
+                continue
+            tid = t.get("thread_root_id")
+            tc = t.get("thread_card") or {}
+            if not isinstance(tc, dict):
+                tc = {}
+            gist = (tc.get("gist_text") or "").strip()
+            my_role = (tc.get("my_role") or "").strip()
+            participants_top = tc.get("participants_top")
+            entry_points = tc.get("entry_points")
+            last_seen_round_id = tc.get("last_seen_round_id")
+
+            try:
+                if isinstance(participants_top, str):
+                    participants_top_str = participants_top.strip()
+                else:
+                    participants_top_str = json.dumps(participants_top) if participants_top is not None else ""
+            except Exception:
+                participants_top_str = str(participants_top or "")
+
+            try:
+                if isinstance(entry_points, str):
+                    entry_points_str = entry_points.strip()
+                else:
+                    entry_points_str = json.dumps(entry_points) if entry_points is not None else ""
+            except Exception:
+                entry_points_str = str(entry_points or "")
+
+            parts.append(f"- thread_root_id={tid}: {gist}")
+            if my_role:
+                parts.append(f"  my_role: {my_role}")
+            if participants_top_str.strip():
+                parts.append(f"  participants_top: {participants_top_str.strip()[:400]}")
+            if entry_points_str.strip():
+                parts.append(f"  entry_points: {entry_points_str.strip()[:200]}")
+            if last_seen_round_id is not None:
+                parts.append(f"  last_seen_round_id: {last_seen_round_id}")
+
+    ev_tail = snapshot.get("agent_events_tail")
+    if isinstance(ev_tail, list) and ev_tail:
+        parts.append("\nRECENT EVENTS (agent-related tail):")
+        for ev in ev_tail[-15:]:
+            if not isinstance(ev, dict):
+                continue
+            claim = (ev.get("salient_claim") or "").strip()
+            if claim and len(claim) > 160:
+                claim = claim[:157].rstrip() + "..."
+            parts.append(
+                f"- r{ev.get('round_id')}: {ev.get('event_type')} "
+                f"relation={ev.get('relation_label')} tone={ev.get('tone_label')} "
+                f"thread_root_id={ev.get('thread_root_id')} target_post_id={ev.get('target_post_id')} "
+                f"claim={claim}"
+            )
+
+    out = "\n".join([p for p in parts if p is not None])
+    out = out.strip()
+    if len(out) <= max_chars:
+        return out
+    return out[: max_chars - 3].rstrip() + "..."
+
+
+_INTERVIEW_TERM_STOPWORDS = {
+    "a",
+    "about",
+    "after",
+    "and",
+    "any",
+    "are",
+    "as",
+    "at",
+    "be",
+    "by",
+    "can",
+    "comment",
+    "commented",
+    "comments",
+    "did",
+    "do",
+    "does",
+    "for",
+    "from",
+    "have",
+    "hi",
+    "i",
+    "in",
+    "is",
+    "it",
+    "like",
+    "make",
+    "made",
+    "me",
+    "my",
+    "more",
+    "no",
+    "not",
+    "of",
+    "on",
+    "or",
+    "post",
+    "posted",
+    "posts",
+    "recently",
+    "reply",
+    "replied",
+    "replies",
+    "remember",
+    "the",
+    "their",
+    "thread",
+    "threads",
+    "to",
+    "upvote",
+    "upvoted",
+    "upvotes",
+    "what",
+    "who",
+    "which",
+    "with",
+    "one",
+    "tell",
+    "you",
+    "your",
+    "yourself",
+    "yes",
+}
+
+_INTERVIEW_QUERY_TERM_ALIASES: Dict[str, List[str]] = {
+    # Common shorthand that often misses direct lexical matching in posts.
+    "dnd": ["d&d", "dungeons and dragons", "dungeons", "dragons", "tabletop"],
+    "d&d": ["dungeons and dragons", "dnd", "tabletop"],
+}
+
+_INTERVIEW_WEAK_QUERY_TERMS = {
+    "new",
+    "latest",
+    "lately",
+    "latetly",
+    "recent",
+    "recently",
+    "help",
+    "girl",
+    "guy",
+    "post",
+    "posted",
+    "comment",
+    "commented",
+    "thread",
+    "threads",
+    "out",
+}
+
+
+def _truncate_middle(text: str, max_len: int) -> str:
+    s = (text or "").strip()
+    if max_len <= 0:
+        return ""
+    if len(s) <= max_len:
+        return s
+    keep = max_len - 3
+    left = max(0, keep // 2)
+    right = max(0, keep - left)
+    return (s[:left] + "..." + s[-right:]).strip()
+
+
+def _extract_query_terms(admin_text: str, *, max_terms: int = 8) -> List[str]:
+    """
+    Heuristic keyword extraction from the admin's message.
+
+    Intentionally simple and deterministic: helps retrieve evidence without an extra LLM call.
+    """
+    text = (admin_text or "").strip()
+    if not text:
+        return []
+
+    # Prefer explicit @mentions.
+    mentions = re.findall(r"@([A-Za-z0-9_]{2,32})", text)
+    terms: List[str] = []
+    for m in mentions:
+        t = m.strip()
+        if t:
+            terms.append(t)
+
+    # Extract \"interesting\" tokens: 3+ chars, alpha-numeric.
+    tokens = re.findall(r"[A-Za-z][A-Za-z0-9_'-]{2,}", text)
+    for tok in tokens:
+        t = tok.strip().strip("'\"").lower()
+        if not t or t in _INTERVIEW_TERM_STOPWORDS:
+            continue
+        if t.isdigit() or len(t) < 3:
+            continue
+        terms.append(t)
+
+    # Deduplicate while preserving order.
+    seen = set()
+    base_terms: List[str] = []
+    for t in terms:
+        key = t.lower()
+        if key in seen:
+            continue
+        seen.add(key)
+        base_terms.append(t)
+        if len(base_terms) >= max_terms:
+            break
+
+    # Expand lightweight aliases to improve lexical fallback recall.
+    out: List[str] = list(base_terms)
+    for t in base_terms:
+        alias_candidates = _INTERVIEW_QUERY_TERM_ALIASES.get(str(t).strip().lower()) or []
+        for alias in alias_candidates:
+            alias_clean = str(alias or "").strip().lower()
+            if not alias_clean or alias_clean in seen:
+                continue
+            seen.add(alias_clean)
+            out.append(alias_clean)
+            if len(out) >= max_terms:
+                break
+        if len(out) >= max_terms:
+            break
+    return out[:max_terms]
+
+
+def _extract_query_ids(admin_text: str) -> Dict[str, List[int]]:
+    text = (admin_text or "").strip()
+    if not text:
+        return {"thread_ids": [], "post_ids": [], "comment_ids": []}
+
+    def _ints_from(pattern: str) -> List[int]:
+        vals: List[int] = []
+        for m in re.findall(pattern, text, flags=re.IGNORECASE):
+            try:
+                v = int(str(m).strip())
+            except Exception:
+                continue
+            if v > 0:
+                vals.append(v)
+        # Deduplicate, preserve order.
+        seen = set()
+        out: List[int] = []
+        for v in vals:
+            if v in seen:
+                continue
+            seen.add(v)
+            out.append(v)
+        return out
+
+    thread_ids = _ints_from(r"\bthread(?:_root_id)?\s*(?:=|:)?\s*#?(\d+)\b")
+    post_ids = _ints_from(r"\bpost(?:_id)?\s*(?:=|:)?\s*#?(\d+)\b")
+    comment_ids = _ints_from(r"\bcomment(?:_id)?\s*(?:=|:)?\s*#?(\d+)\b")
+    return {
+        "thread_ids": thread_ids[:8],
+        "post_ids": post_ids[:8],
+        "comment_ids": comment_ids[:8],
+    }
+
+
+def _evaluate_query_hit_text(text: str, terms: List[str]) -> Dict[str, Any]:
+    text_l = str(text or "").lower()
+    term_list = [str(t or "").strip().lower() for t in (terms or [])]
+    term_list = [t for t in term_list if len(t) >= 3]
+    matched_terms: List[str] = []
+    for t in term_list:
+        if t in text_l:
+            matched_terms.append(t)
+    matched_terms = list(dict.fromkeys(matched_terms))
+    informative_terms = [t for t in matched_terms if t not in _INTERVIEW_WEAK_QUERY_TERMS]
+    score = (2 * len(informative_terms)) + len(matched_terms)
+    return {
+        "matched_terms": matched_terms,
+        "informative_terms": informative_terms,
+        "term_matches": len(matched_terms),
+        "informative_matches": len(informative_terms),
+        "score": int(score),
+    }
+
+
+def _build_contextual_admin_query_text(
+    session_id: int,
+    latest_admin_text: str,
+    *,
+    max_admin_msgs: int = 3,
+    max_chars: int = 900,
+) -> str:
+    """
+    Build a retrieval query that preserves references across follow-up turns.
+
+    Example: "but what was his original comment?" should carry prior @mention context.
+    """
+    latest = (latest_admin_text or "").strip()
+    chunks: List[str] = []
+    if latest:
+        chunks.append(latest)
+
+    try:
+        rows = (
+            AdminInterviewMessage.query.filter_by(session_id=int(session_id), role="admin")
+            .order_by(AdminInterviewMessage.id.desc())
+            .limit(max(1, int(max_admin_msgs) + 1))
+            .all()
+        )
+    except Exception:
+        rows = []
+
+    # Keep only previous admin turns (exclude latest if duplicated).
+    prev_texts: List[str] = []
+    for m in rows:
+        txt = (getattr(m, "content", "") or "").strip()
+        if not txt:
+            continue
+        if latest and txt == latest:
+            continue
+        prev_texts.append(txt)
+        if len(prev_texts) >= max(1, int(max_admin_msgs)):
+            break
+
+    for txt in reversed(prev_texts):
+        chunks.append(txt)
+
+    merged = "\n".join([c for c in chunks if c]).strip()
+    if not merged:
+        return latest
+    if len(merged) <= int(max_chars):
+        return merged
+    return merged[-int(max_chars) :].strip()
+
+
+def _get_reaction_counts_for_posts(post_ids: List[int]) -> Dict[int, Dict[str, int]]:
+    if not post_ids:
+        return {}
+    ids = [int(x) for x in post_ids if x is not None]
+    if not ids:
+        return {}
+
+    # Default to 0/0 for requested ids.
+    counts: Dict[int, Dict[str, int]] = {int(pid): {"likes": 0, "dislikes": 0} for pid in ids}
+
+    try:
+        q = (
+            db.session.query(
+                Reactions.post_id.label("post_id"),
+                func.sum(case((Reactions.type == "like", 1), else_=0)).label("likes"),
+                func.sum(case((Reactions.type == "dislike", 1), else_=0)).label("dislikes"),
+            )
+            .filter(Reactions.post_id.in_(ids))
+            .group_by(Reactions.post_id)
+        )
+        for row in q.all():
+            pid = int(getattr(row, "post_id", 0) or 0)
+            if pid <= 0:
+                continue
+            counts[pid] = {
+                "likes": int(getattr(row, "likes", 0) or 0),
+                "dislikes": int(getattr(row, "dislikes", 0) or 0),
+            }
+    except Exception:
+        # Best-effort only; fall back to zeros.
+        pass
+
+    return counts
+
+
+def _post_to_fact(
+    p: Post,
+    counts: Dict[int, Dict[str, int]],
+    comment_context: Optional[Dict[int, Dict[str, Any]]] = None,
+) -> Dict[str, Any]:
+    if p is None:
+        return {}
+    pid = int(getattr(p, "id", 0) or 0)
+    c = counts.get(pid) or {}
+    text = getattr(p, "tweet", "") or ""
+    out = {
+        "post_id": pid,
+        "thread_root_id": int(getattr(p, "thread_id", 0) or 0) or None,
+        "comment_to": (
+            int(getattr(p, "comment_to", -1) or -1) if getattr(p, "comment_to", None) is not None else None
+        ),
+        "round": int(getattr(p, "round", 0) or 0) or None,
+        "reaction_count": int(getattr(p, "reaction_count", 0) or 0),
+        "likes": int(c.get("likes", 0) or 0),
+        "dislikes": int(c.get("dislikes", 0) or 0),
+        "text": _truncate_middle(str(text), 240),
+    }
+    if isinstance(comment_context, dict):
+        extra = comment_context.get(pid)
+        if isinstance(extra, dict):
+            out.update(extra)
+    return out
+
+
+def _build_facts_snapshot(
+    *,
+    agent_user_id: int,
+    admin_text: str,
+    top_posts_limit: int = 3,
+    recent_comments_limit: int = 5,
+    query_hits_limit: int = 5,
+) -> Dict[str, Any]:
+    """
+    Deterministic evidence extracted from the experiment DB (db_exp bind).
+
+    Purpose: reduce hallucination in interviews by giving the model a short list
+    of concrete things it actually posted/commented on, plus query-matched hits.
+    """
+    snap: Dict[str, Any] = {
+        "agent_user_id": int(agent_user_id),
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+    }
+
+    def _collect_seen_replies(parent_posts: List[Post]) -> List[Dict[str, Any]]:
+        parent_list = [p for p in (parent_posts or []) if p is not None]
+        parent_ids = [int(getattr(p, "id", 0) or 0) for p in parent_list]
+        parent_ids = [pid for pid in parent_ids if pid > 0]
+        if not parent_ids:
+            return []
+
+        parent_map = {int(getattr(p, "id")): p for p in parent_list if getattr(p, "id", None)}
+
+        # Reading signal: replies up to this cursor were seen in notifications inbox.
+        last_seen_reply_id = 0
+        try:
+            st = ReplyInboxState.query.filter_by(user_id=int(agent_user_id)).first()
+            if st is not None:
+                last_seen_reply_id = int(getattr(st, "last_seen_reply_id", 0) or 0)
+        except Exception:
+            last_seen_reply_id = 0
+
+        total_counts: Dict[int, int] = {}
+        try:
+            q_total = (
+                Post.query.with_entities(
+                    Post.comment_to.label("comment_to"),
+                    func.count(Post.id).label("cnt"),
+                )
+                .filter(Post.comment_to.in_(parent_ids))
+                .filter(Post.user_id != int(agent_user_id))
+                .group_by(Post.comment_to)
+            )
+            for row in q_total.all():
+                pid = int(getattr(row, "comment_to", 0) or 0)
+                if pid > 0:
+                    total_counts[pid] = int(getattr(row, "cnt", 0) or 0)
+        except Exception:
+            total_counts = {}
+
+        try:
+            reply_posts = (
+                Post.query.filter(Post.comment_to.in_(parent_ids))
+                .filter(Post.user_id != int(agent_user_id))
+                .order_by(desc(Post.id))
+                .limit(120)
+                .all()
+            )
+        except Exception:
+            reply_posts = []
+
+        reply_ids = [int(getattr(rp, "id", 0) or 0) for rp in reply_posts if int(getattr(rp, "id", 0) or 0) > 0]
+        reacted_ids: set[int] = set()
+        direct_reply_ids: set[int] = set()
+
+        if reply_ids:
+            try:
+                reacted_rows = (
+                    Reactions.query.with_entities(Reactions.post_id)
+                    .filter(Reactions.user_id == int(agent_user_id))
+                    .filter(Reactions.post_id.in_(reply_ids))
+                    .all()
+                )
+                reacted_ids = {
+                    int(getattr(r, "post_id", 0) or 0) for r in reacted_rows if int(getattr(r, "post_id", 0) or 0) > 0
+                }
+            except Exception:
+                reacted_ids = set()
+
+            try:
+                replied_rows = (
+                    Post.query.with_entities(Post.comment_to)
+                    .filter(Post.user_id == int(agent_user_id))
+                    .filter(Post.comment_to.in_(reply_ids))
+                    .all()
+                )
+                direct_reply_ids = {
+                    int(getattr(r, "comment_to", 0) or 0)
+                    for r in replied_rows
+                    if int(getattr(r, "comment_to", 0) or 0) > 0
+                }
+            except Exception:
+                direct_reply_ids = set()
+
+        try:
+            author_ids = sorted(
+                {int(getattr(rp, "user_id", 0) or 0) for rp in reply_posts if int(getattr(rp, "user_id", 0) or 0) > 0}
+            )
+            users = User_mgmt.query.filter(User_mgmt.id.in_(author_ids)).all() if author_ids else []
+            author_name_by_id = {int(u.id): getattr(u, "username", None) for u in users if u is not None}
+        except Exception:
+            author_name_by_id = {}
+
+        seen_counts: Dict[int, int] = {pid: 0 for pid in parent_ids}
+        seen_examples_map: Dict[int, List[Dict[str, Any]]] = {pid: [] for pid in parent_ids}
+        seen_reply_ids_by_parent: Dict[int, set[int]] = {pid: set() for pid in parent_ids}
+
+        for rp in reply_posts:
+            rid = int(getattr(rp, "id", 0) or 0)
+            parent_id = int(getattr(rp, "comment_to", -1) or -1)
+            author_id = int(getattr(rp, "user_id", 0) or 0)
+            if rid <= 0 or parent_id not in seen_examples_map:
+                continue
+
+            seen_via: List[str] = []
+            if rid <= int(last_seen_reply_id):
+                seen_via.append("read")
+            if rid in reacted_ids:
+                seen_via.append("voted")
+            if rid in direct_reply_ids:
+                seen_via.append("commented")
+            if not seen_via:
+                continue
+
+            if rid not in seen_reply_ids_by_parent[parent_id]:
+                seen_reply_ids_by_parent[parent_id].add(rid)
+                seen_counts[parent_id] = int(seen_counts.get(parent_id, 0) or 0) + 1
+
+            if len(seen_examples_map[parent_id]) >= 2:
+                continue
+
+            seen_examples_map[parent_id].append(
+                {
+                    "reply_post_id": rid,
+                    "user_id": author_id or None,
+                    "username": author_name_by_id.get(author_id),
+                    "round": int(getattr(rp, "round", 0) or 0) or None,
+                    "text": _truncate_middle(str(getattr(rp, "tweet", "") or ""), 200),
+                    "seen_via": seen_via,
+                }
+            )
+
+        out: List[Dict[str, Any]] = []
+        for p in parent_list:
+            pid = int(getattr(p, "id", 0) or 0)
+            if pid <= 0:
+                continue
+            parent_post = parent_map.get(pid) or p
+            out.append(
+                {
+                    "post_id": pid,
+                    "thread_root_id": int(getattr(parent_post, "thread_id", 0) or 0) or None,
+                    "round": int(getattr(parent_post, "round", 0) or 0) or None,
+                    "text": _truncate_middle(str(getattr(parent_post, "tweet", "") or ""), 220),
+                    "total_reply_count": int(total_counts.get(pid, 0) or 0),
+                    "seen_reply_count": int(seen_counts.get(pid, 0) or 0),
+                    "seen_reply_examples": seen_examples_map.get(pid) or [],
+                }
+            )
+        return out
+
+    # Root posts (threads started by the agent).
+    try:
+        q_top = (
+            Post.query.filter(Post.user_id == int(agent_user_id))
+            .filter(Post.comment_to == -1)
+            .order_by(desc(Post.reaction_count), desc(Post.id))
+            .limit(int(top_posts_limit))
+        )
+        top_posts = q_top.all()
+    except Exception:
+        top_posts = []
+
+    # Recent comments.
+    try:
+        q_recent = (
+            Post.query.filter(Post.user_id == int(agent_user_id))
+            .filter(Post.comment_to != -1)
+            .order_by(desc(Post.id))
+            .limit(int(recent_comments_limit))
+        )
+        recent_comments = q_recent.all()
+    except Exception:
+        recent_comments = []
+
+    replies_to_recent_comments: List[Dict[str, Any]] = []
+    replies_to_top_posts: List[Dict[str, Any]] = []
+    try:
+        replies_to_recent_comments = _collect_seen_replies(recent_comments or [])
+    except Exception:
+        replies_to_recent_comments = []
+    try:
+        replies_to_top_posts = _collect_seen_replies(top_posts or [])
+    except Exception:
+        replies_to_top_posts = []
+
+    # Query-conditioned hits in the agent's own text.
+    terms = _extract_query_terms(admin_text)
+    snap["query_terms"] = terms
+    query_ids = _extract_query_ids(admin_text)
+    snap["query_id_filters"] = query_ids
+    query_hits = []
+    if terms:
+        try:
+            conds = [Post.tweet.ilike(f"%{t}%") for t in terms[:8] if isinstance(t, str) and t.strip()]
+            if conds:
+                q_hits = (
+                    Post.query.filter(Post.user_id == int(agent_user_id))
+                    .filter(or_(*conds))
+                    .order_by(desc(Post.id))
+                    .limit(int(query_hits_limit))
+                )
+                query_hits = q_hits.all()
+        except Exception:
+            query_hits = []
+
+    # Explicit id-conditioned hits (e.g., "thread 79", "post_id=122").
+    id_hits = []
+    try:
+        thread_ids = [int(x) for x in (query_ids.get("thread_ids") or []) if int(x) > 0]
+        post_ids = [int(x) for x in (query_ids.get("post_ids") or []) if int(x) > 0]
+        comment_ids = [int(x) for x in (query_ids.get("comment_ids") or []) if int(x) > 0]
+    except Exception:
+        thread_ids, post_ids, comment_ids = [], [], []
+
+    if thread_ids or post_ids or comment_ids:
+        try:
+            id_conds = []
+            if thread_ids:
+                id_conds.append(Post.thread_id.in_(thread_ids))
+            if post_ids:
+                id_conds.append(Post.id.in_(post_ids))
+            if comment_ids:
+                id_conds.append(Post.comment_to.in_(comment_ids))
+            if id_conds:
+                q_id_hits = (
+                    Post.query.filter(Post.user_id == int(agent_user_id))
+                    .filter(or_(*id_conds))
+                    .order_by(desc(Post.id))
+                    .limit(max(int(query_hits_limit), 8))
+                )
+                id_hits = q_id_hits.all()
+        except Exception:
+            id_hits = []
+
+    # Merge explicit-id hits first, then lexical hits, dedup by post id.
+    merged_hits: List[Post] = []
+    seen_hit_ids = set()
+    for p in (id_hits or []) + (query_hits or []):
+        if p is None:
+            continue
+        pid = int(getattr(p, "id", 0) or 0)
+        if pid <= 0 or pid in seen_hit_ids:
+            continue
+        seen_hit_ids.add(pid)
+        merged_hits.append(p)
+        if len(merged_hits) >= max(int(query_hits_limit), 8):
+            break
+    query_hits = merged_hits
+
+    # Score lexical relevance so weak generic term matches do not override strict evidence mode.
+    hit_eval_rows: List[Dict[str, Any]] = []
+    hit_eval_by_pid: Dict[int, Dict[str, Any]] = {}
+    for p in query_hits:
+        if p is None:
+            continue
+        pid = int(getattr(p, "id", 0) or 0)
+        if pid <= 0:
+            continue
+        ev = _evaluate_query_hit_text(str(getattr(p, "tweet", "") or ""), terms)
+        row = {
+            "post_id": pid,
+            "thread_root_id": int(getattr(p, "thread_id", 0) or 0) or None,
+            "score": int(ev.get("score") or 0),
+            "term_matches": int(ev.get("term_matches") or 0),
+            "informative_matches": int(ev.get("informative_matches") or 0),
+            "matched_terms": ev.get("matched_terms") or [],
+            "informative_terms": ev.get("informative_terms") or [],
+        }
+        hit_eval_rows.append(row)
+        hit_eval_by_pid[pid] = row
+
+    hit_eval_rows.sort(
+        key=lambda r: (
+            int(r.get("informative_matches") or 0),
+            int(r.get("score") or 0),
+            int(r.get("post_id") or 0),
+        ),
+        reverse=True,
+    )
+    if hit_eval_rows:
+        pid_order = [int(r.get("post_id") or 0) for r in hit_eval_rows if int(r.get("post_id") or 0) > 0]
+        by_pid = {int(getattr(p, "id", 0) or 0): p for p in query_hits if p is not None}
+        query_hits = [by_pid[pid] for pid in pid_order if pid in by_pid][: max(int(query_hits_limit), 8)]
+    query_hits_viable_count = sum(1 for r in hit_eval_rows if int(r.get("informative_matches") or 0) > 0)
+    snap["query_hit_evaluations"] = hit_eval_rows[:8]
+    snap["query_hits_viable_count"] = int(query_hits_viable_count)
+
+    # Build explicit "who did I reply to?" context for comment rows so interview
+    # answers can resolve OP/parent identity deterministically.
+    comment_context: Dict[int, Dict[str, Any]] = {}
+    try:
+        comment_posts = []
+        for p in (recent_comments or []):
+            if p is None:
+                continue
+            try:
+                if int(getattr(p, "comment_to", -1) or -1) != -1:
+                    comment_posts.append(p)
+            except Exception:
+                continue
+        for p in (query_hits or []):
+            if p is None:
+                continue
+            try:
+                if int(getattr(p, "comment_to", -1) or -1) != -1:
+                    comment_posts.append(p)
+            except Exception:
+                continue
+
+        comment_posts_by_id: Dict[int, Post] = {}
+        for p in comment_posts:
+            pid = int(getattr(p, "id", 0) or 0)
+            if pid > 0 and pid not in comment_posts_by_id:
+                comment_posts_by_id[pid] = p
+
+        if comment_posts_by_id:
+            parent_ids = sorted(
+                {
+                    int(getattr(p, "comment_to", -1) or -1)
+                    for p in comment_posts_by_id.values()
+                    if int(getattr(p, "comment_to", -1) or -1) > 0
+                }
+            )
+            thread_root_ids = sorted(
+                {
+                    int(getattr(p, "thread_id", 0) or 0)
+                    for p in comment_posts_by_id.values()
+                    if int(getattr(p, "thread_id", 0) or 0) > 0
+                }
+            )
+
+            parent_map: Dict[int, Post] = {}
+            if parent_ids:
+                parents = Post.query.filter(Post.id.in_(parent_ids)).all()
+                parent_map = {int(getattr(pp, "id", 0) or 0): pp for pp in parents if pp is not None}
+
+            op_map: Dict[int, Post] = {}
+            if thread_root_ids:
+                ops = Post.query.filter(Post.id.in_(thread_root_ids)).all()
+                op_map = {int(getattr(op, "id", 0) or 0): op for op in ops if op is not None}
+
+            user_ids = set()
+            for pp in parent_map.values():
+                try:
+                    uid = int(getattr(pp, "user_id", 0) or 0)
+                    if uid > 0:
+                        user_ids.add(uid)
+                except Exception:
+                    continue
+            for op in op_map.values():
+                try:
+                    uid = int(getattr(op, "user_id", 0) or 0)
+                    if uid > 0:
+                        user_ids.add(uid)
+                except Exception:
+                    continue
+
+            username_by_id: Dict[int, Optional[str]] = {}
+            if user_ids:
+                users = User_mgmt.query.filter(User_mgmt.id.in_(sorted(user_ids))).all()
+                username_by_id = {int(u.id): getattr(u, "username", None) for u in users if u is not None}
+
+            for pid, p in comment_posts_by_id.items():
+                parent_id = int(getattr(p, "comment_to", -1) or -1)
+                thread_root_id = int(getattr(p, "thread_id", 0) or 0)
+                parent_post = parent_map.get(parent_id)
+                thread_op_post = op_map.get(thread_root_id)
+
+                parent_user_id = (
+                    int(getattr(parent_post, "user_id", 0) or 0)
+                    if parent_post is not None
+                    else None
+                )
+                if parent_user_id is not None and parent_user_id <= 0:
+                    parent_user_id = None
+
+                thread_op_user_id = (
+                    int(getattr(thread_op_post, "user_id", 0) or 0)
+                    if thread_op_post is not None
+                    else None
+                )
+                if thread_op_user_id is not None and thread_op_user_id <= 0:
+                    thread_op_user_id = None
+
+                comment_context[pid] = {
+                    "parent_post_id": int(parent_id) if parent_id > 0 else None,
+                    "parent_user_id": parent_user_id,
+                    "parent_username": username_by_id.get(parent_user_id) if parent_user_id is not None else None,
+                    "parent_text": (
+                        _truncate_middle(str(getattr(parent_post, "tweet", "") or ""), 220)
+                        if parent_post is not None
+                        else None
+                    ),
+                    "thread_op_post_id": int(thread_root_id) if thread_root_id > 0 else None,
+                    "thread_op_user_id": thread_op_user_id,
+                    "thread_op_username": (
+                        username_by_id.get(thread_op_user_id) if thread_op_user_id is not None else None
+                    ),
+                    "thread_op_text": (
+                        _truncate_middle(str(getattr(thread_op_post, "tweet", "") or ""), 180)
+                        if thread_op_post is not None
+                        else None
+                    ),
+                }
+    except Exception:
+        comment_context = {}
+
+    # Batch counts for all referenced posts.
+    all_posts: List[Post] = []
+    for lst in [top_posts, recent_comments, query_hits]:
+        for p in lst:
+            if p is not None:
+                all_posts.append(p)
+    post_ids = sorted({int(getattr(p, "id", 0) or 0) for p in all_posts if getattr(p, "id", None) is not None})
+    counts = _get_reaction_counts_for_posts(post_ids)
+
+    snap["top_posts"] = [_post_to_fact(p, counts, comment_context) for p in (top_posts or [])]
+    snap["recent_comments"] = [_post_to_fact(p, counts, comment_context) for p in (recent_comments or [])]
+    snap["replies_to_recent_comments"] = replies_to_recent_comments
+    snap["replies_to_top_posts"] = replies_to_top_posts
+    snap["query_hits"] = [_post_to_fact(p, counts, comment_context) for p in (query_hits or [])]
+    return snap
+
+
+def _format_facts_pack(snapshot: Dict[str, Any], *, max_chars: int = 3500) -> str:
+    if not isinstance(snapshot, dict):
+        return ""
+    parts: List[str] = []
+    parts.append("FACTS PACK (ground truth from the experiment DB)")
+
+    terms = snapshot.get("query_terms") or []
+    if isinstance(terms, list) and terms:
+        parts.append("Query terms: " + ", ".join([str(t) for t in terms[:8] if str(t).strip()]))
+    query_ids = snapshot.get("query_id_filters") or {}
+    if isinstance(query_ids, dict):
+        tids = query_ids.get("thread_ids") or []
+        pids = query_ids.get("post_ids") or []
+        cids = query_ids.get("comment_ids") or []
+        if tids or pids or cids:
+            parts.append(
+                "Query ids: "
+                f"thread_ids={tids if tids else []}, "
+                f"post_ids={pids if pids else []}, "
+                f"comment_ids={cids if cids else []}"
+            )
+
+    def _fmt_posts(label: str, posts: Any, *, limit: int):
+        parts.append(f"\n{label}:")
+        if not isinstance(posts, list) or not posts:
+            parts.append("- (none)")
+            return
+        for p in posts[:limit]:
+            if not isinstance(p, dict):
+                continue
+            pid = p.get("post_id")
+            tr = p.get("thread_root_id")
+            ct = p.get("comment_to")
+            rd = p.get("round")
+            likes = p.get("likes")
+            dislikes = p.get("dislikes")
+            rc = p.get("reaction_count")
+            txt = (p.get("text") or "").strip()
+            parent_username = p.get("parent_username")
+            parent_user_id = p.get("parent_user_id")
+            parent_post_id = p.get("parent_post_id")
+            op_username = p.get("thread_op_username")
+            op_user_id = p.get("thread_op_user_id")
+            op_post_id = p.get("thread_op_post_id")
+            parent_text = (p.get("parent_text") or "").strip()
+            op_text = (p.get("thread_op_text") or "").strip()
+            parts.append(
+                f"- post_id={pid} thread_root_id={tr} comment_to={ct} round={rd} "
+                f"likes={likes} dislikes={dislikes} reactions={rc}: {txt}"
+            )
+            if parent_post_id is not None or op_post_id is not None:
+                parent_label = f"@{parent_username}" if parent_username else f"user_id={parent_user_id}"
+                op_label = f"@{op_username}" if op_username else f"user_id={op_user_id}"
+                parts.append(
+                    f"  reply_target: parent_post_id={parent_post_id} parent={parent_label} "
+                    f"thread_op_post_id={op_post_id} thread_op={op_label}"
+                )
+                if parent_text:
+                    parts.append(f"  parent_text: {parent_text}")
+                elif op_text:
+                    parts.append(f"  thread_op_text: {op_text}")
+
+    _fmt_posts("Top threads you started", snapshot.get("top_posts"), limit=3)
+    _fmt_posts("Recent comments you made", snapshot.get("recent_comments"), limit=5)
+
+    def _fmt_seen_replies(label: str, rows: Any, *, limit: int):
+        parts.append(f"\n{label}:")
+        if not isinstance(rows, list) or not rows:
+            parts.append("- (none)")
+            return
+        for c in rows[:limit]:
+            if not isinstance(c, dict):
+                continue
+            pid = c.get("post_id")
+            tr = c.get("thread_root_id")
+            rd = c.get("round")
+            seen_rc = int(c.get("seen_reply_count") or 0)
+            total_rc = int(c.get("total_reply_count") or 0)
+            txt = (c.get("text") or "").strip()
+            parts.append(
+                f"- post_id={pid} thread_root_id={tr} round={rd} "
+                f"seen_replies={seen_rc} total_replies={total_rc}: {txt}"
+            )
+            exs = c.get("seen_reply_examples")
+            if isinstance(exs, list) and exs:
+                for ex in exs[:2]:
+                    if not isinstance(ex, dict):
+                        continue
+                    who = ex.get("username") or f"user_id={ex.get('user_id')}"
+                    via = ex.get("seen_via") or []
+                    via_s = ",".join([str(v) for v in via if str(v).strip()]) if isinstance(via, list) else ""
+                    parts.append(
+                        f"  - by @{who} reply_post_id={ex.get('reply_post_id')} "
+                        f"round={ex.get('round')} seen_via={via_s}: {ex.get('text')}"
+                    )
+
+    _fmt_seen_replies("Replies you've seen to your top threads", snapshot.get("replies_to_top_posts"), limit=3)
+    _fmt_seen_replies(
+        "Replies you've seen to your recent comments",
+        snapshot.get("replies_to_recent_comments"),
+        limit=5,
+    )
+
+    _fmt_posts("Your posts/comments matching the admin's question", snapshot.get("query_hits"), limit=5)
+
+    out = "\n".join([p for p in parts if p is not None]).strip()
+    if len(out) <= max_chars:
+        return out
+    return out[: max_chars - 3].rstrip() + "..."
+
+
+def _build_evidence_guard(
+    *,
+    facts_snapshot: Dict[str, Any],
+    memory_snapshot: Dict[str, Any],
+) -> Tuple[str, Dict[str, Any]]:
+    facts = facts_snapshot if isinstance(facts_snapshot, dict) else {}
+    mem = memory_snapshot if isinstance(memory_snapshot, dict) else {}
+
+    query_hits = facts.get("query_hits")
+    if not isinstance(query_hits, list):
+        query_hits = []
+    try:
+        query_hits_viable_n = int(facts.get("query_hits_viable_count") or 0)
+    except Exception:
+        query_hits_viable_n = 0
+
+    def _safe_len(key: str) -> int:
+        v = facts.get(key)
+        return len(v) if isinstance(v, list) else 0
+
+    top_posts_n = _safe_len("top_posts")
+    recent_comments_n = _safe_len("recent_comments")
+    seen_replies_top_n = _safe_len("replies_to_top_posts")
+    seen_replies_recent_n = _safe_len("replies_to_recent_comments")
+    query_hits_n = len(query_hits)
+
+    retrieval_meta = mem.get("retrieval_meta")
+    if not isinstance(retrieval_meta, dict):
+        retrieval_meta = {}
+
+    try:
+        memory_returned_k = int(retrieval_meta.get("returned_k") or 0)
+    except Exception:
+        memory_returned_k = 0
+    memory_degraded = bool(retrieval_meta.get("degraded_mode", False))
+
+    strict_no_inference = bool(memory_degraded or (memory_returned_k <= 0 and query_hits_viable_n <= 0))
+
+    lines = ["EVIDENCE STATUS (for this answer):"]
+    lines.append(
+        f"- query_hits={query_hits_n}, query_hits_viable={query_hits_viable_n}, "
+        f"top_posts={top_posts_n}, recent_comments={recent_comments_n}"
+    )
+    lines.append(
+        f"- seen_replies_top={seen_replies_top_n}, seen_replies_recent={seen_replies_recent_n}"
+    )
+    lines.append(
+        f"- memory_returned_k={memory_returned_k}, memory_degraded={memory_degraded}"
+    )
+    lines.append(f"- strict_no_inference={strict_no_inference}")
+    if strict_no_inference:
+        lines.append(
+            "- For activity-specific questions, answer \"can't confirm\" unless exact evidence is present."
+        )
+        lines.append(
+            "- Do not introduce new movie/book titles, usernames, or thread narratives not in evidence."
+        )
+
+    meta = {
+        "strict_no_inference": strict_no_inference,
+        "query_hits": query_hits_n,
+        "query_hits_viable": query_hits_viable_n,
+        "memory_returned_k": memory_returned_k,
+        "memory_degraded_mode": memory_degraded,
+    }
+    return "\n".join(lines), meta
+
+
+def _collect_known_record_ids(*objs: Any) -> List[int]:
+    ids = set()
+
+    def _walk(obj: Any):
+        if isinstance(obj, dict):
+            for k, v in obj.items():
+                key = str(k).lower()
+                if key.endswith("_id"):
+                    try:
+                        iv = int(v)
+                    except Exception:
+                        iv = None
+                    if iv is not None and iv > 0:
+                        ids.add(iv)
+                _walk(v)
+        elif isinstance(obj, list):
+            for item in obj:
+                _walk(item)
+
+    for o in objs:
+        _walk(o)
+
+    return sorted(ids)
+
+
+def _extract_semantic_candidates(
+    *,
+    facts_snapshot: Dict[str, Any],
+    memory_snapshot: Dict[str, Any],
+    max_candidates: int = 2,
+) -> List[Dict[str, Any]]:
+    facts = facts_snapshot if isinstance(facts_snapshot, dict) else {}
+    memory = memory_snapshot if isinstance(memory_snapshot, dict) else {}
+    semantic_items = memory.get("semantic_items")
+    if not isinstance(semantic_items, list) or not semantic_items:
+        return []
+
+    query_terms = []
+    for t in (facts.get("query_terms") or []):
+        ts = str(t or "").strip().lower()
+        if ts:
+            query_terms.append(ts)
+
+    rows: List[Dict[str, Any]] = []
+    for it in semantic_items:
+        if not isinstance(it, dict):
+            continue
+        text = str(it.get("text_humanized") or it.get("text") or "").strip()
+        if not text:
+            continue
+        text_l = text.lower()
+        term_hits = 0
+        if query_terms:
+            term_hits = sum(1 for t in query_terms if len(t) >= 3 and t in text_l)
+        try:
+            score = float(it.get("score") or 0.0)
+        except Exception:
+            score = 0.0
+        # Keep moderate+ similarity rows or explicit term-overlap rows.
+        if term_hits <= 0 and score < 0.33:
+            continue
+        rows.append(
+            {
+                "score": score,
+                "term_hits": term_hits,
+                "round_id": it.get("round_id"),
+                "thread_root_id": it.get("thread_root_id"),
+                "target_post_id": it.get("target_post_id"),
+                "text": _truncate_middle(text, 120),
+            }
+        )
+
+    rows.sort(key=lambda r: (int(r.get("term_hits") or 0), float(r.get("score") or 0.0)), reverse=True)
+    return rows[: max(1, int(max_candidates))]
+
+
+def _extract_facts_candidates(*, facts_snapshot: Dict[str, Any], max_candidates: int = 2) -> List[Dict[str, Any]]:
+    facts = facts_snapshot if isinstance(facts_snapshot, dict) else {}
+    rows = facts.get("query_hits")
+    if not isinstance(rows, list) or not rows:
+        return []
+    evals_raw = facts.get("query_hit_evaluations")
+    evals_by_pid: Dict[int, Dict[str, Any]] = {}
+    if isinstance(evals_raw, list):
+        for e in evals_raw:
+            if not isinstance(e, dict):
+                continue
+            try:
+                pid = int(e.get("post_id") or 0)
+            except Exception:
+                pid = 0
+            if pid > 0:
+                evals_by_pid[pid] = e
+    out = []
+    for p in rows:
+        if not isinstance(p, dict):
+            continue
+        try:
+            pid = int(p.get("post_id") or 0)
+        except Exception:
+            pid = 0
+        if pid <= 0:
+            continue
+        e = evals_by_pid.get(pid) or {}
+        out.append(
+            {
+                "post_id": pid,
+                "thread_root_id": p.get("thread_root_id"),
+                "round": p.get("round"),
+                "text": _truncate_middle(str(p.get("text") or "").strip(), 120),
+                "informative_matches": int(e.get("informative_matches") or 0),
+                "score": int(e.get("score") or 0),
+            }
+        )
+    out.sort(
+        key=lambda r: (
+            int(r.get("informative_matches") or 0),
+            int(r.get("score") or 0),
+            int(r.get("post_id") or 0),
+        ),
+        reverse=True,
+    )
+    return out[: max(1, int(max_candidates))]
+
+
+def _build_retrieval_trace(
+    *,
+    contextual_query_text: str,
+    facts_snapshot: Dict[str, Any],
+    memory_snapshot: Dict[str, Any],
+    sanitize_meta: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
+    facts = facts_snapshot if isinstance(facts_snapshot, dict) else {}
+    memory = memory_snapshot if isinstance(memory_snapshot, dict) else {}
+    retrieval_meta = memory.get("retrieval_meta")
+    if not isinstance(retrieval_meta, dict):
+        retrieval_meta = {}
+
+    semantic_items = memory.get("semantic_items")
+    if not isinstance(semantic_items, list):
+        semantic_items = []
+    semantic_top_k = []
+    for it in semantic_items[:5]:
+        if not isinstance(it, dict):
+            continue
+        try:
+            score = float(it.get("score") or 0.0)
+        except Exception:
+            score = 0.0
+        semantic_top_k.append(
+            {
+                "score": score,
+                "item_type": it.get("item_type"),
+                "round_id": it.get("round_id"),
+                "thread_root_id": it.get("thread_root_id"),
+                "target_post_id": it.get("target_post_id"),
+                "text": _truncate_middle(str(it.get("text_humanized") or it.get("text") or ""), 120),
+            }
+        )
+
+    semantic_candidates = _extract_semantic_candidates(
+        facts_snapshot=facts,
+        memory_snapshot=memory,
+        max_candidates=3,
+    )
+
+    query_hits = facts.get("query_hits")
+    query_hits_count = len(query_hits) if isinstance(query_hits, list) else 0
+    try:
+        query_hits_viable_count = int(facts.get("query_hits_viable_count") or 0)
+    except Exception:
+        query_hits_viable_count = 0
+    if query_hits_viable_count > 0:
+        selected_context_source = "facts_query_hits"
+    elif semantic_candidates:
+        selected_context_source = "semantic_candidates"
+    elif semantic_top_k:
+        selected_context_source = "semantic_items_topk"
+    else:
+        selected_context_source = "none"
+
+    return {
+        "contextual_query_text": str(contextual_query_text or "").strip(),
+        "query_terms": facts.get("query_terms") or [],
+        "query_id_filters": facts.get("query_id_filters") or {},
+        "facts_query_hits_count": int(query_hits_count),
+        "facts_query_hits_viable_count": int(query_hits_viable_count),
+        "query_hit_evaluations": facts.get("query_hit_evaluations") or [],
+        "memory_mode_used": memory.get("memory_mode_used"),
+        "memory_retrieval_meta": retrieval_meta,
+        "semantic_top_k": semantic_top_k,
+        "semantic_candidates": semantic_candidates,
+        "selected_context_source": selected_context_source,
+        "sanitize_reason": (sanitize_meta or {}).get("reason"),
+    }
+
+
+def _sanitize_interview_reply(
+    reply: str,
+    *,
+    facts_snapshot: Dict[str, Any],
+    memory_snapshot: Dict[str, Any],
+    strict_no_inference: bool,
+) -> Tuple[str, Dict[str, Any]]:
+    text = (reply or "").strip()
+    if not text:
+        return text, {"sanitized": False, "reason": "empty"}
+
+    known_ids = set(_collect_known_record_ids(facts_snapshot, memory_snapshot))
+    claimed_ids = set()
+    for m in re.findall(
+        r"\b(?:post_id|thread_root_id|comment_to|reply_post_id|parent_post_id|thread_op_post_id)\s*=\s*(\d+)\b",
+        text,
+        flags=re.IGNORECASE,
+    ):
+        try:
+            v = int(str(m).strip())
+        except Exception:
+            continue
+        if v > 0:
+            claimed_ids.add(v)
+
+    unknown_ids = sorted([v for v in claimed_ids if v not in known_ids])
+    if unknown_ids:
+        fallback = (
+            "I can't confirm those specific ids from my records right now. "
+            "Can you give me a post_id, thread_root_id, or username to verify?"
+        )
+        return fallback, {
+            "sanitized": True,
+            "reason": "unknown_ids",
+            "unknown_ids": unknown_ids,
+            "known_ids_count": len(known_ids),
+        }
+
+    if strict_no_inference:
+        lowered = text.lower()
+        has_strong_claim = any(
+            w in lowered
+            for w in [
+                "i commented on",
+                "i posted about",
+                "i replied to",
+                "i upvoted",
+                "i downvoted",
+                "i trust",
+                "i first encountered",
+            ]
+        )
+        has_reference = bool(claimed_ids)
+        if has_strong_claim and not has_reference:
+            semantic_candidates = _extract_semantic_candidates(
+                facts_snapshot=facts_snapshot,
+                memory_snapshot=memory_snapshot,
+                max_candidates=2,
+            )
+            if semantic_candidates:
+                candidate_bits = []
+                for c in semantic_candidates:
+                    candidate_bits.append(
+                        f"\"{c.get('text')}\" (score={float(c.get('score') or 0.0):.2f}, "
+                        f"round={c.get('round_id')}, thread_root_id={c.get('thread_root_id')})"
+                    )
+                fallback = (
+                    "I can't confirm one exact post yet, but I found likely matches: "
+                    + "; ".join(candidate_bits)
+                    + ". Did you mean one of those?"
+                )
+                return fallback, {
+                    "sanitized": True,
+                    "reason": "strict_no_inference_semantic_disambiguation",
+                    "candidate_count": len(semantic_candidates),
+                    "known_ids_count": len(known_ids),
+                }
+            facts_candidates = _extract_facts_candidates(facts_snapshot=facts_snapshot, max_candidates=2)
+            if facts_candidates:
+                candidate_bits = []
+                for c in facts_candidates:
+                    candidate_bits.append(
+                        f"post_id={c.get('post_id')} thread_root_id={c.get('thread_root_id')} "
+                        f"round={c.get('round')}: \"{c.get('text')}\""
+                    )
+                fallback = (
+                    "I can't confirm one exact match yet, but these look likely: "
+                    + "; ".join(candidate_bits)
+                    + ". Did you mean one of these?"
+                )
+                return fallback, {
+                    "sanitized": True,
+                    "reason": "strict_no_inference_facts_disambiguation",
+                    "candidate_count": len(facts_candidates),
+                    "known_ids_count": len(known_ids),
+                }
+            fallback = (
+                "I can't confirm that from my records for this query. "
+                "If you can share a little more detail (topic wording, who was involved, or rough timing), "
+                "I can narrow it down. If you have it, a post_id or thread_root_id can also help verify."
+            )
+            return fallback, {
+                "sanitized": True,
+                "reason": "strict_no_inference_without_ids",
+                "known_ids_count": len(known_ids),
+            }
+
+    # De-loop explicit-ID requests when semantic candidates exist.
+    if (
+        "can't confirm" in text.lower()
+        and "post_id" in text.lower()
+        and "thread_root_id" in text.lower()
+    ):
+        semantic_candidates = _extract_semantic_candidates(
+            facts_snapshot=facts_snapshot,
+            memory_snapshot=memory_snapshot,
+            max_candidates=2,
+        )
+        if semantic_candidates:
+            candidate_bits = []
+            for c in semantic_candidates:
+                candidate_bits.append(
+                    f"\"{c.get('text')}\" (score={float(c.get('score') or 0.0):.2f}, round={c.get('round_id')})"
+                )
+            fallback = (
+                "I can't confirm one exact post yet, but I found likely matches: "
+                + "; ".join(candidate_bits)
+                + ". Did you mean one of these?"
+            )
+            return fallback, {
+                "sanitized": True,
+                "reason": "semantic_disambiguation_replaced_id_loop",
+                "candidate_count": len(semantic_candidates),
+                "known_ids_count": len(known_ids),
+            }
+        facts_candidates = _extract_facts_candidates(facts_snapshot=facts_snapshot, max_candidates=2)
+        if facts_candidates:
+            candidate_bits = []
+            for c in facts_candidates:
+                candidate_bits.append(
+                    f"post_id={c.get('post_id')} thread_root_id={c.get('thread_root_id')}: \"{c.get('text')}\""
+                )
+            fallback = (
+                "I can't confirm one exact post yet, but I found likely matches: "
+                + "; ".join(candidate_bits)
+                + ". Did you mean one of these?"
+            )
+            return fallback, {
+                "sanitized": True,
+                "reason": "facts_disambiguation_replaced_id_loop",
+                "candidate_count": len(facts_candidates),
+                "known_ids_count": len(known_ids),
+            }
+
+    return text, {"sanitized": False, "reason": "pass", "known_ids_count": len(known_ids)}
+
+
+def _resolve_llm_backend(
+    *,
+    backend_mode: str,
+    exp: Exps,
+    agent_user: User_mgmt,
+    admin_user: Admin_users,
+) -> Tuple[str, str, str, str, float, int]:
+    """
+    Return (mode, model, base_url, api_key, temperature, max_tokens) for interview generation.
+    """
+    mode = (backend_mode or "agent_runtime").strip().lower()
+    if mode not in {"agent_runtime", "admin"}:
+        mode = "agent_runtime"
+
+    if mode == "admin":
+        model = (getattr(admin_user, "llm", "") or "").strip() or "llama3.2:latest"
+        base_url = _normalize_llm_base_url(getattr(admin_user, "llm_url", "") or "")
+        api_key = "NULL"
+        temperature = 0.7
+        max_tokens = 450
+        return mode, model, base_url, api_key, temperature, max_tokens
+
+    # agent_runtime
+    model = (getattr(agent_user, "user_type", "") or "").strip() or "llama3.2:latest"
+    base_url = _normalize_llm_base_url(getattr(exp, "llm_default", "") or "")
+    api_key = (getattr(exp, "llm_api_key_default", "") or "").strip() or "NULL"
+    try:
+        temperature = float(getattr(exp, "llm_temperature_default", 0.7) or 0.7)
+    except Exception:
+        temperature = 0.7
+    try:
+        max_tokens = int(getattr(exp, "llm_max_tokens_default", 450) or 450)
+    except Exception:
+        max_tokens = 450
+    return mode, model, base_url, api_key, temperature, max_tokens
+
+
+def _generate_reply(
+    *,
+    model: str,
+    base_url: str,
+    api_key: str,
+    temperature: float,
+    max_tokens: int,
+    system_message: str,
+    user_message: str,
+) -> str:
+    if not base_url:
+        raise RuntimeError("LLM base_url not configured")
+    if not model:
+        raise RuntimeError("LLM model not configured")
+
+    # Import autogen lazily so importing this module doesn't break tooling environments.
+    from autogen import AssistantAgent
+
+    cfg = {
+        "cache_seed": None,
+        "config_list": [
+            {
+                "model": model,
+                "base_url": base_url,
+                "timeout": 10000,
+                "api_type": "open_ai",
+                "api_key": api_key or "NULL",
+                "price": [0, 0],
+            }
+        ],
+        "temperature": float(temperature),
+        "max_tokens": int(max_tokens),
+    }
+
+    agent = AssistantAgent(
+        name="interview-agent",
+        llm_config=cfg,
+        system_message=system_message,
+        max_consecutive_auto_reply=1,
+    )
+    user = AssistantAgent(name="interview-user", max_consecutive_auto_reply=0)
+
+    user.initiate_chat(agent, silent=True, message=user_message)
+    try:
+        content = agent.chat_messages[user][-1]["content"]
+    except Exception:
+        content = ""
+
+    return (content or "").strip()
+
+
+@api_interview.get("/<int:exp_id>/agents")
+@login_required
+def api_interview_agents(exp_id: int):
+    admin_user = _require_privileged()
+    if not admin_user:
+        return _json_error("Forbidden", 403, code="forbidden")
+
+    # LLM agents register their model name in user_type (anything other than "user").
+    try:
+        q = (
+            User_mgmt.query.filter(User_mgmt.is_page == 0)
+            .filter(User_mgmt.user_type != "user")
+            .order_by(User_mgmt.id.asc())
+        )
+        users = q.all()
+    except Exception as exc:
+        return _json_error(f"Failed to load agents: {exc}", 500, code="db_error")
+
+    data = []
+    for u in users:
+        data.append(
+            {
+                "user_id": int(u.id),
+                "username": u.username,
+                "user_type": getattr(u, "user_type", None),
+                "language": getattr(u, "language", None),
+                "leaning": getattr(u, "leaning", None),
+                "toxicity": getattr(u, "toxicity", None),
+                "profession": getattr(u, "profession", None),
+            }
+        )
+
+    return _json_success(data)
+
+
+@api_interview.post("/<int:exp_id>/session")
+@login_required
+def api_interview_create_session(exp_id: int):
+    admin_user = _require_privileged()
+    if not admin_user:
+        return _json_error("Forbidden", 403, code="forbidden")
+
+    payload = request.get_json(silent=True) or {}
+    agent_user_id = payload.get("agent_user_id")
+    if agent_user_id is None:
+        return _json_error("agent_user_id required", 400, code="bad_request")
+
+    try:
+        agent_user_id = int(agent_user_id)
+    except Exception:
+        return _json_error("agent_user_id must be an int", 400, code="bad_request")
+
+    agent_user = User_mgmt.query.get(agent_user_id)
+    if not agent_user:
+        return _json_error("Agent not found", 404, code="not_found")
+
+    exp = Exps.query.filter_by(idexp=int(exp_id)).first()
+    if not exp:
+        return _json_error("Experiment not found", 404, code="not_found")
+    db_binding = _ensure_experiment_server_db_binding(exp)
+
+    backend_mode = (payload.get("backend_mode") or "agent_runtime").strip().lower()
+    if backend_mode not in {"agent_runtime", "admin"}:
+        backend_mode = "agent_runtime"
+    memory_mode = _normalize_memory_mode(payload.get("memory_mode"))
+    preload_memory = _as_bool(payload.get("preload_memory"), False)
+
+    run_id = (payload.get("run_id") or "").strip() or None
+    run_id_source = "override" if run_id else "log_scan"
+    run_id_selected_reason = "provided_by_request" if run_id else "pending_log_scan"
+    run_id_candidates_checked: List[Dict[str, Any]] = []
+    if not run_id:
+        run_pick = _detect_run_id_from_server_log(
+            exp,
+            agent_user_id=int(agent_user_id),
+            probe_memory_coverage=preload_memory,
+        )
+        run_id = str(run_pick.get("run_id") or "").strip() or None
+        run_id_source = str(run_pick.get("source") or "log_scan")
+        run_id_selected_reason = str(run_pick.get("selected_reason") or "log_scan")
+        checked = run_pick.get("candidates_checked")
+        if isinstance(checked, list):
+            run_id_candidates_checked = [c for c in checked if isinstance(c, dict)]
+        if not run_id:
+            run_id_source = "none"
+            run_id_selected_reason = "no_run_detected"
+
+    interests = _get_top_interests_for_user(agent_user_id)
+    persona = _build_persona_snapshot(agent_user, interests, exp)
+    if preload_memory:
+        memory_snapshot = _build_memory_snapshot(
+            exp,
+            run_id=run_id,
+            agent_user_id=agent_user_id,
+            memory_mode=memory_mode,
+            query_text=_INTERVIEW_MEMORY_DEFAULT_QUERY,
+        )
+    else:
+        memory_snapshot = _build_deferred_memory_snapshot(
+            run_id=run_id,
+            agent_user_id=agent_user_id,
+            memory_mode=memory_mode,
+        )
+
+    mode, model, base_url, _api_key, temperature, max_tokens = _resolve_llm_backend(
+        backend_mode=backend_mode,
+        exp=exp,
+        agent_user=agent_user,
+        admin_user=admin_user,
+    )
+
+    sess = AdminInterviewSession(
+        exp_id=int(exp_id),
+        admin_username=getattr(current_user, "username", "") or "",
+        agent_user_id=int(agent_user_id),
+        agent_username=getattr(agent_user, "username", "") or "",
+        run_id=run_id,
+        backend_mode=mode,
+        llm_model=model,
+        llm_base_url=base_url,
+        persona_snapshot=persona,
+        interests_snapshot_json=json.dumps(interests),
+        memory_snapshot_json=json.dumps(memory_snapshot),
+    )
+    db.session.add(sess)
+    try:
+        db.session.commit()
+    except Exception as exc:
+        db.session.rollback()
+        return _json_error(f"Failed to create interview session: {exc}", 500, code="db_error")
+
+    sys_msg = AdminInterviewMessage(
+        session_id=sess.id,
+        role="system",
+        content=(
+            f"Interview session started with @{sess.agent_username}. "
+            f"run_id={run_id or 'none'} (source={run_id_source}). backend={mode}. "
+            f"memory_mode={memory_snapshot.get('memory_mode_used') or memory_mode}."
+        ),
+        meta_json=json.dumps(
+            {
+                "run_id_source": run_id_source,
+                "run_id_selected_reason": run_id_selected_reason,
+                "run_id_candidates_checked": run_id_candidates_checked,
+                "memory_preloaded": preload_memory,
+                "db_binding": db_binding,
+                "memory_mode_requested": memory_mode,
+                "memory_mode_used": memory_snapshot.get("memory_mode_used"),
+            }
+        ),
+    )
+    db.session.add(sys_msg)
+    try:
+        db.session.commit()
+    except Exception as exc:
+        db.session.rollback()
+        return _json_error(
+            f"Session created but failed to write system message: {exc}",
+            500,
+            code="db_error",
+        )
+
+    return _json_success(
+        {
+            "session_id": int(sess.id),
+            "run_id": run_id,
+            "run_id_source": run_id_source,
+            "run_id_selected_reason": run_id_selected_reason,
+            "run_id_candidates_checked": run_id_candidates_checked,
+            "db_binding": db_binding,
+            "backend_mode": mode,
+            "memory_preloaded": preload_memory,
+            "memory_mode_requested": memory_snapshot.get("memory_mode_requested", memory_mode),
+            "memory_mode_used": memory_snapshot.get("memory_mode_used"),
+            "llm_model": model,
+            "llm_base_url": base_url,
+            "persona_snapshot": persona,
+            "interests": interests,
+            "memory_snapshot": memory_snapshot,
+            "messages": [
+                {"id": int(sys_msg.id), "role": sys_msg.role, "content": sys_msg.content}
+            ],
+        }
+    )
+
+
+@api_interview.get("/<int:exp_id>/session/<int:session_id>")
+@login_required
+def api_interview_get_session(exp_id: int, session_id: int):
+    admin_user = _require_privileged()
+    if not admin_user:
+        return _json_error("Forbidden", 403, code="forbidden")
+
+    sess = AdminInterviewSession.query.get(int(session_id))
+    if not sess or int(sess.exp_id) != int(exp_id):
+        return _json_error("Session not found", 404, code="not_found")
+
+    msgs = (
+        AdminInterviewMessage.query.filter_by(session_id=int(session_id))
+        .order_by(AdminInterviewMessage.id.asc())
+        .all()
+    )
+    messages = [{"id": int(m.id), "role": m.role, "content": m.content} for m in msgs]
+
+    interests = []
+    try:
+        interests = json.loads(sess.interests_snapshot_json or "[]")
+        if not isinstance(interests, list):
+            interests = []
+    except Exception:
+        interests = []
+
+    memory_snapshot = {}
+    try:
+        memory_snapshot = json.loads(sess.memory_snapshot_json or "{}")
+        if not isinstance(memory_snapshot, dict):
+            memory_snapshot = {}
+    except Exception:
+        memory_snapshot = {}
+
+    return _json_success(
+        {
+            "session_id": int(sess.id),
+            "run_id": sess.run_id,
+            "backend_mode": sess.backend_mode,
+            "memory_mode_requested": memory_snapshot.get(
+                "memory_mode_requested", _INTERVIEW_MEMORY_MODE_DEFAULT
+            ),
+            "memory_mode_used": memory_snapshot.get("memory_mode_used"),
+            "llm_model": sess.llm_model,
+            "llm_base_url": sess.llm_base_url,
+            "persona_snapshot": sess.persona_snapshot,
+            "interests": interests,
+            "memory_snapshot": memory_snapshot,
+            "messages": messages,
+        }
+    )
+
+
+@api_interview.post("/<int:exp_id>/session/<int:session_id>/refresh_context")
+@login_required
+def api_interview_refresh_context(exp_id: int, session_id: int):
+    admin_user = _require_privileged()
+    if not admin_user:
+        return _json_error("Forbidden", 403, code="forbidden")
+
+    sess = AdminInterviewSession.query.get(int(session_id))
+    if not sess or int(sess.exp_id) != int(exp_id):
+        return _json_error("Session not found", 404, code="not_found")
+
+    exp = Exps.query.filter_by(idexp=int(exp_id)).first()
+    if not exp:
+        return _json_error("Experiment not found", 404, code="not_found")
+    db_binding = _ensure_experiment_server_db_binding(exp)
+
+    payload = request.get_json(silent=True) or {}
+    query_text = (payload.get("query_text") or "").strip() or _INTERVIEW_MEMORY_DEFAULT_QUERY
+    memory_mode = _extract_requested_memory_mode(sess.memory_snapshot_json)
+
+    memory_snapshot = _build_memory_snapshot(
+        exp,
+        run_id=(sess.run_id or "").strip() or None,
+        agent_user_id=int(sess.agent_user_id),
+        memory_mode=memory_mode,
+        query_text=query_text,
+    )
+    sess.memory_snapshot_json = json.dumps(memory_snapshot)
+    db.session.commit()
+
+    return _json_success(
+        {
+            "memory_snapshot": memory_snapshot,
+            "memory_mode_requested": memory_snapshot.get("memory_mode_requested"),
+            "memory_mode_used": memory_snapshot.get("memory_mode_used"),
+            "db_binding": db_binding,
+        }
+    )
+
+
+@api_interview.post("/<int:exp_id>/session/<int:session_id>/message")
+@login_required
+def api_interview_send_message(exp_id: int, session_id: int):
+    try:
+        admin_user = _require_privileged()
+        if not admin_user:
+            return _json_error("Forbidden", 403, code="forbidden")
+
+        sess = AdminInterviewSession.query.get(int(session_id))
+        if not sess or int(sess.exp_id) != int(exp_id):
+            return _json_error("Session not found", 404, code="not_found")
+
+        payload = request.get_json(silent=True) or {}
+        content = (payload.get("content") or "").strip()
+        if not content:
+            return _json_error("content required", 400, code="bad_request")
+
+        auto_refresh = bool(payload.get("auto_refresh_memory", True))
+        debug_trace = _interview_debug_enabled(payload)
+        memory_mode = _extract_requested_memory_mode(sess.memory_snapshot_json)
+
+        admin_msg = AdminInterviewMessage(
+            session_id=int(sess.id),
+            role="admin",
+            content=content,
+        )
+        db.session.add(admin_msg)
+        db.session.commit()
+
+        exp = Exps.query.filter_by(idexp=int(exp_id)).first()
+        if not exp:
+            return _json_error("Experiment not found", 404, code="not_found")
+        db_binding = _ensure_experiment_server_db_binding(exp)
+
+        agent_user = User_mgmt.query.get(int(sess.agent_user_id))
+        if not agent_user:
+            return _json_error("Agent not found", 404, code="not_found")
+
+        contextual_query_text = _build_contextual_admin_query_text(int(sess.id), content)
+
+        if auto_refresh:
+            memory_snapshot = _build_memory_snapshot(
+                exp,
+                run_id=(sess.run_id or "").strip() or None,
+                agent_user_id=int(sess.agent_user_id),
+                memory_mode=memory_mode,
+                query_text=contextual_query_text,
+            )
+            sess.memory_snapshot_json = json.dumps(memory_snapshot)
+            db.session.commit()
+        else:
+            try:
+                memory_snapshot = json.loads(sess.memory_snapshot_json or "{}")
+                if not isinstance(memory_snapshot, dict):
+                    memory_snapshot = {}
+            except Exception:
+                memory_snapshot = {}
+
+        memory_pack = _format_memory_pack(memory_snapshot or {})
+        facts_snapshot = _build_facts_snapshot(
+            agent_user_id=int(sess.agent_user_id),
+            admin_text=contextual_query_text,
+        )
+        facts_pack = _format_facts_pack(facts_snapshot)
+
+        # Some read helpers can swallow SQL errors and leave PostgreSQL tx aborted.
+        # Reset session state before lazy-loading ORM attributes for backend resolution.
+        db.session.rollback()
+
+        # Build transcript window (last ~12 msgs excluding system).
+        msgs = (
+            AdminInterviewMessage.query.filter_by(session_id=int(sess.id))
+            .order_by(AdminInterviewMessage.id.asc())
+            .all()
+        )
+        transcript = []
+        for m in msgs:
+            if m.role not in {"admin", "agent"}:
+                continue
+            who = "ADMIN" if m.role == "admin" else "AGENT_UNVERIFIED"
+            transcript.append(f"{who}: {m.content}")
+        transcript = transcript[-12:]
+
+        evidence_guard, evidence_guard_meta = _build_evidence_guard(
+            facts_snapshot=facts_snapshot,
+            memory_snapshot=memory_snapshot,
+        )
+
+        persona = (sess.persona_snapshot or "").strip()
+        system_message = (
+        "You are being interviewed by a researcher (the experiment admin).\n"
+        "They are evaluating your persona, memory, and social behavior in the simulation.\n"
+        "Stay fully in character. Speak casually and naturally (Reddit-style, not corporate).\n\n"
+        "Truthfulness rules (very important):\n"
+        "- Do NOT guess or invent actions, posts, comments, votes, or other users' replies.\n"
+        "- Use FACTS PACK as ground truth for what you posted/commented, who replied to you, and how many likes/dislikes it got.\n"
+        "- Reply sections in FACTS PACK are \"replies you've seen\" (read/commented/voted), so treat them as seen evidence only.\n"
+        "- For \"who did you reply to / who was OP\" questions, use reply_target fields in FACTS PACK "
+        "(parent=..., thread_op=...). If username is present, answer with it.\n"
+        "- For \"what was their original comment\" questions, use parent_text when available.\n"
+        "- Treat AGENT_UNVERIFIED transcript lines as potentially wrong prior drafts. Never use them as evidence.\n"
+        "- When the admin asks about a specific topic/person/keyword, use the 'matching the admin's question' section.\n"
+        "  If that section is empty, you have no evidence that you wrote about it.\n"
+        "- If FACTS PACK shows '(none)' for a section, treat it as no evidence. Do not invent.\n"
+        "- Use MEMORY PACK for subjective context: retrieved memories, relationships, community vibe, and thread summaries.\n"
+        "- If you cannot find evidence in FACTS PACK or MEMORY PACK, say you don't remember / can't confirm.\n"
+        "- Never introduce a new specific title/name/event unless it appears in evidence or the admin's latest message.\n"
+        "- If you previously said something wrong in this interview, explicitly correct yourself.\n\n"
+        "Style:\n"
+        "- Answer the admin directly.\n"
+        "- For questions about your actions (\"Did you post/comment/vote…?\"), start with a direct yes/no (or \"can't confirm\"), then justify.\n"
+        "- Keep it concise.\n"
+        "- If the admin's question is ambiguous, ask ONE short clarifying question to help you identify the right evidence "
+        "(e.g., which username/topic/thread_root_id/approx round range they mean).\n"
+        "- End your reply with ONE short follow-up question that helps the researcher continue the interview.\n"
+        "  Prefer clarification questions when needed; otherwise ask if they want you to expand on a specific detail.\n"
+        "- Avoid generic small-talk questions; only ask interview-relevant questions.\n"
+        "- Prefer @username in natural prose when a username is present in evidence.\n"
+        "- Include ids only when the admin asks for verification or when ids are needed to disambiguate "
+        "(e.g., post_id=123, thread_root_id=123).\n"
+        "- If you say you *didn't* do something, do not list random ids. Only cite ids as 'checked recent comments: …'.\n"
+        "- Do not ask other users to 'chime in' or join the interview; only you and the admin are talking.\n"
+        "- Do not mention 'FACTS PACK' or 'MEMORY PACK' explicitly.\n\n"
+        "PERSONA:\n"
+        f"{persona}\n"
+    )
+
+        user_message = (
+            f"{facts_pack}\n\n"
+            f"{memory_pack}\n\n"
+            f"{evidence_guard}\n\n"
+            "CONVERSATION SO FAR (most recent last):\n"
+            + "\n".join(transcript)
+            + "\n\n"
+            f"LATEST ADMIN MESSAGE:\n{content}\n\n"
+            "Respond to the admin's latest message."
+        )
+
+        mode, model, base_url, api_key, temperature, max_tokens = _resolve_llm_backend(
+            backend_mode=sess.backend_mode,
+            exp=exp,
+            agent_user=agent_user,
+            admin_user=admin_user,
+        )
+
+        # Interviews should be grounded and stable; clamp temperature to reduce confabulation.
+        try:
+            temperature = float(temperature)
+        except Exception:
+            temperature = 0.4
+        temperature = min(temperature, 0.2)
+
+        meta = {
+            "backend_mode": mode,
+            "llm_model": model,
+            "llm_base_url": base_url,
+            "contextual_query_text": contextual_query_text,
+            "memory_mode_requested": memory_snapshot.get("memory_mode_requested", memory_mode),
+            "memory_mode_used": memory_snapshot.get("memory_mode_used"),
+            "memory_fallback_reason": memory_snapshot.get("fallback_reason"),
+            "memory_pack_chars": len(memory_pack or ""),
+            "facts_pack_chars": len(facts_pack or ""),
+            "persona_chars": len(persona or ""),
+            "transcript_msgs": len(transcript),
+            "facts_snapshot": facts_snapshot,
+            "evidence_guard": evidence_guard_meta,
+            "db_binding": db_binding,
+        }
+        retrieval_meta = memory_snapshot.get("retrieval_meta")
+        if isinstance(retrieval_meta, dict):
+            meta["memory_retrieval_meta"] = retrieval_meta
+            meta["memory_search_returned_k"] = retrieval_meta.get("returned_k")
+            meta["memory_search_degraded_mode"] = retrieval_meta.get("degraded_mode")
+
+        try:
+            reply = _generate_reply(
+                model=model,
+                base_url=base_url,
+                api_key=api_key,
+                temperature=temperature,
+                max_tokens=max_tokens if max_tokens != -1 else 450,
+                system_message=system_message,
+                user_message=user_message,
+            )
+        except Exception as exc:
+            reply = f"(interview backend error: {exc})"
+            meta["error"] = str(exc)
+
+        try:
+            strict_no_inference = bool(evidence_guard_meta.get("strict_no_inference", False))
+        except Exception:
+            strict_no_inference = False
+        reply, sanitize_meta = _sanitize_interview_reply(
+            reply,
+            facts_snapshot=facts_snapshot,
+            memory_snapshot=memory_snapshot,
+            strict_no_inference=strict_no_inference,
+        )
+        meta["reply_sanitize"] = sanitize_meta
+        if debug_trace:
+            meta["retrieval_trace"] = _build_retrieval_trace(
+                contextual_query_text=contextual_query_text,
+                facts_snapshot=facts_snapshot,
+                memory_snapshot=memory_snapshot,
+                sanitize_meta=sanitize_meta,
+            )
+
+        agent_msg = AdminInterviewMessage(
+            session_id=int(sess.id),
+            role="agent",
+            content=reply,
+            meta_json=json.dumps(meta),
+        )
+        db.session.add(agent_msg)
+        db.session.commit()
+
+        # Return refreshed transcript for UI.
+        msgs = (
+            AdminInterviewMessage.query.filter_by(session_id=int(sess.id))
+            .order_by(AdminInterviewMessage.id.asc())
+            .all()
+        )
+        out_messages = [{"id": int(m.id), "role": m.role, "content": m.content} for m in msgs]
+
+        return _json_success(
+            {
+                "reply": reply,
+                "meta": meta,
+                "memory_mode_requested": memory_snapshot.get("memory_mode_requested", memory_mode),
+                "memory_mode_used": memory_snapshot.get("memory_mode_used"),
+                "memory_snapshot": memory_snapshot,
+                "messages": out_messages,
+            }
+        )
+    except Exception as exc:
+        db.session.rollback()
+        return _json_error(f"Failed to send interview message: {exc}", 500, code="interview_send_error")

--- a/y_web/routes_api/reddit.py
+++ b/y_web/routes_api/reddit.py
@@ -8,22 +8,27 @@ from io import BytesIO
 from flask import Blueprint, jsonify, request
 from flask_login import current_user, login_required
 from PIL import Image
-from werkzeug.utils import safe_join
 from werkzeug.datastructures import FileStorage
+from werkzeug.utils import safe_join
 
 from y_web import db
 from y_web.data_access import get_elicited_emotions, get_topics
 from y_web.llm_annotations import Annotator
 from y_web.llm_annotations.url_summarizer import UrlSummarizer
-from y_web.models import Admin_users, Articles, Images, Post, Rounds, User_mgmt
 from y_web.models import (
+    Admin_users,
+    Articles,
+    Images,
     Mentions,
-    Post_Sentiment,
-    Post_Toxicity,
+    Post,
     Post_emotions,
     Post_hashtags,
+    Post_Sentiment,
     Post_topics,
+    Post_Toxicity,
     Reactions,
+    Rounds,
+    User_mgmt,
 )
 from y_web.reddit.actions import apply_vote, create_comment_reddit, create_post_reddit
 from y_web.reddit.service import (
@@ -302,7 +307,9 @@ def api_enrich_article(exp_id: int, article_id: int):
     if not article:
         return _json_error("Article not found.", 404)
 
-    if not force and not _article_summary_needs_enrichment(getattr(article, "summary", "")):
+    if not force and not _article_summary_needs_enrichment(
+        getattr(article, "summary", "")
+    ):
         return _json_success(
             {
                 "ok": True,
@@ -530,7 +537,9 @@ def _serialize_comment(comment: Post, skip_metadata: bool = False) -> dict:
     day = str(round_obj.day) if round_obj else "None"
     hour = f"{round_obj.hour:02d}" if round_obj else "00"
     comment_created_at = getattr(comment, "created_at", None)
-    display_time = _format_display_time_from_created_at(comment_created_at) or _format_display_time(day, hour)
+    display_time = _format_display_time_from_created_at(
+        comment_created_at
+    ) or _format_display_time(day, hour)
 
     # Get emotions and topics (skip for new comments to improve performance)
     if skip_metadata:
@@ -807,9 +816,9 @@ def api_delete_post(exp_id: int, post_id: int):
             synchronize_session=False
         )
         if ContentShown is not None:
-            ContentShown.query.filter(ContentShown.content_id.in_(target_post_ids)).delete(
-                synchronize_session=False
-            )
+            ContentShown.query.filter(
+                ContentShown.content_id.in_(target_post_ids)
+            ).delete(synchronize_session=False)
         Post.query.filter(Post.id.in_(target_post_ids)).delete(
             synchronize_session=False
         )
@@ -819,5 +828,9 @@ def api_delete_post(exp_id: int, post_id: int):
         return _json_error(f"Failed to delete post: {exc}", 500)
 
     return _json_success(
-        {"post_id": post_id, "deleted": True, "deleted_post_count": len(target_post_ids)}
+        {
+            "post_id": post_id,
+            "deleted": True,
+            "deleted_post_count": len(target_post_ids),
+        }
     )

--- a/y_web/routes_uploads.py
+++ b/y_web/routes_uploads.py
@@ -14,7 +14,6 @@ from werkzeug.utils import safe_join
 
 from y_web.utils.path_utils import get_writable_path
 
-
 uploads = Blueprint("uploads", __name__)
 
 

--- a/y_web/static/assets/js/interview.js
+++ b/y_web/static/assets/js/interview.js
@@ -1,0 +1,265 @@
+/* interview.js
+ *
+ * Admin-only interview module for live experiments.
+ * Uses server-side persona + memory injection via /api/interview/*.
+ */
+
+(function () {
+  'use strict'
+
+  const expId = window.INTERVIEW_EXP_ID
+  const agentSelect = document.getElementById('interview-agent-select')
+  if (!expId || !agentSelect) return
+
+  const runIdInput = document.getElementById('interview-run-id')
+  const startBtn = document.getElementById('interview-start-session')
+  const refreshBtn = document.getElementById('interview-refresh-memory')
+  const statusEl = document.getElementById('interview-status')
+  const messagesEl = document.getElementById('interview-messages')
+  const inputEl = document.getElementById('interview-input')
+  const sendBtn = document.getElementById('interview-send')
+  const personaEl = document.getElementById('interview-persona')
+  const interestsEl = document.getElementById('interview-interests')
+  const memoryEl = document.getElementById('interview-memory')
+  const debugMode = (function () {
+    try {
+      const v = new URLSearchParams(window.location.search).get('debug')
+      if (!v) return false
+      return ['1', 'true', 'yes', 'on'].includes(String(v).toLowerCase())
+    } catch (e) {
+      return false
+    }
+  })()
+
+  let currentSessionId = null
+  let busy = false
+  let refreshBusy = false
+
+  function setStatus (msg, isError) {
+    if (!statusEl) return
+    statusEl.textContent = msg || ''
+    statusEl.style.color = isError ? '#b00020' : ''
+  }
+
+  function setMemorySnapshot (snap) {
+    if (!memoryEl) return
+    try {
+      memoryEl.textContent = JSON.stringify(snap || {}, null, 2)
+    } catch (e) {
+      memoryEl.textContent = String(snap || '')
+    }
+  }
+
+  async function apiGet (path) {
+    const resp = await fetch(path, { credentials: 'same-origin' })
+    const text = await resp.text()
+    let data = null
+    try {
+      data = text ? JSON.parse(text) : {}
+    } catch (e) {
+      const ct = resp.headers.get('content-type') || ''
+      const snippet = (text || '').slice(0, 120).replace(/\s+/g, ' ').trim()
+      throw new Error(`HTTP ${resp.status} non-JSON response (${ct || 'unknown content-type'}): ${snippet || 'empty body'}`)
+    }
+    return data
+  }
+
+  async function apiPost (path, body) {
+    const resp = await fetch(path, {
+      method: 'POST',
+      credentials: 'same-origin',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body || {})
+    })
+    const text = await resp.text()
+    let data = null
+    try {
+      data = text ? JSON.parse(text) : {}
+    } catch (e) {
+      const ct = resp.headers.get('content-type') || ''
+      const snippet = (text || '').slice(0, 120).replace(/\s+/g, ' ').trim()
+      throw new Error(`HTTP ${resp.status} non-JSON response (${ct || 'unknown content-type'}): ${snippet || 'empty body'}`)
+    }
+    return data
+  }
+
+  function backendMode () {
+    const radios = document.querySelectorAll('input[name="backend_mode"]')
+    for (const r of radios) {
+      if (r && r.checked) return r.value
+    }
+    return 'agent_runtime'
+  }
+
+  function escapeHtml (s) {
+    return (s || '')
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;')
+      .replace(/'/g, '&#039;')
+  }
+
+  function renderMessages (messages) {
+    if (!messagesEl) return
+    const msgs = Array.isArray(messages) ? messages : []
+    const html = msgs.map((m) => {
+      const role = (m.role || 'system').toUpperCase()
+      const content = escapeHtml(m.content || '')
+      const cls = role === 'ADMIN' ? 'has-text-link' : (role === 'AGENT' ? 'has-text-dark' : 'has-text-grey')
+      return `
+        <div style="margin-bottom: 10px;">
+          <div style="font-size: 12px; font-weight: 700;" class="${cls}">${role}</div>
+          <div style="white-space: pre-wrap;">${content}</div>
+        </div>
+      `
+    }).join('')
+    messagesEl.innerHTML = html
+    // Scroll to bottom
+    try {
+      const parent = messagesEl.parentElement
+      if (parent) parent.scrollTop = parent.scrollHeight
+    } catch (e) {}
+  }
+
+  function renderContext (data) {
+    if (!data) return
+    if (personaEl) personaEl.textContent = data.persona_snapshot || ''
+    if (interestsEl) {
+      const ints = Array.isArray(data.interests) ? data.interests : []
+      interestsEl.textContent = ints.length ? ints.join(', ') : '(none)'
+    }
+    const snap = data.memory_snapshot || data.memory_snapshot_json || data.memory_snapshot || {}
+    setMemorySnapshot(snap)
+  }
+
+  async function loadAgents () {
+    setStatus('Loading agents…')
+    try {
+      const res = await apiGet(`/api/interview/${expId}/agents`)
+      if (!res || !res.success) {
+        setStatus((res && res.error) ? res.error : 'Failed to load agents', true)
+        return
+      }
+      const agents = Array.isArray(res.data) ? res.data : []
+      agentSelect.innerHTML = agents.map((a) => {
+        const label = `${a.username} (${a.user_type || 'llm'})`
+        return `<option value="${a.user_id}">${escapeHtml(label)}</option>`
+      }).join('')
+      if (!agents.length) {
+        agentSelect.innerHTML = '<option value="">(no LLM agents found)</option>'
+      }
+      setStatus('')
+    } catch (e) {
+      setStatus(`Failed to load agents: ${e}`, true)
+    }
+  }
+
+  async function startSession () {
+    if (busy) return
+    const agentUserId = parseInt(agentSelect.value, 10)
+    if (!agentUserId) {
+      setStatus('Pick an agent first.', true)
+      return
+    }
+    busy = true
+    setStatus('Starting session…')
+    try {
+      const runId = (runIdInput && runIdInput.value ? runIdInput.value.trim() : '')
+      const res = await apiPost(`/api/interview/${expId}/session`, {
+        agent_user_id: agentUserId,
+        run_id: runId || null,
+        backend_mode: backendMode(),
+        preload_memory: false
+      })
+      if (!res || !res.success) {
+        setStatus((res && res.error) ? res.error : 'Failed to start session', true)
+        return
+      }
+      const data = res.data || {}
+      currentSessionId = data.session_id
+      renderContext(data)
+      renderMessages(data.messages || [])
+
+      if (inputEl) inputEl.disabled = false
+      if (sendBtn) sendBtn.disabled = false
+      if (refreshBtn) refreshBtn.disabled = false
+      const startedMsg = `Session ${currentSessionId} started. run_id=${data.run_id || 'none'}.`
+      setStatus(startedMsg)
+    } catch (e) {
+      setStatus(`Failed to start session: ${e}`, true)
+    } finally {
+      busy = false
+    }
+  }
+
+  async function refreshMemory (opts) {
+    const options = opts || {}
+    if (!currentSessionId || refreshBusy) return
+    refreshBusy = true
+    if (refreshBtn) refreshBtn.disabled = true
+    if (!options.silent) setStatus('Refreshing memory…')
+    try {
+      const res = await apiPost(`/api/interview/${expId}/session/${currentSessionId}/refresh_context`, {})
+      if (!res || !res.success) {
+        const msg = (res && res.error) ? res.error : 'Failed to refresh memory'
+        setStatus(options.failureStatus || msg, true)
+        return
+      }
+      const snap = (res.data || {}).memory_snapshot || {}
+      setMemorySnapshot(snap)
+      setStatus(options.successStatus || 'Memory refreshed.')
+    } catch (e) {
+      const msg = `Failed to refresh memory: ${e}`
+      setStatus(options.failureStatus || msg, true)
+    } finally {
+      refreshBusy = false
+      if (refreshBtn) refreshBtn.disabled = !currentSessionId
+    }
+  }
+
+  async function sendMessage () {
+    if (!currentSessionId || busy) return
+    const text = (inputEl && inputEl.value ? inputEl.value.trim() : '')
+    if (!text) return
+    busy = true
+    setStatus('Sending…')
+    if (sendBtn) sendBtn.disabled = true
+    try {
+      const res = await apiPost(`/api/interview/${expId}/session/${currentSessionId}/message`, {
+        content: text,
+        auto_refresh_memory: true,
+        debug: debugMode
+      })
+      if (!res || !res.success) {
+        setStatus((res && res.error) ? res.error : 'Failed to send message', true)
+        return
+      }
+      const data = res.data || {}
+      renderMessages(data.messages || [])
+      setMemorySnapshot(data.memory_snapshot || {})
+      if (inputEl) inputEl.value = ''
+      setStatus('')
+    } catch (e) {
+      setStatus(`Failed to send: ${e}`, true)
+    } finally {
+      busy = false
+      if (sendBtn) sendBtn.disabled = false
+    }
+  }
+
+  if (startBtn) startBtn.addEventListener('click', startSession)
+  if (refreshBtn) refreshBtn.addEventListener('click', refreshMemory)
+  if (sendBtn) sendBtn.addEventListener('click', sendMessage)
+  if (inputEl) {
+    inputEl.addEventListener('keydown', function (e) {
+      // Ctrl+Enter to send
+      if (e && e.key === 'Enter' && (e.ctrlKey || e.metaKey)) {
+        e.preventDefault()
+        sendMessage()
+      }
+    })
+  }
+
+  loadAgents()
+})()

--- a/y_web/templates/admin/clients.html
+++ b/y_web/templates/admin/clients.html
@@ -82,6 +82,38 @@
                                             </label>
                                         </span>
                                     </div>
+                                    <div class="box-line">
+                                        <span class="left">Experiment Clock Mode</span>
+                                        <span class="right" style="width: 70%;">
+                                            <div class="select" style="width: 100%;">
+                                                <select name="clock_mode" class="input" style="width: 100%;">
+                                                    {% set selected_clock_mode = experiment_clock.get('mode', 'simulated') %}
+                                                    <option value="simulated" {% if selected_clock_mode == 'simulated' %}selected{% endif %}>Simulated (run as fast as possible)</option>
+                                                    <option value="real_time" {% if selected_clock_mode == 'real_time' %}selected{% endif %}>Real-time (one wall-clock hour per round)</option>
+                                                </select>
+                                            </div>
+                                            <small style="color: #666; display: block; margin-top: 4px;">
+                                                Experiment-wide setting shared by all clients in this experiment.
+                                            </small>
+                                        </span>
+                                    </div>
+                                    <div class="box-line">
+                                        <span class="left">Clock Timezone</span>
+                                        <span class="right" style="width: 70%;">
+                                            <input type="text"
+                                                   name="clock_timezone"
+                                                   class="input"
+                                                   value="{{ experiment_clock.get('timezone', 'Europe/Belgrade') }}"
+                                                   placeholder="Europe/Belgrade"
+                                                   required>
+                                            <small style="color: #666; display: block; margin-top: 4px;">
+                                                Used for real-time wall-hour mapping (IANA timezone).
+                                            </small>
+                                        </span>
+                                    </div>
+                                    <input type="hidden"
+                                           name="clock_feed_refresh"
+                                           value="{{ experiment_clock.get('feed_refresh', 'hourly') }}">
                                     <script>
                                         // Sync display input with hidden input
                                         document.getElementById('days_display').addEventListener('change', function() {
@@ -113,6 +145,20 @@
                                         });
                                     </script>
                                     <div class="box-line">
+                                        <span class="left">Initial Number of Agents</span>
+                                        <span class="right" style="width: 70%;">
+                                            <input type="number"
+                                                   name="initial_agents"
+                                                   class="input"
+                                                   min="1"
+                                                   step="1"
+                                                   placeholder="Leave empty for all agents">
+                                            <small style="color: #666; display: block; margin-top: 4px;">
+                                                Subset of population to activate initially. Leave empty to use all agents.
+                                            </small>
+                                        </span>
+                                    </div>
+                                    <div class="box-line">
                                         <span class="left">% New Agents (daily)</span>
                                         <span class="right" style="width: 70%;"><input type="number"
                                                                                        name="percentage_new_agents_iteration"
@@ -136,13 +182,52 @@
                                     </div>
                                     <div class="box-line">
                                         <span class="left">Thread Context Length</span>
-                                        <span class="right" style="width: 70%;"><input type="number"
-                                                                                       name="max_length_thread_reading"
-                                                                                       class="input"
-                                                                                       min="1"
-                                                                                       step="1"
-                                                                                       value="5"
-                                                                                       required></span>
+                                        <span class="right" style="width: 70%;">
+                                            <input type="number"
+                                                   name="max_length_thread_reading"
+                                                   class="input"
+                                                   min="1"
+                                                   step="1"
+                                                   value="10"
+                                                   required>
+                                            <small style="color: #666; display: block; margin-top: 4px;">
+                                                Max number of thread items (post + comments) to fetch for context.
+                                            </small>
+                                        </span>
+                                    </div>
+                                    <div class="box-line">
+                                        <span class="left">Thread Context Max Chars</span>
+                                        <span class="right" style="width: 70%;">
+                                            <input type="number"
+                                                   name="max_thread_context_chars"
+                                                   class="input"
+                                                   min="200"
+                                                   step="100"
+                                                   max="4800"
+                                                   value="3200"
+                                                   required>
+                                            <small style="color: #666; display: block; margin-top: 4px;">
+                                                Character cap on thread text sent to the LLM (24B/Ollama-safe default).
+                                            </small>
+                                        </span>
+                                    </div>
+                                    <div class="box-line">
+                                        <span class="left">Context Preset</span>
+                                        <span class="right" style="width: 70%;">
+                                            <div style="display: flex; gap: 8px; align-items: center;">
+                                                <select id="context_preset_select" class="input" style="flex: 1;">
+                                                    <option value="balanced" selected>Balanced (Recommended)</option>
+                                                    <option value="high_24b">High Context (24B/Ollama)</option>
+                                                </select>
+                                                <button type="button" class="button is-solid" onclick="applyContextPreset()">
+                                                    Apply
+                                                </button>
+                                            </div>
+                                            <small style="color: #666; display: block; margin-top: 4px;">
+                                                Applies thread + memory + LLM token budgets. High profile stays within 24B/Ollama-safe caps.
+                                            </small>
+                                            <small id="context_preset_status" style="color: #1a7f37; display: none; margin-top: 4px;"></small>
+                                        </span>
                                     </div>
                                     <div class="box-line">
                                         <span class="left">Timeline Follower Ratio</span>
@@ -198,166 +283,332 @@
                                                                                        required></span>
                                     </div>
                                     </div><!-- End section-simulation-params -->
-                                    <div id="section-actions-relevance" class="tutorial-section">
-                                    <div class="form-section-header">Agents' Actions Relevance</div>
+
+                                    <div id="section-reply-controls" class="tutorial-section">
+                                    <div class="form-section-header">Reply Behavior Controls</div>
                                     <div class="form-section-description">
-                                        All actions are scored from 0 to 10, where 0 means that the action is never performed. 
-                                        Scores greater than 0 are relative to each other. For example, if "Post new content" has a score of 3
-                                        and "Comment a Post" has a score of 6, then the agent will comment twice as much as posting new content.
+                                        Configure how agents respond to mentions and comments.
+                                        These settings help prevent excessive reply loops in conversations.
+                                    </div>
+                                    <div class="box-line">
+                                        <span class="left">Max Replies per Round</span>
+                                        <span class="right" style="width: 70%;">
+                                            <input type="number" name="max_replies_per_round" class="input"
+                                                   min="0" max="10" step="1" value="2" required>
+                                            <small style="color: #666; display: block; margin-top: 4px;">
+                                                Maximum number of replies an agent can make per simulation round
+                                            </small>
+                                        </span>
+                                    </div>
+                                    <div class="box-line">
+                                        <span class="left">Reply Cooldown (rounds)</span>
+                                        <span class="right" style="width: 70%;">
+                                            <input type="number" name="reply_cooldown_rounds" class="input"
+                                                   min="0" max="10" step="1" value="2" required>
+                                            <small style="color: #666; display: block; margin-top: 4px;">
+                                                Rounds to wait before replying to the same user again
+                                            </small>
+                                        </span>
+                                    </div>
+                                    </div><!-- End section-reply-controls -->
+
+                                    <div id="section-agent-memory" class="tutorial-section">
+                                    <div class="form-section-header">Agent Memory (Run-Scoped)</div>
+                                    <div class="form-section-description">
+                                        Configure lightweight, run-scoped memory. Agents remember who they interacted with,
+                                        how it went (agreement/conflict/trust/humor), and a gist of threads/community.
+                                        Memory resets between separate runs.
+                                    </div>
+                                    <div class="box-line">
+                                        <span class="left">Enable Memory</span>
+                                        <span class="right" style="width: 70%;">
+                                            <label style="display: flex; align-items: center; gap: 8px; cursor: pointer;">
+                                                <input type="checkbox" name="memory_enabled" checked>
+                                                <span style="color: #039be5;">Enable run-scoped memory</span>
+                                            </label>
+                                            <small style="color: #666; display: block; margin-top: 4px;">
+                                                When enabled, memory can influence posting, commenting, and voting.
+                                            </small>
+                                        </span>
+                                    </div>
+                                    <input type="hidden" name="memory_semantic_enabled" value="on">
+
+                                    <div class="box-line">
+                                        <span class="left">Pair Limit</span>
+                                        <span class="right" style="width: 70%;">
+                                            <input type="number" name="memory_pair_limit" class="input"
+                                                   min="1" max="50" step="1" value="5" required>
+                                            <small style="color: #666; display: block; margin-top: 4px;">
+                                                How many recent interaction events to include in LLM context per user/thread pair.
+                                            </small>
+                                        </span>
+                                    </div>
+                                    <div class="box-line">
+                                        <span class="left">Prompt Max Chars</span>
+                                        <span class="right" style="width: 70%;">
+                                            <input type="number" name="memory_prompt_max_chars" class="input"
+                                                   min="200" max="3200" step="50" value="1600" required>
+                                            <small style="color: #666; display: block; margin-top: 4px;">
+                                                Character cap for injected memory context (24B/Ollama-safe default).
+                                            </small>
+                                        </span>
+                                    </div>
+                                    <div class="box-line">
+                                        <span class="left">Search K</span>
+                                        <span class="right" style="width: 70%;">
+                                            <input type="number" name="memory_search_k" class="input"
+                                                   min="1" max="40" step="1" value="8" required>
+                                            <small style="color: #666; display: block; margin-top: 4px;">
+                                                Number of top semantic memory items considered per retrieval.
+                                            </small>
+                                        </span>
+                                    </div>
+                                    <div class="box-line">
+                                        <span class="left">Search Window (rounds)</span>
+                                        <span class="right" style="width: 70%;">
+                                            <input type="number" name="memory_search_time_window_rounds" class="input"
+                                                   min="0" max="10000" step="1" value="40" required>
+                                            <small style="color: #666; display: block; margin-top: 4px;">
+                                                Recency horizon for semantic search candidates.
+                                            </small>
+                                        </span>
+                                    </div>
+                                    <div class="box-line">
+                                        <span class="left">Total Memory Chars</span>
+                                        <span class="right" style="width: 70%;">
+                                            <input type="number" name="memory_total_max_chars" class="input"
+                                                   min="800" max="5000" step="50" value="2200" required>
+                                            <small style="color: #666; display: block; margin-top: 4px;">
+                                                Overall cap for injected memory context across tiers.
+                                            </small>
+                                        </span>
+                                    </div>
+
+                                    <div class="box-line">
+                                        <span class="left">Reflection Cadence</span>
+                                        <span class="right" style="width: 70%;">
+                                            <input type="number" name="memory_reflection_cadence_rounds" class="input"
+                                                   min="1" max="200" step="1" value="3" required>
+                                            <small style="color: #666; display: block; margin-top: 4px;">
+                                                How often memory reflections are generated.
+                                            </small>
+                                        </span>
+                                    </div>
+                                    <div class="box-line">
+                                        <span class="left">Cold-Start Window</span>
+                                        <span class="right" style="width: 70%;">
+                                            <input type="number" name="memory_cold_start_window" class="input"
+                                                   min="1" max="1000" step="1" value="5" required>
+                                            <small style="color: #666; display: block; margin-top: 4px;">
+                                                Number of initial interactions treated as full memory imprint before progressive decay starts.
+                                            </small>
+                                        </span>
+                                    </div>
+
+                                    <div class="box-line">
+                                        <span class="left">Semantic Retrieval</span>
+                                        <span class="right" style="width: 70%;">
+                                            <small style="color: #666; display: block; margin-top: 4px;">
+                                                Enabled by default (semantic-first memory). Advanced overrides are optional below.
+                                            </small>
+                                        </span>
+                                    </div>
+
+                                    <details style="margin-top: 12px;">
+                                        <summary style="cursor: pointer; color: #666; font-weight: 600;">
+                                            Advanced Memory Settings (Optional)
+                                        </summary>
+                                        <div style="margin-top: 12px;">
+                                            <div class="box-line">
+                                                <span class="left">Social Decay (lambda)</span>
+                                                <span class="right" style="width: 70%;">
+                                                    <input type="number" name="memory_social_decay_lambda" class="input"
+                                                           min="0" max="5" step="0.001" value="0.05" required>
+                                                </span>
+                                            </div>
+                                            <div class="box-line">
+                                                <span class="left">Social Corruption Rate</span>
+                                                <span class="right" style="width: 70%;">
+                                                    <input type="number" name="memory_social_corruption_rate" class="input"
+                                                           min="0" max="1" step="0.001" value="0.02" required>
+                                                </span>
+                                            </div>
+                                            <div class="box-line">
+                                                <span class="left">Social Resummarize Every (events)</span>
+                                                <span class="right" style="width: 70%;">
+                                                    <input type="number" name="memory_social_resummarize_every_events" class="input"
+                                                           min="1" max="100" step="1" value="4" required>
+                                                </span>
+                                            </div>
+                                            <div class="box-line">
+                                                <span class="left">Thread Decay (lambda)</span>
+                                                <span class="right" style="width: 70%;">
+                                                    <input type="number" name="memory_thread_decay_lambda" class="input"
+                                                           min="0" max="5" step="0.001" value="0.03" required>
+                                                </span>
+                                            </div>
+                                            <div class="box-line">
+                                                <span class="left">Thread Corruption Rate</span>
+                                                <span class="right" style="width: 70%;">
+                                                    <input type="number" name="memory_thread_corruption_rate" class="input"
+                                                           min="0" max="1" step="0.001" value="0.01" required>
+                                                </span>
+                                            </div>
+                                            <div class="box-line">
+                                                <span class="left">Thread Resummarize Every (events)</span>
+                                                <span class="right" style="width: 70%;">
+                                                    <input type="number" name="memory_thread_resummarize_every_events" class="input"
+                                                           min="1" max="100" step="1" value="4" required>
+                                                </span>
+                                            </div>
+                                            <div class="box-line">
+                                                <span class="left">Evidence Tail Max</span>
+                                                <span class="right" style="width: 70%;">
+                                                    <input type="number" name="memory_evidence_tail_max" class="input"
+                                                           min="0" max="100" step="1" value="8" required>
+                                                </span>
+                                            </div>
+                                            <div class="box-line">
+                                                <span class="left">Digest Update Cadence (rounds)</span>
+                                                <span class="right" style="width: 70%;">
+                                                    <input type="number" name="memory_digest_update_cadence_rounds" class="input"
+                                                           min="1" max="100" step="1" value="3" required>
+                                                </span>
+                                            </div>
+                                            <div class="box-line">
+                                                <span class="left">Digest Events Limit</span>
+                                                <span class="right" style="width: 70%;">
+                                                    <input type="number" name="memory_digest_events_limit" class="input"
+                                                           min="10" max="1000" step="5" value="80" required>
+                                                </span>
+                                            </div>
+                                            <div class="box-line">
+                                                <span class="left">Search Max Chars</span>
+                                                <span class="right" style="width: 70%;">
+                                                    <input type="number" name="memory_search_max_chars" class="input"
+                                                           min="300" max="1800" step="50" value="900" required>
+                                                </span>
+                                            </div>
+                                            <div class="box-line">
+                                                <span class="left">Tier A Max Chars</span>
+                                                <span class="right" style="width: 70%;">
+                                                    <input type="number" name="memory_tier_a_max_chars" class="input"
+                                                           min="100" max="2000" step="25" value="350" required>
+                                                </span>
+                                            </div>
+                                            <div class="box-line">
+                                                <span class="left">Tier B Max Chars</span>
+                                                <span class="right" style="width: 70%;">
+                                                    <input type="number" name="memory_tier_b_max_chars" class="input"
+                                                           min="400" max="3200" step="50" value="900" required>
+                                                </span>
+                                            </div>
+                                            <div class="box-line">
+                                                <span class="left">Tier C Max Chars</span>
+                                                <span class="right" style="width: 70%;">
+                                                    <input type="number" name="memory_tier_c_max_chars" class="input"
+                                                           min="400" max="3200" step="50" value="900" required>
+                                                </span>
+                                            </div>
+                                            <div class="box-line">
+                                                <span class="left">Tier C Uncertainty</span>
+                                                <span class="right" style="width: 70%;">
+                                                    <input type="number" name="memory_tier_c_uncertainty_threshold" class="input"
+                                                           min="0" max="1" step="0.01" value="0.45" required>
+                                                </span>
+                                            </div>
+                                            <div class="box-line">
+                                                <span class="left">Reflection Min Events</span>
+                                                <span class="right" style="width: 70%;">
+                                                    <input type="number" name="memory_reflection_min_events" class="input"
+                                                           min="1" max="500" step="1" value="12" required>
+                                                </span>
+                                            </div>
+                                            <div class="box-line">
+                                                <span class="left">Reflection Trigger Sum</span>
+                                                <span class="right" style="width: 70%;">
+                                                    <input type="number" name="memory_reflection_trigger_importance_sum" class="input"
+                                                           min="0" max="20" step="0.1" value="3.5" required>
+                                                </span>
+                                            </div>
+                                            <div class="box-line">
+                                                <span class="left">Reflection Max Items</span>
+                                                <span class="right" style="width: 70%;">
+                                                    <input type="number" name="memory_reflection_max_items_per_run" class="input"
+                                                           min="1" max="5000" step="1" value="60" required>
+                                                </span>
+                                            </div>
+                                            <div class="box-line">
+                                                <span class="left">Embedding Model</span>
+                                                <span class="right" style="width: 70%;">
+                                                    <input type="text" name="memory_embedding_model" class="input"
+                                                           value="BAAI/bge-m3">
+                                                </span>
+                                            </div>
+                                            <div class="box-line">
+                                                <span class="left">Async Embedding</span>
+                                                <span class="right" style="width: 70%;">
+                                                    <label style="display: flex; align-items: center; gap: 8px; cursor: pointer;">
+                                                        <input type="checkbox" name="memory_embedding_async" checked>
+                                                        <span style="color: #039be5;">Background indexing</span>
+                                                    </label>
+                                                </span>
+                                            </div>
+                                            <div class="box-line">
+                                                <span class="left">Importance Mode</span>
+                                                <span class="right" style="width: 70%;">
+                                                    <input type="text" name="memory_importance_mode" class="input"
+                                                           value="heuristic_then_batch_llm">
+                                                </span>
+                                            </div>
+                                        </div>
+                                    </details>
+                                    </div><!-- End section-agent-memory -->
+
+                                    <div id="section-actions-likelihood" class="tutorial-section">
+                                    <div class="form-section-header">Agents' Actions Likelihood</div>
+                                    <div class="form-section-description">
+                                        Configure relative action weights from 0.0 to 1.0. A value of 0.0 means the action is never performed.
+                                        Values are relative weights that get normalized. For example, if "Post new content" has weight 0.3
+                                        and "Comment a Post" has weight 0.6, agents will comment roughly twice as much as posting.
                                     </div>
                                     <div class="box-line">
                                         <span class="left">Post new content</span>
                                         <span class="right" style="width: 70%;">
-                                            <!--<input type="text" name="post" class="input"  value="0.2">-->
-                                            <div class="scale-wrapper">
-                                            <div class="number-scale">
-                                                  <div class="number-box" data-value="0">0</div>
-                                                  <div class="number-box" data-value="1">1</div>
-                                                  <div class="number-box" data-value="2">2</div>
-                                                  <div class="number-box selected" data-value="3">3</div>
-                                                  <div class="number-box" data-value="4">4</div>
-                                                  <div class="number-box" data-value="5">5</div>
-                                                  <div class="number-box" data-value="6">6</div>
-                                                  <div class="number-box" data-value="7">7</div>
-                                                  <div class="number-box" data-value="8">8</div>
-                                                  <div class="number-box" data-value="9">9</div>
-                                                  <div class="number-box" data-value="10">10</div>
-                                            </div>
-                                            <input type="hidden" name="post" id="post" value="3">
-                                            </div>
+                                            <input type="number" name="post" id="post" class="input" step="0.001" min="0" max="1" value="0.3">
                                         </span>
                                     </div>
                                     {% if experiment.platform_type == "microblogging" %}
                                     <div class="box-line">
                                         <span class="left">Share and comment an Image</span>
-                                        <!--<span class="right" style="width: 70%;"><input type="text" name="image"
-                                                                                       class="input"
-                                                                                       value="0"></span>-->
                                         <span class="right" style="width: 70%;">
-                                            <div class="scale-wrapper">
-                                            <div class="number-scale">
-                                                  <div class="number-box selected" data-value="0">0</div>
-                                                  <div class="number-box" data-value="1">1</div>
-                                                  <div class="number-box" data-value="2">2</div>
-                                                  <div class="number-box" data-value="3">3</div>
-                                                  <div class="number-box" data-value="4">4</div>
-                                                  <div class="number-box" data-value="5">5</div>
-                                                  <div class="number-box" data-value="6">6</div>
-                                                  <div class="number-box" data-value="7">7</div>
-                                                  <div class="number-box" data-value="8">8</div>
-                                                  <div class="number-box" data-value="9">9</div>
-                                                  <div class="number-box" data-value="10">10</div>
-                                            </div>
-                                            <input type="hidden" name="image" id="image" value="0">
-                                            </div>
-
+                                            <input type="number" name="image" id="image" class="input" step="0.001" min="0" max="1" value="0.0">
                                         </span>
                                     </div>
                                     <div class="box-line">
                                         <span class="left">Comment on a News</span>
-                                       <!-- <span class="right" style="width: 70%;"><input type="text"
-                                                                                       name="news"
-                                                                                       class="input"
-                                                                                       value="0"></span> -->
                                         <span class="right" style="width: 70%;">
-                                            <div class="scale-wrapper">
-                                            <div class="number-scale">
-                                                  <div class="number-box selected" data-value="0">0</div>
-                                                  <div class="number-box" data-value="1">1</div>
-                                                  <div class="number-box" data-value="2">2</div>
-                                                  <div class="number-box" data-value="3">3</div>
-                                                  <div class="number-box" data-value="4">4</div>
-                                                  <div class="number-box" data-value="5">5</div>
-                                                  <div class="number-box" data-value="6">6</div>
-                                                  <div class="number-box" data-value="7">7</div>
-                                                  <div class="number-box" data-value="8">8</div>
-                                                  <div class="number-box" data-value="9">9</div>
-                                                  <div class="number-box" data-value="10">10</div>
-                                            </div>
-                                            <input type="hidden" name="news" id="news" value="0">
-                                            </div>
-
+                                            <input type="number" name="news" id="news" class="input" step="0.001" min="0" max="1" value="0.0">
                                         </span>
                                     </div>
                                     {% endif %}
                                     <div class="box-line">
                                         <span class="left">Comment a Post</span>
-                                        <!--<span class="right" style="width: 70%;"><input type="text"
-                                                                                       name="comment"
-                                                                                       class="input"
-                                                                                       value="0.5"></span> -->
-                                         <span class="right" style="width: 70%;">
-                                            <div class="scale-wrapper">
-                                            <div class="number-scale">
-                                                  <div class="number-box" data-value="0">0</div>
-                                                  <div class="number-box" data-value="1">1</div>
-                                                  <div class="number-box" data-value="2">2</div>
-                                                  <div class="number-box" data-value="3">3</div>
-                                                  <div class="number-box" data-value="4">4</div>
-                                                  <div class="number-box selected" data-value="5">5</div>
-                                                  <div class="number-box" data-value="6">6</div>
-                                                  <div class="number-box" data-value="7">7</div>
-                                                  <div class="number-box" data-value="8">8</div>
-                                                  <div class="number-box" data-value="9">9</div>
-                                                  <div class="number-box" data-value="10">10</div>
-                                            </div>
-                                            <input type="hidden" name="comment" id="comment" value="5">
-                                            </div>
-
+                                        <span class="right" style="width: 70%;">
+                                            <input type="number" name="comment" id="comment" class="input" step="0.001" min="0" max="1" value="0.5">
                                         </span>
                                     </div>
                                     <div class="box-line">
                                         <span class="left">Read a content</span>
-                                        <!-- <span class="right" style="width: 70%;"><input type="text"
-                                                                                       name="read"
-                                                                                       class="input"
-                                                                                       value="0.2"></span> -->
                                         <span class="right" style="width: 70%;">
-                                            <div class="scale-wrapper">
-                                            <div class="number-scale">
-                                                  <div class="number-box" data-value="0">0</div>
-                                                  <div class="number-box" data-value="1">1</div>
-                                                  <div class="number-box selected" data-value="2">2</div>
-                                                  <div class="number-box" data-value="3">3</div>
-                                                  <div class="number-box" data-value="4">4</div>
-                                                  <div class="number-box" data-value="5">5</div>
-                                                  <div class="number-box" data-value="6">6</div>
-                                                  <div class="number-box" data-value="7">7</div>
-                                                  <div class="number-box" data-value="8">8</div>
-                                                  <div class="number-box" data-value="9">9</div>
-                                                  <div class="number-box" data-value="10">10</div>
-                                            </div>
-                                            <input type="hidden" name="read" id="read" value="2">
-                                            </div>
-
+                                            <input type="number" name="read" id="read" class="input" step="0.001" min="0" max="1" value="0.2">
                                         </span>
-
                                     </div>
                                     {% if experiment.platform_type == "microblogging" %}
                                     <div class="box-line">
                                         <span class="left">Share News from a Page</span>
-                                        <!-- <span class="right" style="width: 70%;"><input type="text"
-                                                                                       name="share"
-                                                                                       class="input"
-                                                                                       value="0"></span> -->
-                                         <span class="right" style="width: 70%;">
-                                            <div class="scale-wrapper">
-                                            <div class="number-scale">
-                                                  <div class="number-box selected" data-value="0">0</div>
-                                                  <div class="number-box" data-value="1">1</div>
-                                                  <div class="number-box" data-value="2">2</div>
-                                                  <div class="number-box" data-value="3">3</div>
-                                                  <div class="number-box" data-value="4">4</div>
-                                                  <div class="number-box" data-value="5">5</div>
-                                                  <div class="number-box" data-value="6">6</div>
-                                                  <div class="number-box" data-value="7">7</div>
-                                                  <div class="number-box" data-value="8">8</div>
-                                                  <div class="number-box" data-value="9">9</div>
-                                                  <div class="number-box" data-value="10">10</div>
-                                            </div>
-                                            <input type="hidden" name="share" id="share" value="0">
-                                            </div>
-
+                                        <span class="right" style="width: 70%;">
+                                            <input type="number" name="share" id="share" class="input" step="0.001" min="0" max="1" value="0.0">
                                         </span>
                                     </div>
                                     {% endif %}
@@ -365,28 +616,8 @@
                                     {# SQLite database - show Search a Hashtag field #}
                                     <div class="box-line">
                                         <span class="left">Search a Hashtag</span>
-                                       <!-- <span class="right" style="width: 70%;"><input type="text"
-                                                                                       name="search"
-                                                                                       class="input"
-                                                                                       value="0.1"></span> -->
                                         <span class="right" style="width: 70%;">
-                                            <div class="scale-wrapper">
-                                            <div class="number-scale">
-                                                  <div class="number-box" data-value="0">0</div>
-                                                  <div class="number-box selected" data-value="1">1</div>
-                                                  <div class="number-box" data-value="2">2</div>
-                                                  <div class="number-box" data-value="3">3</div>
-                                                  <div class="number-box" data-value="4">4</div>
-                                                  <div class="number-box" data-value="5">5</div>
-                                                  <div class="number-box" data-value="6">6</div>
-                                                  <div class="number-box" data-value="7">7</div>
-                                                  <div class="number-box" data-value="8">8</div>
-                                                  <div class="number-box" data-value="9">9</div>
-                                                  <div class="number-box" data-value="10">10</div>
-                                            </div>
-                                            <input type="hidden" name="search" id="search" value="1">
-                                            </div>
-
+                                            <input type="number" name="search" id="search" class="input" step="0.001" min="0" max="1" value="0.1">
                                         </span>
                                     </div>
                                     {% else %}
@@ -398,28 +629,8 @@
                                     {# SQLite database - show Cast Vote field #}
                                     <div class="box-line">
                                         <span class="left">Cast Vote</span>
-                                        <!-- <span class="right" style="width: 70%;"><input type="text"
-                                                                                       name="vote"
-                                                                                       class="input"
-                                                                                       value="0"></span> -->
                                         <span class="right" style="width: 70%;">
-                                            <div class="scale-wrapper">
-                                            <div class="number-scale">
-                                                  <div class="number-box selected" data-value="0">0</div>
-                                                  <div class="number-box" data-value="1">1</div>
-                                                  <div class="number-box" data-value="2">2</div>
-                                                  <div class="number-box" data-value="3">3</div>
-                                                  <div class="number-box" data-value="4">4</div>
-                                                  <div class="number-box" data-value="5">5</div>
-                                                  <div class="number-box" data-value="6">6</div>
-                                                  <div class="number-box" data-value="7">7</div>
-                                                  <div class="number-box" data-value="8">8</div>
-                                                  <div class="number-box" data-value="9">9</div>
-                                                  <div class="number-box" data-value="10">10</div>
-                                            </div>
-                                            <input type="hidden" name="vote" id="vote" value="0">
-                                            </div>
-
+                                            <input type="number" name="vote" id="vote" class="input" step="0.001" min="0" max="1" value="0.0">
                                         </span>
                                     </div>
                                     {% else %}
@@ -430,10 +641,15 @@
                                     {% if experiment.platform_type == "forum" %}
                                     <div class="box-line">
                                         <span class="left">Share Link</span>
-                                        <span class="right" style="width: 70%;"><input type="text"
-                                                                                       name="share_link"
-                                                                                       class="input"
-                                                                                       value="0"></span>
+                                        <span class="right" style="width: 70%;">
+                                            <input type="number" name="share_link" id="share_link" class="input" step="0.001" min="0" max="1" value="0.0">
+                                        </span>
+                                    </div>
+                                    <div class="box-line">
+                                        <span class="left">Share Image</span>
+                                        <span class="right" style="width: 70%;">
+                                            <input type="number" name="share_image" id="share_image" class="input" step="0.001" min="0" max="1" value="0.15">
+                                        </span>
                                     </div>
                                     {% endif %}
                                     {% if llm_agents_enabled %}
@@ -445,7 +661,7 @@
                                         <span class="left">LLM Server URL</span>
                                         <span class="right" style="width: 70%;">
                                             <div style="display: flex; align-items: center; gap: 10px; margin-bottom: 5px;">
-                                                <input type="text" id="custom_llm_url_client" name="llm" class="input" placeholder="e.g., localhost:8000" value="http://127.0.0.1:11434/v1" style="flex: 1;">
+                                                <input type="text" id="custom_llm_url_client" name="llm" class="input" placeholder="e.g., localhost:8000" value="{{ exp_llm_defaults.llm }}" style="flex: 1;">
                                                 <button type="button" class="button is-solid primary-button" onclick="fetchModelsForClient()">
                                                     Fetch Models
                                                 </button>
@@ -469,39 +685,45 @@
                                         <span class="right" style="width: 70%;"><input type="text"
                                                                                        name="llm_api_key"
                                                                                        class="input"
-                                                                                       value="NULL"></span>
+                                                                                       value="{{ exp_llm_defaults.llm_api_key }}"></span>
                                     </div>
                                     <div class="box-line">
                                         <span class="left">Max tokens</span>
                                         <span class="right" style="width: 70%;"><input type="number"
                                                                                        name="llm_max_tokens"
                                                                                        class="input"
-                                                                                       value="-1"></span>
+                                                                                       step="1"
+                                                                                       value="{{ exp_llm_defaults.llm_max_tokens }}"></span>
                                     </div>
                                     <div class="box-line">
                                         <span class="left">Temperature</span>
                                         <span class="right" style="width: 70%;"><input type="number"
                                                                                        name="llm_temperature"
                                                                                        class="input"
-                                                                                       value="1.5"></span>
+                                                                                       step="any"
+                                                                                       value="{{ exp_llm_defaults.llm_temperature }}"></span>
                                     </div>
                                     <div class="form-section-header">Large Language Models (Image Transcription)</div>
                                     <div class="form-section-description">
                                         Configure the vision LLM for image content analysis and transcription.
                                     </div>
                                     <div class="box-line">
-                                        <span class="left">LLM Model</span>
-                                        <span class="right" style="width: 70%;">minicpm-v:latest<input  type="hidden"
-                                                                                       name="llm_v_agent"
-                                                                                       id="llm_v_agent"
-                                                                                       class="input"
-                                                                                       value="minicpm-v"></span>
+                                        <span class="left">VLM Model</span>
+                                        <span class="right" style="width: 70%;">
+                                            <select name="llm_v_agent" id="llm_v_agent" class="input">
+                                                <option value="qwen3-vl:8b" {% if exp_llm_defaults.llm_v_agent == 'qwen3-vl:8b' or not exp_llm_defaults.llm_v_agent %}selected{% endif %}>qwen3-vl:8b (Recommended)</option>
+                                                <option value="minicpm-v" {% if exp_llm_defaults.llm_v_agent == 'minicpm-v' %}selected{% endif %}>minicpm-v</option>
+                                                <option value="llava:7b" {% if exp_llm_defaults.llm_v_agent == 'llava:7b' %}selected{% endif %}>llava:7b</option>
+                                                <option value="llava:13b" {% if exp_llm_defaults.llm_v_agent == 'llava:13b' %}selected{% endif %}>llava:13b</option>
+                                                <option value="llava:34b" {% if exp_llm_defaults.llm_v_agent == 'llava:34b' %}selected{% endif %}>llava:34b</option>
+                                            </select>
+                                        </span>
                                     </div>
                                     <div class="box-line">
                                         <span class="left">LLM Server URL</span>
                                         <span class="right" style="width: 70%;">
                                             <div style="display: flex; align-items: center; gap: 10px; margin-bottom: 5px;">
-                                                <input type="text" id="custom_llm_url_v_client" name="llm_v" class="input" placeholder="e.g., localhost:8000" value="http://127.0.0.1:11434/v1" style="flex: 1;">
+                                                <input type="text" id="custom_llm_url_v_client" name="llm_v" class="input" placeholder="e.g., localhost:8000" value="{{ exp_llm_defaults.llm_v }}" style="flex: 1;">
                                                 <button type="button" class="button is-solid primary-button" onclick="validateImageLLMModel()">
                                                     Validate Model
                                                 </button>
@@ -514,25 +736,26 @@
                                         <span class="right" style="width: 70%;"><input type="text"
                                                                                        name="llm_v_api_key"
                                                                                        class="input"
-                                                                                       value="NULL"></span>
+                                                                                       value="{{ exp_llm_defaults.llm_v_api_key }}"></span>
                                     </div>
                                     <div class="box-line">
                                         <span class="left">Max tokens</span>
                                         <span class="right" style="width: 70%;"><input type="number"
                                                                                        name="llm_v_max_tokens"
                                                                                        class="input"
-                                                                                       value="300"></span>
+                                                                                       value="{{ exp_llm_defaults.llm_v_max_tokens }}"></span>
                                     </div>
                                     <div class="box-line">
                                         <span class="left">Temperature</span>
                                         <span class="right" style="width: 70%;"><input type="number"
                                                                                        name="llm_v_temperature"
                                                                                        class="input"
-                                                                                       value="0.5"></span>
+                                                                                       step="any"
+                                                                                       value="{{ exp_llm_defaults.llm_v_temperature }}"></span>
                                     </div>
                                     <input type="hidden" id="llm_v_validation_status" value="false">
                                     <div id="image_action_warning" style="padding: 10px; margin: 10px 0; background-color: #fff3cd; border: 1px solid #ffc107; border-radius: 4px; color: #856404;">
-                                        <i class="mdi mdi-alert"></i> <strong>Notice:</strong> Image sharing/commenting is currently disabled. Please validate that the minicpm-v:latest model is available on your server to enable this feature.
+                                        <i class="mdi mdi-alert"></i> <strong>Notice:</strong> Image sharing/commenting is currently disabled. Please validate that your selected VLM model is available on your server to enable this feature.
                                     </div>
                                     {% endif %}
                                     </div><!-- End section-actions-relevance -->
@@ -715,428 +938,6 @@
                                     </details>
                                     </div><!-- End section-network -->
 
-                                    <div id="section-activity-rates" class="tutorial-section">
-                                    <div class="form-section-header">Hourly Activity Rates <span style="font-size: 0.85em; color: #6b7280; font-weight: 400;">(Optional)</span></div>
-                                    <div class="form-section-description">
-                                        Configure hourly activity rates for the simulation. Default values are based on
-                                        <a href="https://zenodo.org/records/14669616" target="_blank" style="color: #039be5;">Bluesky Data</a>.
-                                        Leave empty to use defaults.
-                                    </div>
-
-                                    <details style="margin-bottom: 20px;">
-                                        <summary style="cursor: pointer; font-weight: 500; font-size: 0.95em; padding: 8px 0; color: #374151; list-style: none;">
-                                            <span>Click to expand/collapse activity rates configuration</span>
-                                        </summary>
-                                        <div style="padding: 15px 0; margin-top: 10px;">
-
-                                            <!-- Bar Chart Visualization -->
-                                            <div style="margin-bottom: 20px;">
-                                                <h4 style="font-size: 0.9em; font-weight: 600; margin-bottom: 8px; color: #333; border-bottom: 1px solid #e0e0e0; padding-bottom: 3px;">Activity Rates Visualization</h4>
-                                                <div style="height: 200px; position: relative; background: white; padding: 10px; border: 1px solid #e5e7eb; border-radius: 4px;">
-                                                    <canvas id="activity_rates_create"></canvas>
-                                                </div>
-                                            </div>
-
-                                            <!-- Activity Rates Input Fields -->
-                                            <div style="margin-bottom: 20px;">
-                                                <h4 style="font-size: 0.9em; font-weight: 600; margin-bottom: 8px; color: #333; border-bottom: 1px solid #e0e0e0; padding-bottom: 3px;">Customize Hourly Rates</h4>
-                                                <p style="font-size: 0.8em; color: #666; margin-bottom: 12px;">Enter custom values for specific hours (leave empty to use defaults shown in placeholders)</p>
-                                            </div>
-
-                                            <style>
-                                                .activity-grid-create {
-                                                    display: grid;
-                                                    grid-template-columns: repeat(12, 1fr);
-                                                    gap: 8px;
-                                                    margin-bottom: 16px;
-                                                }
-                                                .activity-hour-create {
-                                                    display: flex;
-                                                    flex-direction: column;
-                                                    align-items: center;
-                                                }
-                                                .activity-hour-create label {
-                                                    font-size: 0.75em;
-                                                    color: #666;
-                                                    margin-bottom: 4px;
-                                                    font-weight: 500;
-                                                }
-                                                .activity-hour-create input {
-                                                    width: 100%;
-                                                    padding: 4px 6px;
-                                                    text-align: center;
-                                                    font-size: 0.85em;
-                                                    border: 1px solid #d1d5db;
-                                                    border-radius: 4px;
-                                                }
-                                                .activity-hour-create input:focus {
-                                                    outline: none;
-                                                    border-color: #22c55e;
-                                                    box-shadow: 0 0 0 2px rgba(34, 197, 94, 0.1);
-                                                }
-                                            </style>
-
-                                            <div class="activity-grid-create">
-                                                <div class="activity-hour-create">
-                                                    <label>0h</label>
-                                                    <input type="number" name="hourly_0" placeholder="0.023" value="">
-                                                </div>
-                                                <div class="activity-hour-create">
-                                                    <label>1h</label>
-                                                    <input type="number" name="hourly_1" placeholder="0.021" value="">
-                                                </div>
-                                                <div class="activity-hour-create">
-                                                    <label>2h</label>
-                                                    <input type="number" name="hourly_2" placeholder="0.020" value="">
-                                                </div>
-                                                <div class="activity-hour-create">
-                                                    <label>3h</label>
-                                                    <input type="number" name="hourly_3" placeholder="0.020" value="">
-                                                </div>
-                                                <div class="activity-hour-create">
-                                                    <label>4h</label>
-                                                    <input type="number" name="hourly_4" placeholder="0.018" value="">
-                                                </div>
-                                                <div class="activity-hour-create">
-                                                    <label>5h</label>
-                                                    <input type="number" name="hourly_5" placeholder="0.017" value="">
-                                                </div>
-                                                <div class="activity-hour-create">
-                                                    <label>6h</label>
-                                                    <input type="number" name="hourly_6" placeholder="0.017" value="">
-                                                </div>
-                                                <div class="activity-hour-create">
-                                                    <label>7h</label>
-                                                    <input type="number" name="hourly_7" placeholder="0.018" value="">
-                                                </div>
-                                                <div class="activity-hour-create">
-                                                    <label>8h</label>
-                                                    <input type="number" name="hourly_8" placeholder="0.020" value="">
-                                                </div>
-                                                <div class="activity-hour-create">
-                                                    <label>9h</label>
-                                                    <input type="number" name="hourly_9" placeholder="0.020" value="">
-                                                </div>
-                                                <div class="activity-hour-create">
-                                                    <label>10h</label>
-                                                    <input type="number" name="hourly_10" placeholder="0.021" value="">
-                                                </div>
-                                                <div class="activity-hour-create">
-                                                    <label>11h</label>
-                                                    <input type="number" name="hourly_11" placeholder="0.022" value="">
-                                                </div>
-                                            </div>
-                                            <div class="activity-grid-create">
-                                                <div class="activity-hour-create">
-                                                    <label>12h</label>
-                                                    <input type="number" name="hourly_12" placeholder="0.024" value="">
-                                                </div>
-                                                <div class="activity-hour-create">
-                                                    <label>13h</label>
-                                                    <input type="number" name="hourly_13" placeholder="0.027" value="">
-                                                </div>
-                                                <div class="activity-hour-create">
-                                                    <label>14h</label>
-                                                    <input type="number" name="hourly_14" placeholder="0.030" value="">
-                                                </div>
-                                                <div class="activity-hour-create">
-                                                    <label>15h</label>
-                                                    <input type="number" name="hourly_15" placeholder="0.032" value="">
-                                                </div>
-                                                <div class="activity-hour-create">
-                                                    <label>16h</label>
-                                                    <input type="number" name="hourly_16" placeholder="0.032" value="">
-                                                </div>
-                                                <div class="activity-hour-create">
-                                                    <label>17h</label>
-                                                    <input type="number" name="hourly_17" placeholder="0.032" value="">
-                                                </div>
-                                                <div class="activity-hour-create">
-                                                    <label>18h</label>
-                                                    <input type="number" name="hourly_18" placeholder="0.032" value="">
-                                                </div>
-                                                <div class="activity-hour-create">
-                                                    <label>19h</label>
-                                                    <input type="number" name="hourly_19" placeholder="0.031" value="">
-                                                </div>
-                                                <div class="activity-hour-create">
-                                                    <label>20h</label>
-                                                    <input type="number" name="hourly_20" placeholder="0.030" value="">
-                                                </div>
-                                                <div class="activity-hour-create">
-                                                    <label>21h</label>
-                                                    <input type="number" name="hourly_21" placeholder="0.029" value="">
-                                                </div>
-                                                <div class="activity-hour-create">
-                                                    <label>22h</label>
-                                                    <input type="number" name="hourly_22" placeholder="0.027" value="">
-                                                </div>
-                                                <div class="activity-hour-create">
-                                                    <label>23h</label>
-                                                    <input type="number" name="hourly_23" placeholder="0.025" value="">
-                                                </div>
-                                            </div>
-
-                                            <script>
-                                                // Initialize chart with default data
-                                                function initActivityChart() {
-                                                    const defaultData = [
-                                                        0.023, 0.021, 0.020, 0.020, 0.018, 0.017, 0.017, 0.018,
-                                                        0.020, 0.020, 0.021, 0.022, 0.024, 0.027, 0.030, 0.032,
-                                                        0.032, 0.032, 0.032, 0.031, 0.030, 0.029, 0.027, 0.025
-                                                    ];
-                                                    const labels = Array.from({length: 24}, (_, i) => i.toString());
-                                                    
-                                                    // Convert to percentages
-                                                    const activityData = defaultData.map(v => v * 100);
-                                                    const maxValue = Math.max(...activityData);
-                                                    const yAxisMax = Math.ceil(maxValue * 1.1);
-
-                                                    const ctx = document.getElementById('activity_rates_create');
-                                                    if (!ctx) return;
-
-                                                    new Chart(ctx, {
-                                                        type: 'bar',
-                                                        data: {
-                                                            labels: labels,
-                                                            datasets: [{
-                                                                label: 'Activity %',
-                                                                data: activityData,
-                                                                backgroundColor: 'rgba(34, 197, 94, 0.6)',
-                                                                borderColor: 'rgba(34, 197, 94, 1)',
-                                                                borderWidth: 1,
-                                                                borderRadius: 4
-                                                            }]
-                                                        },
-                                                        options: {
-                                                            responsive: true,
-                                                            maintainAspectRatio: false,
-                                                            plugins: {
-                                                                legend: {
-                                                                    display: false
-                                                                },
-                                                                tooltip: {
-                                                                    backgroundColor: 'rgba(0, 0, 0, 0.8)',
-                                                                    padding: 8,
-                                                                    titleFont: { size: 12 },
-                                                                    bodyFont: { size: 11 },
-                                                                    callbacks: {
-                                                                        label: function(context) {
-                                                                            return 'Active: ' + context.parsed.y.toFixed(2) + '%';
-                                                                        }
-                                                                    }
-                                                                }
-                                                            },
-                                                            scales: {
-                                                                y: {
-                                                                    beginAtZero: true,
-                                                                    suggestedMax: yAxisMax,
-                                                                    ticks: {
-                                                                        font: { size: 10 },
-                                                                        callback: function(value) {
-                                                                            return value + '%';
-                                                                        }
-                                                                    },
-                                                                    grid: {
-                                                                        color: 'rgba(0, 0, 0, 0.05)'
-                                                                    }
-                                                                },
-                                                                x: {
-                                                                    ticks: {
-                                                                        font: { size: 9 }
-                                                                    },
-                                                                    grid: {
-                                                                        display: false
-                                                                    }
-                                                                }
-                                                            }
-                                                        }
-                                                    });
-                                                }
-
-                                                // Initialize chart when details are expanded
-                                                document.addEventListener('DOMContentLoaded', function() {
-                                                    const detailsElements = document.querySelectorAll('details');
-                                                    detailsElements.forEach(details => {
-                                                        details.addEventListener('toggle', function() {
-                                                            if (this.open && this.querySelector('#activity_rates_create')) {
-                                                                setTimeout(initActivityChart, 100);
-                                                            }
-                                                        });
-                                                    });
-                                                });
-                                            </script>
-                                        </div>
-                                    </details>
-                                    </div><!-- End section-activity-rates -->
-
-                                    <div id="section-agent-archetypes" class="tutorial-section">
-                                    <div class="form-section-header">Agent Archetypes and Transitions <span style="font-size: 0.85em; color: #6b7280; font-weight: 400;">(Optional)</span></div>
-                                    <div class="form-section-description">
-                                        Configure the behavioral archetypes and transition probabilities for agents. Default values are based on
-                                        <a href="https://zenodo.org/records/14669616" target="_blank" style="color: #039be5;">Bluesky Data</a>.
-                                    </div>
-
-                                    <div style="margin: 15px 0; padding: 12px; background: #f9fafb; border-radius: 6px; border: 1px solid #e5e7eb;">
-                                        <label style="display: flex; align-items: center; cursor: pointer; font-size: 0.9em; font-weight: 500; color: #374151;">
-                                            <input type="checkbox" id="enable_archetypes" name="enable_archetypes" checked style="margin-right: 8px; cursor: pointer;">
-                                            <span>Enable Agent Archetypes Distribution</span>
-                                        </label>
-                                        <p style="font-size: 0.8em; color: #6b7280; margin: 8px 0 0 28px; line-height: 1.4;">
-                                            When disabled, all agents will be able to perform all actions without archetype restrictions.
-                                        </p>
-                                    </div>
-
-                                    <details style="margin-bottom: 20px;" id="archetype-details">
-                                        <summary style="cursor: pointer; font-weight: 500; font-size: 0.95em; padding: 8px 0; color: #374151; list-style: none;">
-                                            <span>Click to expand/collapse archetype configuration</span>
-                                        </summary>
-                                        <div style="padding: 15px 0; margin-top: 10px;">
-
-                                            <style>
-                                                .archetype-boxes {
-                                                    display: grid;
-                                                    grid-template-columns: repeat(3, 1fr);
-                                                    gap: 12px;
-                                                    margin-bottom: 20px;
-                                                }
-                                                .archetype-box {
-                                                    background: #f9fafb;
-                                                    border: 1px solid #e5e7eb;
-                                                    border-radius: 6px;
-                                                    padding: 12px;
-                                                }
-                                                .archetype-box h4 {
-                                                    font-size: 0.85em;
-                                                    font-weight: 600;
-                                                    color: #374151;
-                                                    margin-bottom: 6px;
-                                                }
-                                                .archetype-box p {
-                                                    font-size: 0.75em;
-                                                    color: #6b7280;
-                                                    line-height: 1.3;
-                                                    margin-bottom: 8px;
-                                                }
-                                                .archetype-box input {
-                                                    width: 70px;
-                                                    padding: 4px 8px;
-                                                    text-align: center;
-                                                    font-size: 0.85em;
-                                                    border: 1px solid #d1d5db;
-                                                    border-radius: 4px;
-                                                }
-                                                .archetype-box input:focus {
-                                                    outline: none;
-                                                    border-color: #22c55e;
-                                                    box-shadow: 0 0 0 2px rgba(34, 197, 94, 0.1);
-                                                }
-                                                .transition-table-compact {
-                                                    width: 100%;
-                                                    border-collapse: collapse;
-                                                    font-size: 0.75em;
-                                                    margin-top: 16px;
-                                                }
-                                                .transition-table-compact th,
-                                                .transition-table-compact td {
-                                                    padding: 4px 6px;
-                                                    text-align: center;
-                                                    border: 1px solid #e5e7eb;
-                                                }
-                                                .transition-table-compact th {
-                                                    background-color: #f9fafb;
-                                                    color: #374151;
-                                                    font-weight: 600;
-                                                    font-size: 0.7em;
-                                                }
-                                                .transition-table-compact td:first-child {
-                                                    background-color: #f9fafb;
-                                                    font-weight: 500;
-                                                    text-align: left;
-                                                    color: #374151;
-                                                    font-size: 0.7em;
-                                                }
-                                                .transition-table-compact input {
-                                                    width: 50px;
-                                                    padding: 3px 4px;
-                                                    text-align: center;
-                                                    font-size: 0.75em;
-                                                    border: 1px solid #d1d5db;
-                                                    border-radius: 3px;
-                                                }
-                                                .transition-table-compact input:focus {
-                                                    outline: none;
-                                                    border-color: #22c55e;
-                                                    box-shadow: 0 0 0 2px rgba(34, 197, 94, 0.1);
-                                                }
-                                                .archetype-box.disabled {
-                                                    opacity: 0.5;
-                                                    background: #f3f4f6;
-                                                }
-                                                .archetype-box.disabled input {
-                                                    background: #e5e7eb;
-                                                    cursor: not-allowed;
-                                                }
-                                            </style>
-
-                                            <h4 style="font-size: 0.9em; font-weight: 600; margin-bottom: 8px; color: #333; border-bottom: 1px solid #e0e0e0; padding-bottom: 3px;">Archetype Distribution (%)</h4>
-                                            <p style="font-size: 0.8em; color: #666; margin-bottom: 12px;">Define the percentage of agents in each behavioral archetype (must sum to 100%).</p>
-                                            
-                                            <div class="archetype-boxes">
-                                                <div class="archetype-box" id="archetype-validator-box">
-                                                    <h4>The Validator</h4>
-                                                    <p>Active Audience - ~70% of activity is validating others</p>
-                                                    <input type="number" id="archetype_validator" name="archetype_validator" value="52" step="0.1" min="0" max="100"> <span style="font-size: 0.8em; color: #6b7280;">%</span>
-                                                </div>
-                                                <div class="archetype-box" id="archetype-broadcaster-box">
-                                                    <h4>The Broadcaster</h4>
-                                                    <p>Content Creator - ~75% of actions are posts/comments</p>
-                                                    <input type="number" id="archetype_broadcaster" name="archetype_broadcaster" value="20" step="0.1" min="0" max="100"> <span style="font-size: 0.8em; color: #6b7280;">%</span>
-                                                </div>
-                                                <div class="archetype-box" id="archetype-explorer-box">
-                                                    <h4>The Explorer</h4>
-                                                    <p>Network Growth - Focused on expanding social graph</p>
-                                                    <input type="number" id="archetype_explorer" name="archetype_explorer" value="28" step="0.1" min="0" max="100"> <span style="font-size: 0.8em; color: #6b7280;">%</span>
-                                                </div>
-                                            </div>
-
-                                            <h4 style="font-size: 0.9em; font-weight: 600; margin-bottom: 8px; color: #333; border-bottom: 1px solid #e0e0e0; padding-bottom: 3px; margin-top: 16px;">Transition Probabilities (%)</h4>
-                                            <p style="font-size: 0.8em; color: #666; margin-bottom: 12px;">Probability that an agent transitions from one archetype to another (each row must sum to 100%).</p>
-                                            
-                                            <table class="transition-table-compact">
-                                                <thead>
-                                                    <tr>
-                                                        <th style="text-align: left;">From / To</th>
-                                                        <th>Validator</th>
-                                                        <th>Broadcaster</th>
-                                                        <th>Explorer</th>
-                                                    </tr>
-                                                </thead>
-                                                <tbody>
-                                                    <tr>
-                                                        <td>Validator</td>
-                                                        <td><input type="number" id="trans_val_val" name="trans_val_val" value="85.3" step="0.1" min="0" max="100"></td>
-                                                        <td><input type="number" id="trans_val_broad" name="trans_val_broad" value="8.1" step="0.1" min="0" max="100"></td>
-                                                        <td><input type="number" id="trans_val_expl" name="trans_val_expl" value="6.6" step="0.1" min="0" max="100"></td>
-                                                    </tr>
-                                                    <tr>
-                                                        <td>Broadcaster</td>
-                                                        <td><input type="number" id="trans_broad_val" name="trans_broad_val" value="19.5" step="0.1" min="0" max="100"></td>
-                                                        <td><input type="number" id="trans_broad_broad" name="trans_broad_broad" value="72.9" step="0.1" min="0" max="100"></td>
-                                                        <td><input type="number" id="trans_broad_expl" name="trans_broad_expl" value="7.5" step="0.1" min="0" max="100"></td>
-                                                    </tr>
-                                                    <tr>
-                                                        <td>Explorer</td>
-                                                        <td><input type="number" id="trans_expl_val" name="trans_expl_val" value="36.4" step="0.1" min="0" max="100"></td>
-                                                        <td><input type="number" id="trans_expl_broad" name="trans_expl_broad" value="14.6" step="0.1" min="0" max="100"></td>
-                                                        <td><input type="number" id="trans_expl_expl" name="trans_expl_expl" value="49.0" step="0.1" min="0" max="100"></td>
-                                                    </tr>
-                                                </tbody>
-                                            </table>
-                                        </div>
-                                    </details>
-                                    </div><!-- End section-agent-archetypes -->
-
                                 </div>
                                 <div class="button-wrap">
                                     <button id="create_client_button" class="button is-solid primary-button is-fullwidth" disabled>
@@ -1172,6 +973,8 @@
                                 <b>Simulation Parameters</b><br>
                                 Configure duration, agent behavior, and network dynamics.<br><br>
                                 <em>Simulation Length:</em> Number of days to run. Check "Run until stopped" to create an infinite-duration client that runs until manually stopped.<br>
+                                <em>Experiment Clock Mode:</em> `Simulated` runs quickly; `Real-time` processes the current wall-clock hour.<br>
+                                <em>Clock Timezone:</em> Timezone used by real-time mode (experiment-wide across all clients).<br>
                                 <em>New Agents/Churn:</em> Daily agent creation and removal rates<br>
                                 <em>Thread Context:</em> How much conversation history agents see<br>
                                 <em>Timeline Ratio:</em> Balance between follower and general content<br>
@@ -1186,8 +989,8 @@
                             </p>
                             <hr>
                             <p>
-                                <b>Agents' Actions Relevance</b><br>
-                                Set relative probabilities (0-10) for each action type. Higher values mean more frequent actions. Use 0 to disable an action.<br><br>
+                                <b>Agents' Actions Likelihood</b><br>
+                                Set relative weights (0.0-1.0) for each action type. Higher values mean more frequent actions. Use 0.0 to disable an action. Values are normalized relative to each other.<br><br>
                                 Actions include posting, commenting, reading, searching, and platform-specific features.
                             </p>
                             <hr>
@@ -1201,7 +1004,7 @@
                             <p>
                                 <b>Image Transcription (Optional)</b><br>
                                 Configure vision LLM for image content analysis.<br><br>
-                                Click "Validate Model" to verify minicpm-v:latest is available. This enables image-related actions.
+                                Select a VLM model and click "Validate Model" to verify it's available. This enables image-related actions.
                             </p>
                             <hr>
                             <p>
@@ -1210,22 +1013,6 @@
                                 <em>Synthetic Network:</em> Generate using Random or Scale-Free models<br>
                                 <em>Custom Network:</em> Upload a CSV edge list file<br><br>
                                 <em>Note:</em> These options are mutually exclusive.
-                            </p>
-                            <hr>
-                            <p>
-                                <b>Hourly Activity Rates (Optional)</b><br>
-                                Customize agent activity patterns by hour.<br><br>
-                                Default values are based on real-world Bluesky data. Leave empty to use defaults.
-                            </p>
-                            <hr>
-                            <p>
-                                <b>Agent Archetypes and Transitions (Optional)</b><br>
-                                Configure behavioral archetypes and transition probabilities for agents.<br><br>
-                                <em>Enable/Disable Toggle:</em> When disabled, all agents can perform all actions without archetype restrictions.<br><br>
-                                <em>The Validator:</em> Active Audience (~70% validation activity)<br>
-                                <em>The Broadcaster:</em> Content Creator (~75% posts/comments)<br>
-                                <em>The Explorer:</em> Network Growth (focused on connections, enabled only when follow probabilities > 0)<br><br>
-                                Default values (52-20-28) are based on real-world Bluesky data.
                             </p>
 
                         </div>
@@ -1239,21 +1026,6 @@
 </div>
 
 <script>
-                                            document.querySelectorAll('.number-scale').forEach(scale => {
-                                              const boxes = scale.querySelectorAll('.number-box');
-                                              const wrapper = scale.closest('.scale-wrapper');
-                                              const hiddenInput = wrapper.querySelector('input[type="hidden"]');
-
-                                              boxes.forEach(box => {
-                                                box.addEventListener('click', () => {
-                                                  boxes.forEach(b => b.classList.remove('selected'));
-                                                  box.classList.add('selected');
-                                                  hiddenInput.value = box.dataset.value;
-                                                  display.textContent = box.dataset.value;
-                                                });
-                                              });
-                                            });
-
 // Track if models have been fetched and validated
 let llmModelsFetched = false;
 let llmModelSelected = false;
@@ -1268,6 +1040,59 @@ function updateFormButtonState() {
         // When LLM agents are disabled, form can be submitted without LLM validation
         submitButton.disabled = false;
         {% endif %}
+    }
+}
+
+function setNumericInputByName(name, value) {
+    const input = document.querySelector(`input[name="${name}"]`);
+    if (!input) return;
+    input.value = String(value);
+    input.dispatchEvent(new Event('input', { bubbles: true }));
+    input.dispatchEvent(new Event('change', { bubbles: true }));
+}
+
+function applyContextPreset() {
+    const presetSelect = document.getElementById('context_preset_select');
+    const status = document.getElementById('context_preset_status');
+    if (!presetSelect) return;
+
+    const presets = {
+        balanced: {
+            max_thread_context_chars: 3200,
+            memory_prompt_max_chars: 1600,
+            memory_search_max_chars: 900,
+            memory_tier_a_max_chars: 350,
+            memory_tier_b_max_chars: 900,
+            memory_tier_c_max_chars: 900,
+            memory_total_max_chars: 2200,
+            llm_max_tokens: 768,
+        },
+        high_24b: {
+            max_thread_context_chars: 4200,
+            memory_prompt_max_chars: 2200,
+            memory_search_max_chars: 1200,
+            memory_tier_a_max_chars: 450,
+            memory_tier_b_max_chars: 1200,
+            memory_tier_c_max_chars: 1200,
+            memory_total_max_chars: 3000,
+            llm_max_tokens: 1024,
+        },
+    };
+
+    const preset = presets[presetSelect.value];
+    if (!preset) return;
+
+    Object.entries(preset).forEach(([name, value]) => {
+        setNumericInputByName(name, value);
+    });
+
+    if (status) {
+        const label = presetSelect.options[presetSelect.selectedIndex].text;
+        status.textContent = `Applied: ${label}`;
+        status.style.display = 'block';
+        setTimeout(() => {
+            status.style.display = 'none';
+        }, 2500);
     }
 }
 
@@ -1317,13 +1142,14 @@ function fetchModelsForClient() {
         });
 }
 
-// Validate that minicpm-v:latest is available for image transcription
+// Validate that selected VLM model is available for image transcription
 function validateImageLLMModel() {
     const llmVUrlInput = document.getElementById('custom_llm_url_v_client');
     const status = document.getElementById('llm_v_url_status_client');
     const validationStatus = document.getElementById('llm_v_validation_status');
     const llmVUrl = llmVUrlInput.value.trim();
-    const modelName = 'minicpm-v:latest';
+    const modelSelect = document.getElementById('llm_v_agent');
+    const modelName = modelSelect.value;
     
     if (!llmVUrl) {
         alert('Please enter an LLM server URL for image transcription');
@@ -1342,9 +1168,9 @@ function validateImageLLMModel() {
                 alert('Unable to connect to the LLM server. Image sharing/commenting functionality will remain disabled.');
                 setTimeout(() => { status.innerHTML = ''; }, 5000);
             } else {
-                // Check if minicpm-v:latest model exists in fetched models
+                // Check if selected VLM model exists in fetched models
                 const modelExists = data.models.includes(modelName);
-                
+
                 if (modelExists) {
                     status.innerHTML = '<span style="color: green;"><i class="mdi mdi-check"></i> Model "' + modelName + '" found and validated!</span>';
                     validationStatus.value = 'true';
@@ -1354,7 +1180,7 @@ function validateImageLLMModel() {
                     status.innerHTML = '<span style="color: red;"><i class="mdi mdi-alert"></i> Model "' + modelName + '" not found on this server!</span>';
                     validationStatus.value = 'false';
                     disableImageAction();
-                    alert('The minicpm-v:latest model is not available on the specified server. Image sharing/commenting functionality will remain disabled.');
+                    alert('The "' + modelName + '" model is not available on the specified server. Image sharing/commenting functionality will remain disabled.');
                     // Set llm_v to empty/None to signal model unavailability
                     llmVUrlInput.value = '';
                 }
@@ -1519,191 +1345,6 @@ document.addEventListener('DOMContentLoaded', function() {
     
     // Initial state
     updateNetworkInputStates();
-    
-    // Handle Explorer archetype based on follow probabilities
-    function updateExplorerArchetype() {
-        const dailyFollow = document.querySelector('input[name="probability_of_daily_follow"]');
-        const secondaryFollow = document.querySelector('input[name="probability_of_secondary_follow"]');
-        const explorerBox = document.getElementById('archetype-explorer-box');
-        const explorerInput = document.getElementById('archetype_explorer');
-        const validatorInput = document.getElementById('archetype_validator');
-        const broadcasterInput = document.getElementById('archetype_broadcaster');
-        
-        // Get transition probability inputs
-        const transValExpl = document.getElementById('trans_val_expl');
-        const transBroadExpl = document.getElementById('trans_broad_expl');
-        const transExplVal = document.getElementById('trans_expl_val');
-        const transExplBroad = document.getElementById('trans_expl_broad');
-        const transExplExpl = document.getElementById('trans_expl_expl');
-        const transValVal = document.getElementById('trans_val_val');
-        const transValBroad = document.getElementById('trans_val_broad');
-        const transBroadVal = document.getElementById('trans_broad_val');
-        const transBroadBroad = document.getElementById('trans_broad_broad');
-        
-        if (!dailyFollow || !secondaryFollow || !explorerBox || !explorerInput) return;
-        
-        const dailyFollowValue = parseFloat(dailyFollow.value) || 0;
-        const secondaryFollowValue = parseFloat(secondaryFollow.value) || 0;
-        
-        // Check if both probabilities are zero
-        if (dailyFollowValue === 0 && secondaryFollowValue === 0) {
-            // Disable Explorer
-            explorerBox.classList.add('disabled');
-            explorerInput.disabled = true;
-            explorerInput.readOnly = true;
-            
-            // Move Explorer's percentage to Validator
-            const explorerValue = parseFloat(explorerInput.value) || 0;
-            if (explorerValue > 0) {
-                const currentValidator = parseFloat(validatorInput.value) || 0;
-                validatorInput.value = (currentValidator + explorerValue).toFixed(1);
-            }
-            explorerInput.value = '0';
-            
-            // Redistribute transition probabilities
-            // Set all Explorer-related transitions to 0
-            transValExpl.value = '0';
-            transValExpl.disabled = true;
-            transValExpl.readOnly = true;
-            
-            transBroadExpl.value = '0';
-            transBroadExpl.disabled = true;
-            transBroadExpl.readOnly = true;
-            
-            transExplVal.value = '0';
-            transExplVal.disabled = true;
-            transExplVal.readOnly = true;
-            
-            transExplBroad.value = '0';
-            transExplBroad.disabled = true;
-            transExplBroad.readOnly = true;
-            
-            transExplExpl.value = '0';
-            transExplExpl.disabled = true;
-            transExplExpl.readOnly = true;
-            
-            // Redistribute Validator->Explorer to Validator->Broadcaster
-            // Original: val->val=85.3, val->broad=8.1, val->expl=6.6
-            // New: redistribute 6.6 proportionally between val->val and val->broad
-            const valToVal = parseFloat(transValVal.value) || 85.3;
-            const valToBroad = parseFloat(transValBroad.value) || 8.1;
-            const valToExpl = 6.6; // redistributing this
-            const total = valToVal + valToBroad;
-            if (total > 0) {
-                transValVal.value = (valToVal + valToExpl * (valToVal / total)).toFixed(1);
-                transValBroad.value = (valToBroad + valToExpl * (valToBroad / total)).toFixed(1);
-            } else {
-                // Fallback: split equally
-                transValVal.value = (valToVal + valToExpl / 2).toFixed(1);
-                transValBroad.value = (valToBroad + valToExpl / 2).toFixed(1);
-            }
-            
-            // Redistribute Broadcaster->Explorer to Broadcaster->Validator
-            // Original: broad->val=19.5, broad->broad=72.9, broad->expl=7.5
-            const broadToVal = parseFloat(transBroadVal.value) || 19.5;
-            const broadToBroad = parseFloat(transBroadBroad.value) || 72.9;
-            const broadToExpl = 7.5; // redistributing this
-            const broadTotal = broadToVal + broadToBroad;
-            if (broadTotal > 0) {
-                transBroadVal.value = (broadToVal + broadToExpl * (broadToVal / broadTotal)).toFixed(1);
-                transBroadBroad.value = (broadToBroad + broadToExpl * (broadToBroad / broadTotal)).toFixed(1);
-            } else {
-                // Fallback: split equally
-                transBroadVal.value = (broadToVal + broadToExpl / 2).toFixed(1);
-                transBroadBroad.value = (broadToBroad + broadToExpl / 2).toFixed(1);
-            }
-            
-        } else {
-            // Enable Explorer
-            explorerBox.classList.remove('disabled');
-            explorerInput.disabled = false;
-            explorerInput.readOnly = false;
-            
-            // Restore default values if currently 0
-            if (parseFloat(explorerInput.value) === 0) {
-                // Restore defaults
-                const currentValidator = parseFloat(validatorInput.value) || 80;
-                const explorerDefault = 28;
-                
-                // If validator was increased to 80 (52+28), restore original values
-                if (currentValidator >= 80) {
-                    validatorInput.value = '52';
-                    explorerInput.value = '28';
-                } else {
-                    explorerInput.value = '28';
-                }
-            }
-            
-            // Re-enable transition probability inputs
-            transValExpl.disabled = false;
-            transValExpl.readOnly = false;
-            transValExpl.value = '6.6';
-            
-            transBroadExpl.disabled = false;
-            transBroadExpl.readOnly = false;
-            transBroadExpl.value = '7.5';
-            
-            transExplVal.disabled = false;
-            transExplVal.readOnly = false;
-            transExplVal.value = '36.4';
-            
-            transExplBroad.disabled = false;
-            transExplBroad.readOnly = false;
-            transExplBroad.value = '14.6';
-            
-            transExplExpl.disabled = false;
-            transExplExpl.readOnly = false;
-            transExplExpl.value = '49.0';
-            
-            // Restore original transition values
-            transValVal.value = '85.3';
-            transValBroad.value = '8.1';
-            transBroadVal.value = '19.5';
-            transBroadBroad.value = '72.9';
-        }
-    }
-    
-    // Set up listeners for probability fields
-    const dailyFollowInput = document.querySelector('input[name="probability_of_daily_follow"]');
-    const secondaryFollowInput = document.querySelector('input[name="probability_of_secondary_follow"]');
-    
-    if (dailyFollowInput) {
-        dailyFollowInput.addEventListener('change', updateExplorerArchetype);
-        dailyFollowInput.addEventListener('input', updateExplorerArchetype);
-    }
-    if (secondaryFollowInput) {
-        secondaryFollowInput.addEventListener('change', updateExplorerArchetype);
-        secondaryFollowInput.addEventListener('input', updateExplorerArchetype);
-    }
-    
-    // Initial check on page load
-    updateExplorerArchetype();
-    
-    // Handle archetype toggle
-    const archetypeToggle = document.getElementById('enable_archetypes');
-    const archetypeDetails = document.getElementById('archetype-details');
-    
-    function updateArchetypeToggle() {
-        if (!archetypeToggle || !archetypeDetails) return;
-        
-        if (archetypeToggle.checked) {
-            // Enable archetypes
-            archetypeDetails.style.opacity = '1';
-            archetypeDetails.style.pointerEvents = 'auto';
-        } else {
-            // Disable archetypes
-            archetypeDetails.style.opacity = '0.5';
-            archetypeDetails.style.pointerEvents = 'none';
-            // Close the details if open
-            archetypeDetails.open = false;
-        }
-    }
-    
-    if (archetypeToggle) {
-        archetypeToggle.addEventListener('change', updateArchetypeToggle);
-        // Initial state
-        updateArchetypeToggle();
-    }
 });
                                             </script>
 {% include "admin/tutorials/clients_tutorial.html" %}

--- a/y_web/templates/interview.html
+++ b/y_web/templates/interview.html
@@ -1,0 +1,130 @@
+{%  include "header.html" %}
+
+<div class="view-wrapper">
+    <div class="container is-fluid" style="max-width: 1400px;">
+        <div class="columns">
+            <div class="column is-3">
+                <div class="card">
+                    <header class="card-header">
+                        <p class="card-header-title">Interview</p>
+                    </header>
+                    <div class="card-content">
+                        <div class="field">
+                            <label class="label">Agent</label>
+                            <div class="control">
+                                <div class="select is-fullwidth">
+                                    <select id="interview-agent-select"></select>
+                                </div>
+                            </div>
+                            <p class="help">Only LLM agents are listed.</p>
+                        </div>
+
+                        <div class="field">
+                            <label class="label">Run ID (optional)</label>
+                            <div class="control">
+                                <input id="interview-run-id" class="input" placeholder="auto-detect from logs"/>
+                            </div>
+                            <p class="help">Leave blank to auto-detect from the server log.</p>
+                        </div>
+
+                        <div class="field">
+                            <label class="label">Backend</label>
+                            <div class="control">
+                                <label class="radio">
+                                    <input type="radio" name="backend_mode" value="agent_runtime" checked>
+                                    Agent runtime
+                                </label>
+                                <label class="radio" style="margin-left: 10px;">
+                                    <input type="radio" name="backend_mode" value="admin">
+                                    Admin
+                                </label>
+                            </div>
+                        </div>
+
+                        <div class="buttons" style="width: 100%;">
+                            <button id="interview-start-session" class="button is-primary is-fullwidth">Start Session</button>
+                            <button id="interview-refresh-memory" class="button is-light is-fullwidth" disabled>Refresh Memory</button>
+                        </div>
+
+                        <p id="interview-status" class="help"></p>
+                    </div>
+                </div>
+            </div>
+
+            <div class="column is-6">
+                <div class="card">
+                    <header class="card-header">
+                        <p class="card-header-title">Conversation</p>
+                    </header>
+                    <div class="card-content" style="height: 560px; overflow: auto;">
+                        <div id="interview-messages"></div>
+                    </div>
+                    <div class="card-content" style="border-top: 1px solid #eee;">
+                        <div class="field">
+                            <label class="label">Message</label>
+                            <div class="control">
+                                <textarea id="interview-input" class="textarea" rows="3" placeholder="Ask the agent about their experiences, relationships, or the community..." disabled></textarea>
+                            </div>
+                        </div>
+                        <div class="field is-grouped is-grouped-right">
+                            <div class="control">
+                                <button id="interview-send" class="button is-link" disabled>Send</button>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            <div class="column is-3">
+                <div class="card">
+                    <header class="card-header">
+                        <p class="card-header-title">Context</p>
+                    </header>
+                    <div class="card-content">
+                        <p class="title is-6" style="margin-bottom: 0.5rem;">Persona</p>
+                        <pre id="interview-persona" style="white-space: pre-wrap; font-size: 0.85em;"></pre>
+
+                        <p class="title is-6" style="margin-top: 1rem; margin-bottom: 0.5rem;">Interests</p>
+                        <div id="interview-interests" style="font-size: 0.9em;"></div>
+
+                        <p class="title is-6" style="margin-top: 1rem; margin-bottom: 0.5rem;">Memory</p>
+                        <pre id="interview-memory" style="white-space: pre-wrap; font-size: 0.85em;"></pre>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+
+<!-- Experiment context -->
+<script>
+    window.EXP_ID = {{ exp_id if exp_id else 'null' }};
+    window.EXP_PREFIX = window.EXP_ID ? '/' + window.EXP_ID : '';
+    window.INTERVIEW_EXP_ID = window.EXP_ID;
+</script>
+
+<!-- Concatenated js plugins and jQuery -->
+<script src="{{ url_for('static', filename='assets/js/app.js') }}"></script>
+<script src="https://js.stripe.com/v3/"></script>
+
+<!-- Core js -->
+<script src="{{ url_for('static', filename='assets/js/global.js') }}"></script>
+
+<!-- Navigation options js -->
+<script src="{{ url_for('static', filename='assets/js/navbar-v1.js') }}"></script>
+<script src="{{ url_for('static', filename='assets/js/navbar-v2.js') }}"></script>
+<script src="{{ url_for('static', filename='assets/js/navbar-mobile.js') }}"></script>
+<script src="{{ url_for('static', filename='assets/js/navbar-options.js') }}"></script>
+<script src="{{ url_for('static', filename='assets/js/sidebar-v1.js') }}"></script>
+
+<!-- Core instance js -->
+<script src="{{ url_for('static', filename='assets/js/main.js') }}"></script>
+<script src="{{ url_for('static', filename='assets/js/chat.js') }}"></script>
+<script src="{{ url_for('static', filename='assets/js/touch.js') }}"></script>
+
+<!-- Interview module -->
+<script src="{{ url_for('static', filename='assets/js/interview.js') }}"></script>
+
+</body>
+</html>
+

--- a/y_web/templates/reddit/interview.html
+++ b/y_web/templates/reddit/interview.html
@@ -1,0 +1,128 @@
+{%  include "reddit/header.html" %}
+
+<div class="view-wrapper">
+    <div class="container is-fluid" style="max-width: 1400px;">
+        <div class="columns">
+            <div class="column is-3">
+                <div class="card">
+                    <header class="card-header">
+                        <p class="card-header-title">Interview</p>
+                    </header>
+                    <div class="card-content">
+                        <div class="field">
+                            <label class="label">Agent</label>
+                            <div class="control">
+                                <div class="select is-fullwidth">
+                                    <select id="interview-agent-select"></select>
+                                </div>
+                            </div>
+                            <p class="help">Only LLM agents are listed.</p>
+                        </div>
+
+                        <div class="field">
+                            <label class="label">Run ID (optional)</label>
+                            <div class="control">
+                                <input id="interview-run-id" class="input" placeholder="auto-detect from logs"/>
+                            </div>
+                        </div>
+
+                        <div class="field">
+                            <label class="label">Backend</label>
+                            <div class="control">
+                                <label class="radio">
+                                    <input type="radio" name="backend_mode" value="agent_runtime" checked>
+                                    Agent runtime
+                                </label>
+                                <label class="radio" style="margin-left: 10px;">
+                                    <input type="radio" name="backend_mode" value="admin">
+                                    Admin
+                                </label>
+                            </div>
+                        </div>
+
+                        <div class="buttons" style="width: 100%;">
+                            <button id="interview-start-session" class="button is-primary is-fullwidth">Start Session</button>
+                            <button id="interview-refresh-memory" class="button is-light is-fullwidth" disabled>Refresh Memory</button>
+                        </div>
+
+                        <p id="interview-status" class="help"></p>
+                    </div>
+                </div>
+            </div>
+
+            <div class="column is-6">
+                <div class="card">
+                    <header class="card-header">
+                        <p class="card-header-title">Conversation</p>
+                    </header>
+                    <div class="card-content" style="height: 560px; overflow: auto;">
+                        <div id="interview-messages"></div>
+                    </div>
+                    <div class="card-content" style="border-top: 1px solid #eee;">
+                        <div class="field">
+                            <label class="label">Message</label>
+                            <div class="control">
+                                <textarea id="interview-input" class="textarea" rows="3" placeholder="Ask the agent about their experiences, relationships, or the community..." disabled></textarea>
+                            </div>
+                        </div>
+                        <div class="field is-grouped is-grouped-right">
+                            <div class="control">
+                                <button id="interview-send" class="button is-link" disabled>Send</button>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            <div class="column is-3">
+                <div class="card">
+                    <header class="card-header">
+                        <p class="card-header-title">Context</p>
+                    </header>
+                    <div class="card-content">
+                        <p class="title is-6" style="margin-bottom: 0.5rem;">Persona</p>
+                        <pre id="interview-persona" style="white-space: pre-wrap; font-size: 0.85em;"></pre>
+
+                        <p class="title is-6" style="margin-top: 1rem; margin-bottom: 0.5rem;">Interests</p>
+                        <div id="interview-interests" style="font-size: 0.9em;"></div>
+
+                        <p class="title is-6" style="margin-top: 1rem; margin-bottom: 0.5rem;">Memory</p>
+                        <pre id="interview-memory" style="white-space: pre-wrap; font-size: 0.85em;"></pre>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+
+<script>
+    window.EXP_ID = {{ exp_id if exp_id else 'null' }};
+    window.EXP_PREFIX = window.EXP_ID ? '/' + window.EXP_ID : '';
+    window.INTERVIEW_EXP_ID = window.EXP_ID;
+</script>
+
+<!-- Concatenated js plugins and jQuery -->
+<script src="{{ url_for('static', filename='assets/js/reddit/app.js') }}"></script>
+<script src="https://js.stripe.com/v3/"></script>
+
+<!-- Core js -->
+<script src="{{ url_for('static', filename='assets/js/global.js') }}"></script>
+
+<!-- Navigation options js -->
+<script src="{{ url_for('static', filename='assets/js/navbar-v1.js') }}"></script>
+<script src="{{ url_for('static', filename='assets/js/navbar-v2.js') }}"></script>
+<script src="{{ url_for('static', filename='assets/js/navbar-mobile.js') }}"></script>
+<script src="{{ url_for('static', filename='assets/js/navbar-options.js') }}"></script>
+<script src="{{ url_for('static', filename='assets/js/sidebar-v1.js') }}"></script>
+
+<!-- Core instance js -->
+<script src="{{ url_for('static', filename='assets/js/main.js') }}"></script>
+<script src="{{ url_for('static', filename='assets/js/chat.js') }}"></script>
+<script src="{{ url_for('static', filename='assets/js/touch.js') }}"></script>
+
+<!-- Interview module -->
+<script src="{{ url_for('static', filename='assets/js/interview.js') }}"></script>
+
+</body>
+</html>
+

--- a/y_web/tests/test_admin_pagination.py
+++ b/y_web/tests/test_admin_pagination.py
@@ -285,15 +285,13 @@ def app():
 
             return "Login failed", 401
 
-        return render_template_string(
-            """
+        return render_template_string("""
         <form method="post">
             <input name="email" type="email" required>
             <input name="password" type="password" required>
             <button type="submit">Login</button>
         </form>
-        """
-        )
+        """)
 
     app.register_blueprint(auth)
 

--- a/y_web/tests/test_admin_routes.py
+++ b/y_web/tests/test_admin_routes.py
@@ -253,15 +253,13 @@ def app():
 
             return "Login failed", 401
 
-        return render_template_string(
-            """
+        return render_template_string("""
         <form method="post">
             <input name="email" type="email" required>
             <input name="password" type="password" required>
             <button type="submit">Login</button>
         </form>
-        """
-        )
+        """)
 
     app.register_blueprint(auth)
 

--- a/y_web/tests/test_auth_routes.py
+++ b/y_web/tests/test_auth_routes.py
@@ -107,16 +107,14 @@ def app():
 
     @auth.route("/signup")
     def signup():
-        return render_template_string(
-            """
+        return render_template_string("""
         <form method="post" action="{{ url_for('auth.signup_post') }}">
             <input name="email" type="email" placeholder="Email" required>
             <input name="name" type="text" placeholder="Name" required>
             <input name="password" type="password" placeholder="Password" required>
             <button type="submit">Sign Up</button>
         </form>
-        """
-        )
+        """)
 
     @auth.route("/signup", methods=["POST"])
     def signup_post():
@@ -170,15 +168,13 @@ def app():
 
     @auth.route("/login")
     def login():
-        return render_template_string(
-            """
+        return render_template_string("""
         <form method="post">
             <input name="email" type="email" placeholder="Email" required>
             <input name="password" type="password" placeholder="Password" required>
             <button type="submit">Login</button>
         </form>
-        """
-        )
+        """)
 
     @auth.route("/login", methods=["POST"])
     def login_post():

--- a/y_web/tests/test_interview_memory.py
+++ b/y_web/tests/test_interview_memory.py
@@ -1,0 +1,119 @@
+from y_web.routes_api import interview
+
+
+def test_parse_timeout_series_uses_positive_numbers_only():
+    parsed = interview._parse_timeout_series(" 2, bad, 0, -4, 6.5 ", (9.0,))
+
+    assert parsed == (2.0, 6.5)
+
+
+def test_build_memory_snapshot_legacy_uses_interview_events_timeouts(monkeypatch):
+    captured = {}
+
+    def fake_post_server_json(exp, path, payload, *, timeout_s=4.0):
+        assert path == "/memory/get_context"
+        return {}
+
+    def fake_post_server_json_with_retries(
+        exp,
+        path,
+        payload,
+        *,
+        timeouts_s,
+        require_status_200=False,
+    ):
+        captured["path"] = path
+        captured["timeouts_s"] = timeouts_s
+        captured["payload"] = payload
+        return {"events": []}
+
+    monkeypatch.setattr(interview, "_post_server_json", fake_post_server_json)
+    monkeypatch.setattr(
+        interview, "_post_server_json_with_retries", fake_post_server_json_with_retries
+    )
+
+    snapshot = interview._build_memory_snapshot_legacy(
+        object(), run_id="run_123", agent_user_id=28
+    )
+
+    assert snapshot["run_id"] == "run_123"
+    assert captured["path"] == "/memory/events_recent"
+    assert captured["payload"] == {"run_id": "run_123", "limit": 200}
+    assert captured["timeouts_s"] == interview._INTERVIEW_MEMORY_EVENTS_TIMEOUTS
+
+
+def test_build_memory_snapshot_semantic_uses_interview_search_timeouts(monkeypatch):
+    captured = {}
+
+    def fake_post_server_json(exp, path, payload, *, timeout_s=4.0):
+        assert path == "/memory/get_context"
+        return {}
+
+    def fake_post_server_json_with_retries(
+        exp,
+        path,
+        payload,
+        *,
+        timeouts_s,
+        require_status_200=False,
+    ):
+        captured["path"] = path
+        captured["timeouts_s"] = timeouts_s
+        captured["payload"] = payload
+        captured["require_status_200"] = require_status_200
+        return {"status": 200, "items": [], "memory_brief": "", "retrieval_meta": {}}
+
+    monkeypatch.setattr(interview, "_post_server_json", fake_post_server_json)
+    monkeypatch.setattr(
+        interview, "_post_server_json_with_retries", fake_post_server_json_with_retries
+    )
+
+    snapshot = interview._build_memory_snapshot_semantic(
+        object(), run_id="run_456", agent_user_id=28
+    )
+
+    assert snapshot["run_id"] == "run_456"
+    assert captured["path"] == "/memory/search"
+    assert captured["payload"]["run_id"] == "run_456"
+    assert captured["payload"]["agent_user_id"] == 28
+    assert captured["require_status_200"] is True
+    assert captured["timeouts_s"] == interview._INTERVIEW_MEMORY_SEARCH_TIMEOUTS
+
+
+def test_build_deferred_memory_snapshot_marks_load_state():
+    snapshot = interview._build_deferred_memory_snapshot(
+        run_id="run_789",
+        agent_user_id=28,
+        memory_mode="semantic",
+    )
+
+    assert snapshot["run_id"] == "run_789"
+    assert snapshot["agent_user_id"] == 28
+    assert snapshot["memory_mode_requested"] == "semantic"
+    assert snapshot["memory_mode_used"] == ""
+    assert snapshot["load_state"] == "deferred"
+    assert snapshot["relationships"] == []
+
+
+def test_detect_run_id_from_server_log_can_skip_coverage_probe(monkeypatch):
+    monkeypatch.setattr(
+        interview,
+        "_iter_run_ids_from_server_log",
+        lambda exp, agent_user_id=None: ["run_fast"] if agent_user_id == 28 else [],
+    )
+
+    def fail_probe(*args, **kwargs):
+        raise AssertionError("coverage probe should not run in fast mode")
+
+    monkeypatch.setattr(interview, "_probe_run_memory_coverage", fail_probe)
+
+    out = interview._detect_run_id_from_server_log(
+        object(),
+        agent_user_id=28,
+        probe_memory_coverage=False,
+    )
+
+    assert out["run_id"] == "run_fast"
+    assert out["source"] == "log_scan_latest"
+    assert out["selected_reason"] == "latest_agent_run_unprobed"
+    assert out["candidates_checked"] == []

--- a/y_web/tests/test_reddit_enrich.py
+++ b/y_web/tests/test_reddit_enrich.py
@@ -72,7 +72,9 @@ def app(tmp_path):
         )
         db.session.add(article)
 
-        image = Images(url="/uploads/reddit/1/test.png", description=None, article_id=None)
+        image = Images(
+            url="/uploads/reddit/1/test.png", description=None, article_id=None
+        )
         db.session.add(image)
         db.session.commit()
 
@@ -154,7 +156,9 @@ def test_enrich_image_disabled_without_llm(client):
     assert payload["data"]["enabled"] is False
 
 
-def test_enrich_image_maps_upload_to_local_path_and_updates_description(client, tmp_path):
+def test_enrich_image_maps_upload_to_local_path_and_updates_description(
+    client, tmp_path
+):
     from y_web import db
     from y_web.models import Admin_users, Images
 

--- a/y_web/tests/test_reddit_post_formatting.py
+++ b/y_web/tests/test_reddit_post_formatting.py
@@ -31,4 +31,6 @@ def test_process_reddit_post_comment_mode_skips_legacy_blankline_split():
 def test_normalize_punctuation_spacing_preserves_urls():
     text = "Hi!How are you?Fine,thanks. Visit https://example.com/a,b?x=1"
     normalized = normalize_punctuation_spacing(text)
-    assert normalized == "Hi! How are you? Fine, thanks. Visit https://example.com/a,b?x=1"
+    assert (
+        normalized == "Hi! How are you? Fine, thanks. Visit https://example.com/a,b?x=1"
+    )

--- a/y_web/tests/test_reply_notifications.py
+++ b/y_web/tests/test_reply_notifications.py
@@ -9,9 +9,8 @@ from werkzeug.security import generate_password_hash
 
 @pytest.fixture
 def app(tmp_path):
-    from y_web import db
-
     import y_web
+    from y_web import db
 
     templates_dir = os.path.join(os.path.dirname(y_web.__file__), "templates")
     static_dir = os.path.join(os.path.dirname(y_web.__file__), "static")
@@ -48,15 +47,21 @@ def app(tmp_path):
         except Exception:
             return None
 
-    from y_web.main import main as main_blueprint
     from y_web.auth import auth as auth_blueprint
+    from y_web.main import main as main_blueprint
 
     app.register_blueprint(main_blueprint)
     app.register_blueprint(auth_blueprint)
 
     with app.app_context():
-        from y_web.models import Admin_users, Exps
-        from y_web.models import Post, ReplyInboxState, Rounds, User_mgmt
+        from y_web.models import (
+            Admin_users,
+            Exps,
+            Post,
+            ReplyInboxState,
+            Rounds,
+            User_mgmt,
+        )
 
         db.create_all(bind="db_admin")
         db.create_all(bind="db_exp")
@@ -190,12 +195,16 @@ def test_notifications_mark_read_and_exclude_self_reply(app, client):
         assert alice is not None
 
         root = Post.query.filter_by(user_id=alice.id, tweet="root").first()
-        alice_comment = Post.query.filter_by(user_id=alice.id, tweet="alice comment").first()
+        alice_comment = Post.query.filter_by(
+            user_id=alice.id, tweet="alice comment"
+        ).first()
         assert root is not None
         assert alice_comment is not None
 
         # Grab the self-reply id so we can ensure it doesn't appear.
-        self_reply = Post.query.filter_by(user_id=alice.id, tweet="alice self reply").first()
+        self_reply = Post.query.filter_by(
+            user_id=alice.id, tweet="alice self reply"
+        ).first()
         assert self_reply is not None
 
         expected_max_reply_id = (

--- a/y_web/tests/test_researcher_login.py
+++ b/y_web/tests/test_researcher_login.py
@@ -112,15 +112,13 @@ def app():
 
     @auth.route("/login")
     def login():
-        return render_template_string(
-            """
+        return render_template_string("""
         <form method="post">
             <input name="email" type="email" placeholder="Email" required>
             <input name="password" type="password" placeholder="Password" required>
             <button type="submit">Login</button>
         </form>
-        """
-        )
+        """)
 
     @auth.route("/login", methods=["POST"])
     def login_post():

--- a/y_web/tests/test_simple_auth.py
+++ b/y_web/tests/test_simple_auth.py
@@ -170,15 +170,13 @@ def test_auth_integration():
                 login_user(user)
                 return "Login successful"
             return "Login failed"
-        return render_template_string(
-            """
+        return render_template_string("""
             <form method="post">
                 <input name="username" type="text" placeholder="Username">
                 <input name="password" type="password" placeholder="Password">
                 <button type="submit">Login</button>
             </form>
-        """
-        )
+        """)
 
     @auth_bp.route("/protected")
     @login_required

--- a/y_web/tests/test_user_password_email_update.py
+++ b/y_web/tests/test_user_password_email_update.py
@@ -246,15 +246,13 @@ def app():
 
             return "Login failed", 401
 
-        return render_template_string(
-            """
+        return render_template_string("""
         <form method="post">
             <input name="email" type="email" required>
             <input name="password" type="password" required>
             <button type="submit">Login</button>
         </form>
-        """
-        )
+        """)
 
     app.register_blueprint(auth)
 

--- a/y_web/user_interaction.py
+++ b/y_web/user_interaction.py
@@ -665,8 +665,13 @@ def publish_comment(exp_id):
             db.session.commit()
 
     # Mirror agent behavior for replies: notify parent author even without explicit @mention.
-    if parent_post.user_id != current_user.id and parent_post.user_id not in mentioned_user_ids:
-        mn = Mentions(user_id=parent_post.user_id, post_id=post.id, round=current_round.id)
+    if (
+        parent_post.user_id != current_user.id
+        and parent_post.user_id not in mentioned_user_ids
+    ):
+        mn = Mentions(
+            user_id=parent_post.user_id, post_id=post.id, round=current_round.id
+        )
         db.session.add(mn)
         db.session.commit()
 

--- a/y_web/utils/experiment_clock.py
+++ b/y_web/utils/experiment_clock.py
@@ -109,7 +109,9 @@ def ensure_experiment_clock(config: Dict[str, Any]) -> Dict[str, Any]:
 
     normalized: Dict[str, Any] = {
         "mode": validate_clock_mode(raw_clock.get("mode", DEFAULT_CLOCK_MODE)),
-        "timezone": validate_timezone(raw_clock.get("timezone", DEFAULT_CLOCK_TIMEZONE)),
+        "timezone": validate_timezone(
+            raw_clock.get("timezone", DEFAULT_CLOCK_TIMEZONE)
+        ),
         "feed_refresh": validate_feed_refresh(
             raw_clock.get("feed_refresh", DEFAULT_CLOCK_FEED_REFRESH)
         ),
@@ -123,10 +125,16 @@ def ensure_experiment_clock(config: Dict[str, Any]) -> Dict[str, Any]:
     return normalized
 
 
-def apply_clock_to_client_simulation(simulation: Dict[str, Any], clock: Dict[str, Any]) -> None:
+def apply_clock_to_client_simulation(
+    simulation: Dict[str, Any], clock: Dict[str, Any]
+) -> None:
     """Write experiment clock settings into a client simulation config payload."""
-    simulation["clock_mode"] = validate_clock_mode(clock.get("mode", DEFAULT_CLOCK_MODE))
-    simulation["timezone"] = validate_timezone(clock.get("timezone", DEFAULT_CLOCK_TIMEZONE))
+    simulation["clock_mode"] = validate_clock_mode(
+        clock.get("mode", DEFAULT_CLOCK_MODE)
+    )
+    simulation["timezone"] = validate_timezone(
+        clock.get("timezone", DEFAULT_CLOCK_TIMEZONE)
+    )
     simulation["feed_refresh"] = validate_feed_refresh(
         clock.get("feed_refresh", DEFAULT_CLOCK_FEED_REFRESH)
     )

--- a/y_web/utils/experiment_helpers.py
+++ b/y_web/utils/experiment_helpers.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+import re
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Dict, Optional
@@ -15,6 +16,22 @@ from y_web.models import Exps
 
 
 BASE_DIR = Path(__file__).resolve().parents[1]
+
+
+def get_experiment_uid_from_db_name(db_name: str) -> Optional[str]:
+    """
+    Extract the experiment UID (folder name) from the db_name field.
+    """
+    if not db_name:
+        return None
+
+    if db_name.startswith("experiments_"):
+        return db_name.replace("experiments_", "")
+    if db_name.startswith("experiments/") or db_name.startswith("experiments\\"):
+        parts = re.split(r"[/\\\\]", db_name)
+        if len(parts) >= 2:
+            return parts[1]
+    return None
 
 
 @dataclass

--- a/y_web/utils/experiment_helpers.py
+++ b/y_web/utils/experiment_helpers.py
@@ -14,7 +14,6 @@ from sqlalchemy.exc import SQLAlchemyError
 from y_web import db
 from y_web.models import Exps
 
-
 BASE_DIR = Path(__file__).resolve().parents[1]
 
 

--- a/y_web/utils/memory_run_id.py
+++ b/y_web/utils/memory_run_id.py
@@ -1,0 +1,62 @@
+"""Helpers for memory run identifier normalization."""
+
+from __future__ import annotations
+
+import hashlib
+from typing import Any, Dict, Optional
+
+MAX_MEMORY_RUN_ID_LEN = 64
+
+
+def normalize_memory_run_id(
+    raw_value: Any,
+    *,
+    max_len: int = MAX_MEMORY_RUN_ID_LEN,
+) -> Optional[str]:
+    """Return a DB-safe memory run id or None when input is empty."""
+    value = str(raw_value or "").strip()
+    if not value:
+        return None
+    if len(value) <= max_len:
+        return value
+
+    digest = hashlib.sha1(value.encode("utf-8")).hexdigest()[:24]
+    return f"run_{digest}"
+
+
+def build_memory_run_seed(exp_uid: str, client_name: str, population_name: str) -> str:
+    """Build deterministic seed used to derive a stable run id."""
+    return (
+        f"exp:{str(exp_uid).strip()}:"
+        f"client:{str(client_name).strip().replace(' ', '_')}:"
+        f"population:{str(population_name).strip().replace(' ', '_')}"
+    )
+
+
+def normalize_client_config_memory_run_id(
+    client_config: Dict[str, Any],
+    *,
+    fallback_seed: Optional[str] = None,
+) -> bool:
+    """
+    Normalize `agents.memory_run_id` in a client config payload.
+
+    Returns True if payload was modified.
+    """
+    if not isinstance(client_config, dict):
+        return False
+
+    agents = client_config.get("agents")
+    if not isinstance(agents, dict):
+        return False
+
+    current = agents.get("memory_run_id")
+    normalized = normalize_memory_run_id(current)
+    if not normalized and fallback_seed:
+        normalized = normalize_memory_run_id(fallback_seed)
+
+    if not normalized or normalized == current:
+        return False
+
+    agents["memory_run_id"] = normalized
+    return True

--- a/y_web/utils/text_utils.py
+++ b/y_web/utils/text_utils.py
@@ -251,18 +251,20 @@ def strip_markdown_artifacts(text):
     # Remove markdown headers with common article section names
     # Patterns: # Conclusion:, # Call to Action, # Key Points, etc.
     text = re.sub(
-        r'^#+\s*(Conclusion|Call to Action|Key Points?|Summary|Overview|'
-        r'Introduction|Background|TL;?DR|Final Thoughts?|Takeaway|'
-        r'What\'s Next|Next Steps?|Resources?)[:\s]*',
-        '', text, flags=re.MULTILINE | re.IGNORECASE
+        r"^#+\s*(Conclusion|Call to Action|Key Points?|Summary|Overview|"
+        r"Introduction|Background|TL;?DR|Final Thoughts?|Takeaway|"
+        r"What\'s Next|Next Steps?|Resources?)[:\s]*",
+        "",
+        text,
+        flags=re.MULTILINE | re.IGNORECASE,
     )
 
     # Remove any isolated markdown header at the very start of text
     # (e.g., "# Some random header" at the beginning)
-    text = re.sub(r'^#+\s+', '', text)
+    text = re.sub(r"^#+\s+", "", text)
 
     # Clean up multiple consecutive newlines
-    text = re.sub(r'\n{3,}', '\n\n', text)
+    text = re.sub(r"\n{3,}", "\n\n", text)
 
     return text.strip()
 
@@ -282,8 +284,8 @@ def calculate_text_similarity(text1, text2):
         return 0.0
 
     # Normalize texts: lowercase and extract words
-    words1 = set(re.findall(r'\b\w+\b', text1.lower()))
-    words2 = set(re.findall(r'\b\w+\b', text2.lower()))
+    words1 = set(re.findall(r"\b\w+\b", text1.lower()))
+    words2 = set(re.findall(r"\b\w+\b", text2.lower()))
 
     if not words1 or not words2:
         return 0.0
@@ -295,7 +297,9 @@ def calculate_text_similarity(text1, text2):
     return intersection / union if union > 0 else 0.0
 
 
-def strip_reproduced_article_content(post_body, article_summary, similarity_threshold=0.6):
+def strip_reproduced_article_content(
+    post_body, article_summary, similarity_threshold=0.6
+):
     """
     Detect and strip content that appears to be reproduced from the article summary.
 
@@ -314,7 +318,7 @@ def strip_reproduced_article_content(post_body, article_summary, similarity_thre
         return post_body, False
 
     # Normalize article summary for substring checking
-    article_words = set(re.findall(r'\b\w+\b', article_summary.lower()))
+    article_words = set(re.findall(r"\b\w+\b", article_summary.lower()))
 
     # Check overall similarity
     similarity = calculate_text_similarity(post_body, article_summary)
@@ -322,7 +326,7 @@ def strip_reproduced_article_content(post_body, article_summary, similarity_thre
     if similarity >= similarity_threshold:
         # Content is too similar to article - try to find and remove the reproduced portion
         # Split into sentences and check each one
-        sentences = re.split(r'(?<=[.!?])\s+', post_body)
+        sentences = re.split(r"(?<=[.!?])\s+", post_body)
         filtered_sentences = []
 
         # Use lower threshold for per-sentence matching since each sentence
@@ -333,10 +337,12 @@ def strip_reproduced_article_content(post_body, article_summary, similarity_thre
             sentence_similarity = calculate_text_similarity(sentence, article_summary)
 
             # Also check if sentence words are mostly from article
-            sentence_words = set(re.findall(r'\b\w+\b', sentence.lower()))
+            sentence_words = set(re.findall(r"\b\w+\b", sentence.lower()))
             if sentence_words:
                 # What percentage of sentence words appear in article?
-                overlap_ratio = len(sentence_words & article_words) / len(sentence_words)
+                overlap_ratio = len(sentence_words & article_words) / len(
+                    sentence_words
+                )
             else:
                 overlap_ratio = 0
 
@@ -346,7 +352,7 @@ def strip_reproduced_article_content(post_body, article_summary, similarity_thre
                 filtered_sentences.append(sentence)
 
         if filtered_sentences:
-            return ' '.join(filtered_sentences), True
+            return " ".join(filtered_sentences), True
         else:
             # All content was reproduced - return empty
             return "", True
@@ -383,11 +389,13 @@ def process_reddit_post(text, allow_legacy_blankline_title=True):
     # Match TITLE: prefix with variations (case-insensitive, typos, optional space)
     # Handles: TITLE:, TITTLE:, TITEL:, Title:, title:, etc.
     # Also handles markdown formatting: **TITLE:, *TITLE:, __TITLE:, _TITLE:
-    title_match = re.match(r'^[\*_]{0,2}(TITLE|TITTLE|TITEL)\s*:\s*', text, re.IGNORECASE)
+    title_match = re.match(
+        r"^[\*_]{0,2}(TITLE|TITTLE|TITEL)\s*:\s*", text, re.IGNORECASE
+    )
 
     if title_match:
         # Remove the matched prefix
-        remaining = text[title_match.end():]
+        remaining = text[title_match.end() :]
 
         # Split on first newline to separate title from body.
         # Some generations forget the newline after TITLE: and produce a single long line.
@@ -396,7 +404,7 @@ def process_reddit_post(text, allow_legacy_blankline_title=True):
         title = lines[0].strip()
 
         # Strip trailing markdown bold/italic markers from title
-        title = re.sub(r'[\*_]{1,2}$', '', title).strip()
+        title = re.sub(r"[\*_]{1,2}$", "", title).strip()
 
         if len(lines) > 1:
             content = lines[1].lstrip()
@@ -443,11 +451,7 @@ def process_reddit_post(text, allow_legacy_blankline_title=True):
             if len(blocks) > 1:
                 candidate_title = blocks[0].strip()
                 candidate_body = blocks[1].lstrip()
-                if (
-                    candidate_title
-                    and candidate_body
-                    and len(candidate_title) <= 300
-                ):
+                if candidate_title and candidate_body and len(candidate_title) <= 300:
                     title = candidate_title
                     content = candidate_body
 

--- a/y_web/utils/y_client_process_runner.py
+++ b/y_web/utils/y_client_process_runner.py
@@ -4,6 +4,7 @@ Client process runner script for YSocial.
 This script is invoked as a subprocess to run client simulations.
 It's designed to be called by start_client using subprocess.Popen.
 """
+
 import argparse
 import json
 import math

--- a/y_web/utils/y_server_process_runner.py
+++ b/y_web/utils/y_server_process_runner.py
@@ -4,6 +4,7 @@ Server process runner script for YSocial.
 This script is invoked as a subprocess to run the YServer.
 It's designed to be called by start_server using subprocess.Popen.
 """
+
 import argparse
 import json
 import os


### PR DESCRIPTION

- Branch: `web/14-interview-memory-ops`
- Base: `web/13-media-uploads`
- Depends on: `web/13-media-uploads`, `ext/13-memory-client`
- Commit: `afa2ab9d`

## Summary

Add the web/admin layer for memory-aware operator interviews: the `/api/interview/*` surface, interview pages and JS, memory run-id normalization in admin client workflows, and reviewer docs for the Reddit/forum memory architecture.

## Included behavior

- Add admin interview API endpoints and session/message persistence models
- Add interview pages for both standard and Reddit/forum layouts
- Add browser-side interview session UI and memory refresh flow
- Add `memory_run_id` normalization helpers and wire them into admin client config generation/copy flows
- Add operator-facing docs describing the Reddit/forum memory architecture and mechanism
- Add focused unit coverage for interview memory snapshot helpers and run-id detection

## Included files

- `docs/memory_architecture_guide.md`
- `docs/reddit_forum_memory_report.md`
- `y_web/__init__.py`
- `y_web/models.py`
- `y_web/routes_admin/clients_routes.py`
- `y_web/routes_admin/experiments_routes.py`
- `y_web/routes_api/__init__.py`
- `y_web/routes_api/interview.py`
- `y_web/static/assets/js/interview.js`
- `y_web/templates/admin/clients.html`
- `y_web/templates/interview.html`
- `y_web/templates/reddit/interview.html`
- `y_web/tests/test_interview_memory.py`
- `y_web/utils/experiment_helpers.py`
- `y_web/utils/memory_run_id.py`

## Out of scope

- No new Reddit client/server memory internals beyond the already-landed external branches
- No additional media/upload work
- No separate web forum-formatting cleanup branch in this restack

## Notes

- This branch is based on `web/13-media-uploads`, but it also depends semantically on `ext/13-memory-client` because the interview UI expects the memory-capable runtime and `/memory/*` APIs from the external stack.
- The admin files are larger because the dirty branch mixed interview plumbing with memory-run-id/config management; this PR keeps that web/admin surface together instead of spreading it across later branches.

## Tests run

- `/opt/ysocial/anaconda3/bin/python3 -m py_compile y_web/utils/experiment_helpers.py y_web/__init__.py y_web/models.py y_web/routes_admin/clients_routes.py y_web/routes_admin/experiments_routes.py y_web/routes_api/__init__.py y_web/routes_api/interview.py y_web/utils/memory_run_id.py y_web/tests/test_interview_memory.py`
- `PYTHONPATH=. /opt/ysocial/anaconda3/bin/python3 -m pytest y_web/tests/test_interview_memory.py`
